### PR TITLE
Consent Feature toggle & parameterization

### DIFF
--- a/roles/engineblock/defaults/main.yml
+++ b/roles/engineblock/defaults/main.yml
@@ -5,6 +5,13 @@ engine_version: ''
 
 # Feature toggles
 engine_feature_ldap_integration: 1
+engine_feature_encrypted_assertions: 1
+engine_feature_encrypted_assertions_require_outer_signature: 1
+engine_feature_run_all_manipulations_prior_to_consent: 0
+
+engine_api_feature_metadata_push: 1
+engine_api_feature_consent_listing: 1
+engine_api_feature_metadata_api: 1
 
 ## Engine installer specific variables.
 engine_version_dir: "{{ engine_version | replace('/', '-') }}"

--- a/roles/engineblock/templates/engineblock.ini.j2
+++ b/roles/engineblock/templates/engineblock.ini.j2
@@ -13,21 +13,21 @@ engineApi.users.profile.username = {{ engine_api_profile_user }}
 engineApi.users.profile.password = {{ engine_api_profile_password }}
 
 ;; EngineBlock API feature toggles
-engineApi.features.metadataPush = 1
-engineApi.features.consentListing = 1
-engineApi.features.metadataApi = 1
+engineApi.features.metadataPush = {{ engine_api_feature_metadata_push }}
+engineApi.features.consentListing = {{ engine_api_feature_consent_listing }}
+engineApi.features.metadataApi = {{ engine_api_feature_metadata_api }}
 
 ; Whether or not the LDAP should be used as secondary backend for the UserDirectory
 ; (database is considered primary).
 engineblock.feature.ldap_integration = {{ engine_feature_ldap_integration }}
 
 ;; EngineBlock response capability feature toggles (on, safe by default)
-engineblock.feature.encrypted_assertions = 1
-engineblock.feature.encrypted_assertions_require_outer_signature = 1
+engineblock.feature.encrypted_assertions = {{ engine_feature_encrypted_assertions }}
+engineblock.feature.encrypted_assertions_require_outer_signature = {{ engine_feature_encrypted_assertions_require_outer_signature }}
 
 ;; EngineBlock consent feature toggles
 ; Whether or not all input and output filter should run prior to consent.
-engineblock.feature.run_all_manipulations_prior_to_consent = 0
+engineblock.feature.run_all_manipulations_prior_to_consent = {{ engine_feature_run_all_manipulations_prior_to_consent }}
 
 ;; Symfony specific variables
 symfony.cachePath = "{{ engineblock_symfony_cache_path }}"

--- a/roles/engineblock/templates/engineblock.ini.j2
+++ b/roles/engineblock/templates/engineblock.ini.j2
@@ -25,6 +25,10 @@ engineblock.feature.ldap_integration = {{ engine_feature_ldap_integration }}
 engineblock.feature.encrypted_assertions = 1
 engineblock.feature.encrypted_assertions_require_outer_signature = 1
 
+;; EngineBlock consent feature toggles
+; Whether or not all input and output filter should run prior to consent.
+engineblock.feature.run_all_manipulations_prior_to_consent = 0
+
 ;; Symfony specific variables
 symfony.cachePath = "{{ engineblock_symfony_cache_path }}"
 symfony.logPath = "{{ engineblock_symfony_log_path }}"


### PR DESCRIPTION
For EngineBlock 5.1 one of the targets is to modify what is shown to the user on the consent screen (for a Proof of Concept see OpenConext/OpenConext-engineblock#332). This PR adds a feature toggle for that functionality to be used in the final implementation.

Furthermore all feature toggle values have been parameterized so that they now can be configured per environment. The original values have been been carried over as default values.