### PR TITLE
Set develop flag to false by default

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1,4 +1,6 @@
 ---
+develop: false
+
 timezone: Europe/Amsterdam
 
 maven_repo: https://build.surfconext.nl/repository/public/releases

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1,4 +1,6 @@
 ---
+# The develop flag is used for development-specific tasks/roles and is set to true via --extra-vars
+# By default, these should not be run
 develop: false
 
 timezone: Europe/Amsterdam


### PR DESCRIPTION
The develop flag is used for development-specific tasks/roles and is set to true via --extra-vars. This change allows Ansible to default to `develop = false` if it is not given as an extra-var.