### PR TITLE
nginx version / conf update

### DIFF
--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -7,7 +7,7 @@
     - nginx.repo
 
 - name: Install
-  yum: name=1.10.1-1.el6.ngx state=present
+  yum: name=nginx-1.10.1-1.el6.ngx state=present
 
 - name: Copy empty default.conf
   copy: src=default.conf dest=/etc/nginx/conf.d

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -7,7 +7,7 @@
     - nginx.repo
 
 - name: Install
-  yum: name=nginx-1.8.0-1.el6.ngx state=present
+  yum: name=1.10.1-1.el6.ngx state=present
 
 - name: Copy empty default.conf
   copy: src=default.conf dest=/etc/nginx/conf.d

--- a/roles/nginx/templates/aa.j2
+++ b/roles/nginx/templates/aa.j2
@@ -10,7 +10,7 @@ server {
 }
 
 server {
-    listen       {{ nginx_ipv4_addresses.aa }}:443 ssl spdy;
+    listen       {{ nginx_ipv4_addresses.aa }}:443 ssl http2;
     server_name  aa.{{ base_domain }};
 
     ssl                  on;
@@ -48,7 +48,7 @@ server {
 }
 
 server {
-    listen       [::]:443 ssl spdy;
+    listen       [::]:443 ssl http2;
     server_name  aa.{{ base_domain }};
 
     ssl                  on;

--- a/roles/nginx/templates/attribute_mapper.j2
+++ b/roles/nginx/templates/attribute_mapper.j2
@@ -10,7 +10,7 @@ server {
 }
 
 server {
-    listen       {{ nginx_ipv4_addresses.attribute_mapper }}:443 ssl spdy;
+    listen       {{ nginx_ipv4_addresses.attribute_mapper }}:443 ssl http2;
     server_name   attribute-mapper.{{ base_domain }};
 
     ssl                  on;
@@ -48,7 +48,7 @@ server {
 }
 
 server {
-    listen       [::]:443 ssl spdy;
+    listen       [::]:443 ssl http2;
     server_name  attribute-mapper.{{ base_domain }};
 
     ssl                  on;

--- a/roles/nginx/templates/authz.j2
+++ b/roles/nginx/templates/authz.j2
@@ -7,7 +7,7 @@ server {
 }
 
 server {
-  listen       {{ nginx_ipv4_addresses.authzserver }}:443 ssl spdy;
+  listen       {{ nginx_ipv4_addresses.authzserver }}:443 ssl http2;
   server_name  authz.{{ base_domain }};
 
   ssl                  on;
@@ -44,7 +44,7 @@ server {
 }
 
 server {
-    listen       [::]:443 ssl spdy;
+    listen       [::]:443 ssl http2;
     server_name  authz.{{ base_domain }};
 
     ssl                  on;

--- a/roles/nginx/templates/authz_admin.j2
+++ b/roles/nginx/templates/authz_admin.j2
@@ -7,7 +7,7 @@ server {
 }
 
 server {
-  listen       {{ nginx_ipv4_addresses.authz_admin }}:443 ssl spdy;
+  listen       {{ nginx_ipv4_addresses.authz_admin }}:443 ssl http2;
   server_name  authz-admin.{{ base_domain }};
 
   ssl                  on;
@@ -44,7 +44,7 @@ server {
 }
 
 server {
-    listen       [::]:443 ssl spdy;
+    listen       [::]:443 ssl http2;
     server_name  authz-admin.{{ base_domain }};
 
     ssl                  on;

--- a/roles/nginx/templates/authz_playground.j2
+++ b/roles/nginx/templates/authz_playground.j2
@@ -7,7 +7,7 @@ server {
 }
 
 server {
-  listen       {{ nginx_ipv4_addresses.authz_playground }}:443 ssl spdy;
+  listen       {{ nginx_ipv4_addresses.authz_playground }}:443 ssl http2;
   server_name  authz-playground.{{ base_domain }};
 
   ssl                  on;
@@ -44,7 +44,7 @@ server {
 }
 
 server {
-    listen       [::]:443 ssl spdy;
+    listen       [::]:443 ssl http2;
     server_name  authz-playground.{{ base_domain }};
 
     ssl                  on;

--- a/roles/nginx/templates/engine.j2
+++ b/roles/nginx/templates/engine.j2
@@ -13,7 +13,7 @@ server {
 }
 
 server {
-    listen       {{ nginx_ipv4_addresses.engine }}:443 ssl spdy;
+    listen       {{ nginx_ipv4_addresses.engine }}:443 ssl http2;
     server_name  engine.{{ base_domain }};
 
     ssl                  on;
@@ -51,7 +51,7 @@ server {
 }
 
 server {
-    listen       [::]:443 ssl spdy;
+    listen       [::]:443 ssl http2;
     server_name  engine.{{ base_domain }};
 
     ssl                  on;

--- a/roles/nginx/templates/engine_api.j2
+++ b/roles/nginx/templates/engine_api.j2
@@ -13,7 +13,7 @@ server {
 }
 
 server {
-    listen       {{ nginx_ipv4_addresses.engine_api }}:443 ssl spdy;
+    listen       {{ nginx_ipv4_addresses.engine_api }}:443 ssl http2;
     server_name  engine-api.{{ base_domain }};
     client_max_body_size 10M;
 	
@@ -52,7 +52,7 @@ server {
 }
 
 server {
-    listen       [::]:443 ssl spdy;
+    listen       [::]:443 ssl http2;
     server_name  engine-api.{{ base_domain }};
     client_max_body_size 10M;
 

--- a/roles/nginx/templates/grouper.j2
+++ b/roles/nginx/templates/grouper.j2
@@ -7,7 +7,7 @@ server {
 }
 
 server {
-  listen       {{ nginx_ipv4_addresses.grouper }}:443 ssl spdy;
+  listen       {{ nginx_ipv4_addresses.grouper }}:443 ssl http2;
   server_name  grouper.{{ base_domain }};
 
   ssl                  on;
@@ -44,7 +44,7 @@ server {
 }
 
 server {
-    listen       [::]:443 ssl spdy;
+    listen       [::]:443 ssl http2;
     server_name  grouper.{{ base_domain }};
 
     ssl                  on;

--- a/roles/nginx/templates/metadata_exporter.j2
+++ b/roles/nginx/templates/metadata_exporter.j2
@@ -10,7 +10,7 @@ server {
 }
 
 server {
-    listen       {{ nginx_ipv4_addresses.metadata_exporter }}:443 ssl spdy;
+    listen       {{ nginx_ipv4_addresses.metadata_exporter }}:443 ssl http2;
     server_name   multidata.{{ base_domain }};
 
     ssl                  on;
@@ -48,7 +48,7 @@ server {
 }
 
 server {
-    listen       [::]:443 ssl spdy;
+    listen       [::]:443 ssl http2;
     server_name  multidata.{{ base_domain }};
 
     ssl                  on;

--- a/roles/nginx/templates/mujina_idp.j2
+++ b/roles/nginx/templates/mujina_idp.j2
@@ -6,7 +6,7 @@ server {
 }
 
 server {
-    listen       {{ nginx_ipv4_addresses.mujina_idp }}:443 ssl spdy;
+    listen       {{ nginx_ipv4_addresses.mujina_idp }}:443 ssl http2;
     server_name  mujina-idp.{{ base_domain }};
 
     ssl                  on;
@@ -44,7 +44,7 @@ server {
 }
 
 server {
-    listen       [::]:443 ssl spdy;
+    listen       [::]:443 ssl http2;
     server_name  mujina-idp.{{ base_domain }};
 
     ssl                  on;

--- a/roles/nginx/templates/mujina_sp.j2
+++ b/roles/nginx/templates/mujina_sp.j2
@@ -10,7 +10,7 @@ server {
 }
 
 server {
-    listen       {{ nginx_ipv4_addresses.mujina_sp }}:443 ssl spdy;
+    listen       {{ nginx_ipv4_addresses.mujina_sp }}:443 ssl http2;
     server_name  mujina-sp.{{ base_domain }};
 
     ssl                  on;
@@ -48,7 +48,7 @@ server {
 }
 
 server {
-    listen       [::]:443 ssl spdy;
+    listen       [::]:443 ssl http2;
     server_name  mujina-sp.{{ base_domain }};
 
     ssl                  on;

--- a/roles/nginx/templates/oidc.j2
+++ b/roles/nginx/templates/oidc.j2
@@ -10,7 +10,7 @@ server {
 }
 
 server {
-    listen       {{ nginx_ipv4_addresses.oidc }}:443 ssl spdy;
+    listen       {{ nginx_ipv4_addresses.oidc }}:443 ssl http2;
     server_name  oidc.{{ base_domain }};
 
     ssl                  on;
@@ -48,7 +48,7 @@ server {
 }
 
 server {
-    listen       [::]:443 ssl spdy;
+    listen       [::]:443 ssl http2;
     server_name  oidc.{{ base_domain }};
 
     ssl                  on;

--- a/roles/nginx/templates/pdp.j2
+++ b/roles/nginx/templates/pdp.j2
@@ -10,7 +10,7 @@ server {
 }
 
 server {
-    listen       {{ nginx_ipv4_addresses.pdp }}:443 ssl spdy;
+    listen       {{ nginx_ipv4_addresses.pdp }}:443 ssl http2;
     server_name  pdp.{{ base_domain }};
 
     ssl                  on;
@@ -48,7 +48,7 @@ server {
 }
 
 server {
-    listen       [::]:443 ssl spdy;
+    listen       [::]:443 ssl http2;
     server_name  pdp.{{ base_domain }};
 
     ssl                  on;

--- a/roles/nginx/templates/profile.j2
+++ b/roles/nginx/templates/profile.j2
@@ -13,7 +13,7 @@ server {
 }
 
 server {
-    listen       {{ nginx_ipv4_addresses.profile }}:443 ssl spdy;
+    listen       {{ nginx_ipv4_addresses.profile }}:443 ssl http2;
     server_name  profile.{{ base_domain }};
 
     ssl                  on;
@@ -51,7 +51,7 @@ server {
 }
 
 server {
-    listen       [::]:443 ssl spdy;
+    listen       [::]:443 ssl http2;
     server_name  profile.{{ base_domain }};
 
     ssl                  on;

--- a/roles/nginx/templates/serviceregistry.j2
+++ b/roles/nginx/templates/serviceregistry.j2
@@ -13,7 +13,7 @@ server {
 }
 
 server {
-    listen       {{ nginx_ipv4_addresses.serviceregistry }}:443 ssl spdy;
+    listen       {{ nginx_ipv4_addresses.serviceregistry }}:443 ssl http2;
     server_name  serviceregistry.{{ base_domain }};
 
     ssl                  on;
@@ -51,7 +51,7 @@ server {
 }
 
 server {
-    listen       [::]:443 ssl spdy;
+    listen       [::]:443 ssl http2;
     server_name  serviceregistry.{{ base_domain }};
 
     ssl                  on;

--- a/roles/nginx/templates/static.j2
+++ b/roles/nginx/templates/static.j2
@@ -10,7 +10,7 @@ server {
 }
 
 server {
-    listen       {{ nginx_ipv4_addresses.static }}:443 ssl spdy;
+    listen       {{ nginx_ipv4_addresses.static }}:443 ssl http2;
     server_name  static.{{ base_domain }};
 
     ssl                  on;
@@ -48,7 +48,7 @@ server {
 }
 
 server {
-    listen       [::]:443 ssl spdy;
+    listen       [::]:443 ssl http2;
     server_name  static.{{ base_domain }};
 
     ssl                  on;

--- a/roles/nginx/templates/teams.j2
+++ b/roles/nginx/templates/teams.j2
@@ -10,7 +10,7 @@ server {
 }
 
 server {
-    listen       {{ nginx_ipv4_addresses.teams }}:443 ssl spdy;
+    listen       {{ nginx_ipv4_addresses.teams }}:443 ssl http2;
     server_name  teams.{{ base_domain }};
 
     ssl                  on;
@@ -48,7 +48,7 @@ server {
 }
 
 server {
-    listen       [::]:443 ssl spdy;
+    listen       [::]:443 ssl http2;
     server_name  teams.{{ base_domain }};
 
     ssl                  on;

--- a/roles/nginx/templates/voot.j2
+++ b/roles/nginx/templates/voot.j2
@@ -10,7 +10,7 @@ server {
 }
 
 server {
-    listen       {{ nginx_ipv4_addresses.voot }}:443 ssl spdy;
+    listen       {{ nginx_ipv4_addresses.voot }}:443 ssl http2;
     server_name  voot.{{ base_domain }};
 
     ssl                  on;
@@ -48,7 +48,7 @@ server {
 }
 
 server {
-    listen       [::]:443 ssl spdy;
+    listen       [::]:443 ssl http2;
     server_name  voot.{{ base_domain }};
 
     ssl                  on;

--- a/roles/nginx/templates/welcome.j2
+++ b/roles/nginx/templates/welcome.j2
@@ -9,7 +9,7 @@ server {
 }
 
 server {
-    listen       {{ nginx_ipv4_addresses.welcome }}:443 ssl spdy;
+    listen       {{ nginx_ipv4_addresses.welcome }}:443 ssl http2;
     server_name  {{ base_domain }};
 
     ssl                  on;
@@ -47,7 +47,7 @@ server {
 }
 
 server {
-    listen       [::]:443 ssl spdy;
+    listen       [::]:443 ssl http2;
     server_name  {{ base_domain }};
 
     ssl                  on;


### PR DESCRIPTION
The nginx repo that's used with OpenConext will upgrade to version 1.10.1 with a `yum upgrade`.  With this version, the `spdy`  directive is no longer used, but replaced by `http2`.  In order to prevent these errors from popping up after the update happens, the configs need to be changed.

I don't know of any harm in updating the this version, but if there is a specific reason to use the 1.8.X branch, then it might be worthwhile pinning it from upgrades.