### PR TITLE
Correct quoting of Attribute Aggregation password

### DIFF
--- a/roles/engineblock/templates/engineblock.ini.j2
+++ b/roles/engineblock/templates/engineblock.ini.j2
@@ -8,7 +8,7 @@ pdp.password = {{ engine_pdp_password }}
 
 attributeAggregation.baseUrl = {{ engine_attribute_aggregation_baseurl }}
 attributeAggregation.username = {{engine_attribute_aggregation_username }}
-attributeAggregation.password = {{engine_attribute_aggregation_password }}"
+attributeAggregation.password = "{{engine_attribute_aggregation_password }}"
 
 api.vovalidate.baseUrl = {{ engine_vovalidate_baseurl }}
 api.vovalidate.key = {{ engine_vovalidate_key }}


### PR DESCRIPTION
Added missing quote to ensure Engineblock can be booted.