### PR TITLE
Add task for running doctrine migrations

### DIFF
--- a/roles/engineblock5/tasks/main.yml
+++ b/roles/engineblock5/tasks/main.yml
@@ -64,9 +64,18 @@
       chdir: "{{ openconext_releases_dir }}/OpenConext-engineblock"
 
 # Any scripts should be placed below this
+- name: Run EngineBlock Doctrine migrations
+  command: app/console doctrine:migrations:migrate -n
+  args:
+    chdir: "{{ openconext_releases_dir }}/OpenConext-engineblock"
+  register: doctrine_migrations_output
+  changed_when: "'No migrations to execute' not in doctrine_migrations_output.stdout"
+  tags: enginemigrations
+
 - name: Run EngineBlock DbPatch migrations
   command: ./bin/migrate
   args:
     chdir: "{{ openconext_releases_dir }}/OpenConext-engineblock"
   register: migrate_output
   changed_when: "'no update needed' not in migrate_output.stderr"
+  tags: enginemigrations


### PR DESCRIPTION
These migrations should be executed prior to the DbPatch migrations and in time will make the DbPatch migrations obsolete.