### PR TITLE
Disable sendfile for development

### DIFF
--- a/roles/httpd/templates/httpd.conf_httpd24.j2
+++ b/roles/httpd/templates/httpd.conf_httpd24.j2
@@ -328,7 +328,14 @@ AddDefaultCharset UTF-8
 # Defaults if commented: EnableMMAP On, EnableSendfile Off
 #
 #EnableMMAP off
-EnableSendfile on
+
+{% if develop %}
+# Disable sendfile for development as modified assets such as JavaScript and CSS will be sent incorrectly
+EnableSendfile Off
+{% else %}
+EnableSendfile On
+{% endif %}
+
 ServerSignature Off
 
 # Supplemental configuration


### PR DESCRIPTION
This mitigates the issue on certain VMs where files sent by the webserver are corrupted because of illegal characters and/or truncation.

_This is a known, long-running issue when using [VirtualBox](https://www.virtualbox.org/ticket/9069)._