### PR TITLE
Adds metadata feature toggle

### DIFF
--- a/roles/engineblock/templates/engineblock.ini.j2
+++ b/roles/engineblock/templates/engineblock.ini.j2
@@ -15,6 +15,7 @@ engineApi.users.profile.password = {{ engine_api_profile_password }}
 ;; EngineBlock API feature toggles
 engineApi.features.metadataPush = 1
 engineApi.features.consentListing = 1
+engineApi.features.metadataApi = 1
 
 ;; Symfony specific variables
 symfony.cachePath = "{{ engineblock_symfony_cache_path }}"


### PR DESCRIPTION
A feature toggle is added to EngineBlock so that we can enable/disable the metadata API. This needs to be added to the provisioned configuration.