### PR TITLE
Java Keytool issues when JDK is not first installed

### DIFF
--- a/provision-template.yml
+++ b/provision-template.yml
@@ -65,8 +65,8 @@
   vars:
     env_lang: java
   roles:
-    - tomcat
     - java
+    - tomcat
     - { role: shibboleth,       tags: ['shib'   ] }
     - { role: grouper,          tags: ['grouper'] }
     - { role: teams,            tags: ['teams'  ] }


### PR DESCRIPTION
the tomcat role needs to interface with the java keytool. However, the keytool that comes bundled with centos does not work with the ca-certificates /etc/pki/java/cacerts file and keeps erroring with a 'bad magic' error. If the jdk is installed first, its keytool works properly with this file.