### PR TITLE
oc_basedomain not used for star cert, so generating passwords was fai…

### DIFF
--- a/scripts/generate-new-passwords.sh
+++ b/scripts/generate-new-passwords.sh
@@ -124,7 +124,7 @@ do
   if [ "$value" == 'https_star_private_key' ]; then
     line="$key: |"
     echo "$line" >> $SV_FILE
-    cat "$BASEDIR/oc_cert/ssl/star.$oc_env.openconext.org.key" | sed "s/^/  /g" >> "$SV_FILE"
+    cat "$BASEDIR/oc_cert/ssl/star.$oc_env.$oc_basedomain.key" | sed "s/^/  /g" >> "$SV_FILE"
     continue
   fi
 


### PR DESCRIPTION
…ling since the gen_ocdemo_certs.sh script was using oc_basedomain

I kept getting error when I'd use my own domain for this, since the cert generate script would never make a file with this name.