### PR TITLE
Updates EB symfony log and cache dirs

### DIFF
--- a/roles/engineblock/defaults/main.yml
+++ b/roles/engineblock/defaults/main.yml
@@ -50,8 +50,8 @@ engine_syslog_priority: 7
 
 #engine_initial_sql: ''
 
-engineblock_symfony_cache_path: "/tmp/engineblock/symfony-cache/{{ engine_version }}"
-engineblock_symfony_log_path: "/var/log/engineblock"
+engineblock_symfony_cache_path: "/tmp/engineblock/cache"
+engineblock_symfony_log_path: "/tmp/engineblock/log"
 
 ##
 ## Deprecated profile configuration. Keeping this around to make it easier to create a new role for profile later on

--- a/roles/engineblock/tasks/main.yml
+++ b/roles/engineblock/tasks/main.yml
@@ -18,6 +18,7 @@
     owner={{ apache_user }}
     group={{ apache_user }}
     recurse=yes
+  when: develop
 
 - name: Create the log dir for Symfony
   file:
@@ -26,6 +27,7 @@
     owner={{ apache_user }}
     group={{ apache_user }}
     recurse=yes
+  when: develop
 
 - name: Create the symfony cache
   command: app/console cache:clear --env=prod --no-debug


### PR DESCRIPTION
In production, syslog and the default Symfony directories are used and do not need to be created.

For development specific log and cache directories are used: `/tmp/engineblock/cache` and `/tmp/engineblock/log`.

See: https://github.com/OpenConext/OpenConext-engineblock/pull/264