### PR TITLE
Dev env provisionig

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -31,6 +31,7 @@ Vagrant.configure("2") do |config|
     lb_centos7.vm.network :private_network, ip: "192.168.66.98"
     lb_centos7.vm.hostname = "lb.vm.openconext.org"
     config.vm.provider :virtualbox do |vb|
+      vb.name = "OpenConext Engineblock Loadbalancer"
       vb.customize ["modifyvm", :id, "--memory", "512"]
       vb.customize ["modifyvm", :id, "--cpus", "1"]
     end
@@ -54,6 +55,7 @@ Vagrant.configure("2") do |config|
     apps_centos7.vm.network :private_network, ip: "192.168.66.99"
     apps_centos7.vm.hostname = "apps.vm.openconext.org"
     config.vm.provider :virtualbox do |vb|
+      vb.name = "OpenConext Engineblock Apps"
       vb.customize ["modifyvm", :id, "--memory", "3072"]
       vb.customize ["modifyvm", :id, "--cpus", "2"]
     end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -44,6 +44,7 @@ Vagrant.configure("2") do |config|
         ansible.playbook = "provision-vm.yml"
         ansible.extra_vars = {
           user: "vagrant",
+          env: "vm",
           secrets_file: "environments/vm/secrets/vm.yml",
           develop: true
         }
@@ -69,6 +70,7 @@ Vagrant.configure("2") do |config|
         ansible.playbook = "provision-vm.yml"
         ansible.extra_vars = {
           user: "vagrant",
+          env: "vm",
           secrets_file: "environments/vm/secrets/vm.yml",
           develop: true,
           engine_apache_symfony_environment: "dev"

--- a/roles/engineblock5/tasks/main.yml
+++ b/roles/engineblock5/tasks/main.yml
@@ -62,20 +62,20 @@
   changed_when: False
 
 # Any scripts should be placed below this
-- name: Run EngineBlock Doctrine migrations
-  command: "app/console doctrine:migrations:migrate -n --env={{ engine_apache_symfony_environment }}"
-  args:
-    chdir: "{{ openconext_releases_dir }}/OpenConext-engineblock"
-  register: doctrine_migrations_output
-  changed_when: "'No migrations to execute' not in doctrine_migrations_output.stdout"
-  tags: enginemigrations
-
 - name: Run EngineBlock DbPatch migrations
   command: ./bin/migrate
   args:
     chdir: "{{ openconext_releases_dir }}/OpenConext-engineblock"
   register: migrate_output
   changed_when: "'no update needed' not in migrate_output.stderr"
+  tags: enginemigrations
+
+- name: Run EngineBlock Doctrine migrations
+  command: "app/console doctrine:migrations:migrate -n --env={{ engine_apache_symfony_environment }}"
+  args:
+    chdir: "{{ openconext_releases_dir }}/OpenConext-engineblock"
+  register: doctrine_migrations_output
+  changed_when: "'No migrations to execute' not in doctrine_migrations_output.stdout"
   tags: enginemigrations
 
 - name: Make sure cache dir has correct permissions


### PR DESCRIPTION
- [X] give sensible names to vms for Virtualbox UI
- [X] use `env=vm` for ansible provisioning
- [X] ensure database migrations run in the correct order
    this is needed because the current dump no longer includes all tables (notably, `sso_provider_roles` is missing)
- [ ] ensure haproxy health checks are disabled in dev env (see [here][1])

[1]: https://github.com/OpenConext/OpenConext-deploy/commit/b27a8441979b118a037475ae32af2679930dd022#diff-20f5428347b213f92e8081ea12666683L41