### PR TITLE
Using github url for SSP download

### DIFF
--- a/roles/janus/defaults/main.yml
+++ b/roles/janus/defaults/main.yml
@@ -9,7 +9,7 @@ janus_ssp_version: 1.13.2
 janus_ssp_unarchived_dir: "{{ janus_installation_dir }}/simplesamlphp-{{ janus_ssp_version}}"
 janus_ssp_dir: "{{ janus_installation_dir }}/simplesamlphp"
 janus_ssp_modules_dir: "{{ janus_ssp_dir }}/modules"
-janus_ssp_download_base_url: https://simplesamlphp.org/res/downloads/
+janus_ssp_download_base_url: https://github.com/simplesamlphp/simplesamlphp/releases/download/v{{ janus_ssp_version }}/
 janus_ssp_tar_file: simplesamlphp-{{ janus_ssp_version }}.tar.gz
 janus_ssp_tar_location: "{{ openconext_builds_dir }}/{{ janus_ssp_tar_file }}"
 #


### PR DESCRIPTION
During the playbook run, python was complaining it can't connect to the SSP download site because it's missing dependencies for SNI..  Rather than installing in a bunch of dependencies, it's better to just use the Github URL which doesn't require SNI.  It also looks like the SSP project uses the github.com link to download the `.tar.gz` now.