### PR TITLE
Install composer for engineblock 5

### DIFF
--- a/roles/engineblock5/tasks/main.yml
+++ b/roles/engineblock5/tasks/main.yml
@@ -88,6 +88,6 @@
 # configuration is loaded correctly.
 - name: Prepare EngineBlock5 environment
   sudo: yes
-  command: ./bin/composer.phar prepare-env
+  command: composer prepare-env
   args:
       chdir: "{{ openconext_releases_dir }}/OpenConext-engineblock"

--- a/roles/php56fpm/tasks/main.yml
+++ b/roles/php56fpm/tasks/main.yml
@@ -22,7 +22,6 @@
   - php-pecl-memcache
   - php-soap
   - php-xml
-  - php-mcrypt
   - php-gd
   - composer
 

--- a/roles/php56fpm/tasks/main.yml
+++ b/roles/php56fpm/tasks/main.yml
@@ -6,7 +6,7 @@
 - name: Enable REMI repo
   copy: src=remi.repo dest=/etc/yum.repos.d/remi.repo
 
-- name: Install httpd, php-(cli,fpm), smtpd, mysql client libs, bzip2
+- name: Install httpd, php-(cli,fpm), smtpd, mysql client libs, bzip2, composer
   yum: name={{item}} state=present
   with_items:
   - mysql
@@ -24,6 +24,7 @@
   - php-xml
   - php-mcrypt
   - php-gd
+  - composer
 
 - name: Configure PHP APC
   template: src={{ item }}.j2 dest=/etc/php.d/{{ item }}


### PR DESCRIPTION
EngineBlock requires composer in order to be able to execute scripts that allow the local environment to influence the application (e.g. configuration through local ini files). These changes install composer through yum.