### PR TITLE
Update common role's main.yml epel-release rpm source

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -3,7 +3,7 @@
   file: state=link src=/usr/share/zoneinfo/{{ timezone }} dest=/etc/localtime force=True
 
 - name: Add Epel repo
-  yum: name=http://ftp.nluug.nl/pub/os/Linux/distr/fedora-epel/6/x86_64/epel-release-6-8.noarch.rpm state=present
+  yum: name=https://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm state=present
 
 - name: Install tools / clients
   yum: name={{ item }} state=present


### PR DESCRIPTION
Using dl.fedoraproject.org source, since ftp.nluug.nl's DNS is currently down and causing the whole provisioning process to break. roles/maven_artifact_requirements/tasks/main.yml is also using the  dl.fedoraproject.org, so I see it as more fitting to use for this as well.