### PR TITLE
Use /dev/urandom as random source instead of /dev/random

### DIFF
--- a/roles/aa/vars/main.yml
+++ b/roles/aa/vars/main.yml
@@ -12,6 +12,7 @@ springapp_local_jar: "{{ aa_local_jar }}"
 springapp_debug: "{{ aa_debug }}"
 springapp_debug_port: 1198
 springapp_heapsize: "512m"
+springapp_random_source: "file:///dev/urandom"
 
 js_error_reporting_access_token: "{{ attribute_aggregator_js_access_token }}"
 js_error_enabled: "true"

--- a/roles/attribute-mapper/vars/main.yml
+++ b/roles/attribute-mapper/vars/main.yml
@@ -12,3 +12,4 @@ springapp_local_jar: "{{ attribute_mapper_local_jar }}"
 springapp_debug: "{{ attribute_mapper_debug }}"
 springapp_debug_port: 1292
 springapp_heapsize: "128m"
+springapp_random_source: "file:///dev/urandom"

--- a/roles/authz-admin/vars/main.yml
+++ b/roles/authz-admin/vars/main.yml
@@ -12,3 +12,4 @@ springapp_local_jar: "{{ authz_admin_local_jar }}"
 springapp_debug: "{{ authz_admin_debug }}"
 springapp_debug_port: 1290
 springapp_heapsize: "128m"
+springapp_random_source: "file:///dev/urandom"

--- a/roles/authz-playground/vars/main.yml
+++ b/roles/authz-playground/vars/main.yml
@@ -12,3 +12,4 @@ springapp_local_jar: "{{ authz_playground_local_jar }}"
 springapp_debug: "{{ authz_playground_debug }}"
 springapp_debug_port: 1291
 springapp_heapsize: "64m"
+springapp_random_source: "file:///dev/urandom"

--- a/roles/authz-server/vars/main.yml
+++ b/roles/authz-server/vars/main.yml
@@ -12,3 +12,4 @@ springapp_local_jar: "{{ authz_server_local_jar }}"
 springapp_debug: "{{ authz_server_debug }}"
 springapp_debug_port: 1190
 springapp_heapsize: "64m"
+springapp_random_source: "file:///dev/urandom"

--- a/roles/eduproxy/vars/main.yml
+++ b/roles/eduproxy/vars/main.yml
@@ -12,3 +12,4 @@ springapp_local_jar: "{{ eduproxy_local_jar }}"
 springapp_debug: "{{ eduproxy_debug }}"
 springapp_debug_port: 1399
 springapp_heapsize: 512m
+springapp_random_source: "file:///dev/urandom"

--- a/roles/grouper/defaults/main.yml
+++ b/roles/grouper/defaults/main.yml
@@ -4,6 +4,6 @@ grouper_source_ldap_id: "openconext-ldap"
 grouper_source_ldap_name: "OpenConext LDAP"
 grouper_source_applications_id: "applications"
 grouper_source_applications_name: "OpenConext Applications"
-grouper_random_souce: "file:///dev/urandom"
+grouper_random_source: "file:///dev/urandom"
 ldap_ro_password: "{{ ldap_password }}"
 

--- a/roles/grouper/defaults/main.yml
+++ b/roles/grouper/defaults/main.yml
@@ -4,5 +4,6 @@ grouper_source_ldap_id: "openconext-ldap"
 grouper_source_ldap_name: "OpenConext LDAP"
 grouper_source_applications_id: "applications"
 grouper_source_applications_name: "OpenConext Applications"
+grouper_random_souce: "file:///dev/urandom"
 ldap_ro_password: "{{ ldap_password }}"
 

--- a/roles/grouper/tasks/main.yml
+++ b/roles/grouper/tasks/main.yml
@@ -58,7 +58,7 @@
   tags: grouper
 
 - name: initialize
-  shell: bin/gsh -registry -runscript -noprompt
+  shell: /bin/env GSH_JVMARGS="-Djava.security.egd=file:///dev/urandom" bin/gsh -registry -runscript -noprompt
   changed_when: False # this will always report a change... so "sudo be quiet"...
   args:
     chdir: /opt/www/grouper-shell

--- a/roles/grouper/tasks/main.yml
+++ b/roles/grouper/tasks/main.yml
@@ -58,7 +58,7 @@
   tags: grouper
 
 - name: initialize
-  shell: /bin/env GSH_JVMARGS="-Djava.security.egd=file:///dev/urandom" bin/gsh -registry -runscript -noprompt
+  shell: '/bin/env GSH_JVMARGS="-Djava.security.egd={{ grouper_random_source }}" bin/gsh -registry -runscript -noprompt'
   changed_when: False # this will always report a change... so "sudo be quiet"...
   args:
     chdir: /opt/www/grouper-shell

--- a/roles/grouper/tasks/provision_grouper.yml
+++ b/roles/grouper/tasks/provision_grouper.yml
@@ -11,7 +11,7 @@
     - { src: sources-grouper-shell.xml, dest: sources.xml }
 
 - name: provision users to call grouper ws
-  shell: /bin/env GSH_JVMARGS="-Djava.security.egd=file:///dev/urandom" bin/gsh ~/{{ item }}
+  shell: '/bin/env GSH_JVMARGS="-Djava.security.egd={{ grouper_random_source }}" bin/gsh ~/{{ item }}'
   register: gsh_output
   changed_when: "'auto-created' in gsh_output.stderr"
   failed_when: "gsh_output.stderr != '' and ('already exists' not in gsh_output.stderr and 'auto-created' not in gsh_output.stderr)"

--- a/roles/grouper/tasks/provision_grouper.yml
+++ b/roles/grouper/tasks/provision_grouper.yml
@@ -11,7 +11,7 @@
     - { src: sources-grouper-shell.xml, dest: sources.xml }
 
 - name: provision users to call grouper ws
-  shell: bin/gsh ~/{{ item }}
+  shell: /bin/env GSH_JVMARGS="-Djava.security.egd=file:///dev/urandom" bin/gsh ~/{{ item }}
   register: gsh_output
   changed_when: "'auto-created' in gsh_output.stderr"
   failed_when: "gsh_output.stderr != '' and ('already exists' not in gsh_output.stderr and 'auto-created' not in gsh_output.stderr)"

--- a/roles/metadata-exporter/vars/main.yml
+++ b/roles/metadata-exporter/vars/main.yml
@@ -12,3 +12,4 @@ springapp_local_jar: "{{ metadata_exporter_local_jar }}"
 springapp_debug: "{{ metadata_exporter_debug }}"
 springapp_debug_port: 1299
 springapp_heapsize: 512m
+springapp_random_source: "file:///dev/urandom"

--- a/roles/mujina-idp/defaults/main.yml
+++ b/roles/mujina-idp/defaults/main.yml
@@ -4,3 +4,4 @@ mujina_idp_artifact_id: mujina-idp
 mujina_snapshot_timestamp: ''
 mujina_idp_local_war: ''
 mujina_idp_signing_algorithm: "http://www.w3.org/2000/09/xmldsig#rsa-sha1"
+mujina_idp_random_source: 'file:///dev/urandom'

--- a/roles/mujina-idp/tasks/provision_grouper.yml
+++ b/roles/mujina-idp/tasks/provision_grouper.yml
@@ -9,7 +9,7 @@
     - { src: sources-grouper-shell.xml, dest: sources.xml }
 
 - name: provision grouper with users
-  shell: "/bin/env GSH_JVMARGS='-Djava.security.egd=file:///dev/urandom' bin/gsh ~/{{ item }}"
+  shell: "/bin/env GSH_JVMARGS='-Djava.security.egd={{ mujina_idp_random_source }}' bin/gsh ~/{{ item }}"
   register: gsh_output
   changed_when: "'auto-created' in gsh_output.stderr"
   failed_when: gsh_output.stderr != '' and ("already exists" not in gsh_output.stderr and "auto-created" not in gsh_output.stderr)

--- a/roles/mujina-idp/tasks/provision_grouper.yml
+++ b/roles/mujina-idp/tasks/provision_grouper.yml
@@ -9,7 +9,7 @@
     - { src: sources-grouper-shell.xml, dest: sources.xml }
 
 - name: provision grouper with users
-  shell: bin/gsh ~/{{ item }}
+  shell: "/bin/env GSH_JVMARGS='-Djava.security.egd=file:///dev/urandom' bin/gsh ~/{{ item }}"
   register: gsh_output
   changed_when: "'auto-created' in gsh_output.stderr"
   failed_when: gsh_output.stderr != '' and ("already exists" not in gsh_output.stderr and "auto-created" not in gsh_output.stderr)

--- a/roles/pdp/vars/main.yml
+++ b/roles/pdp/vars/main.yml
@@ -12,6 +12,7 @@ springapp_local_jar: "{{ pdp_local_jar }}"
 springapp_debug: "{{ pdp_debug }}"
 springapp_debug_port: 1196
 springapp_heapsize: "512m"
+springapp_random_source: "file:///dev/urandom"
 
 js_error_reporting_access_token: "{{ pdp_js_access_token }}"
 js_error_enabled: "true"

--- a/roles/teams/defaults/main.yml
+++ b/roles/teams/defaults/main.yml
@@ -5,3 +5,4 @@ teams_snapshot_timestamp: ''
 teams_local_jar: ''
 teams_jar: teams-current.war
 teams_server_debug: false
+teams_random_source: 'file:///dev/urandom'

--- a/roles/teams/tasks/main.yml
+++ b/roles/teams/tasks/main.yml
@@ -74,7 +74,7 @@
   when: env == 'vm' or env == 'test2' or env == 'template'
 
 - name: provision grouper for teams
-  shell: "/bin/env GSH_JVMARGS='-Djava.security.egd=file:///dev/urandom' bin/gsh ~/create-stems.gsh"
+  shell: "/bin/env GSH_JVMARGS='-Djava.security.egd={{ teams_random_source }}' bin/gsh ~/create-stems.gsh"
   register: gsh_output
   changed_when: "gsh_output.stderr != ''"
   args:

--- a/roles/teams/tasks/main.yml
+++ b/roles/teams/tasks/main.yml
@@ -74,7 +74,7 @@
   when: env == 'vm' or env == 'test2' or env == 'template'
 
 - name: provision grouper for teams
-  shell: "bin/gsh ~/create-stems.gsh"
+  shell: "/bin/env GSH_JVMARGS='-Djava.security.egd=file:///dev/urandom' bin/gsh ~/create-stems.gsh"
   register: gsh_output
   changed_when: "gsh_output.stderr != ''"
   args:

--- a/roles/teams/vars/main.yml
+++ b/roles/teams/vars/main.yml
@@ -12,3 +12,4 @@ springapp_local_jar: "{{ teams_local_jar }}"
 springapp_debug: "{{ teams_debug | default(false) }}"
 springapp_debug_port: 1197
 springapp_heapsize: "256m"
+springapp_random_source: "file:///dev/urandom"

--- a/roles/voot/vars/main.yml
+++ b/roles/voot/vars/main.yml
@@ -12,3 +12,4 @@ springapp_local_jar: "{{ voot_local_jar }}"
 springapp_debug: "{{ voot_debug }}"
 springapp_debug_port: 1191
 springapp_heapsize: "128m"
+springapp_random_source: "file:///dev/urandom"

--- a/templates/spring-boot.j2
+++ b/templates/spring-boot.j2
@@ -17,6 +17,7 @@ APP_NAME="{{ springapp_service_name }}"
 APP_JAR="{{ springapp_jar }}"
 APP_USER="{{ springapp_user }}"
 HEAPSIZE="{{ springapp_heapsize }}"
+RANDOM_SOURCE="{{ springapp_random_source }}"
 
 LOG="/var/log/$APP_NAME.log"
 LOCK="/var/lock/subsys/$APP_NAME"
@@ -53,7 +54,7 @@ start() {
     fi
 
     cd "$APPLICATION_HOME"
-    $SU - $APP_USER -c "nohup $JAVA $DEBUG_OPTS -Xms$HEAPSIZE  -Xmx$HEAPSIZE -jar $APP_JAR >> /var/log/$APP_NAME/init.log 2>&1 &"
+    $SU - $APP_USER -c "nohup $JAVA $DEBUG_OPTS -Xms$HEAPSIZE  -Xmx$HEAPSIZE -Djava.security.egd=$RANDOM_SOURCE -jar $APP_JAR >> /var/log/$APP_NAME/init.log 2>&1 &"
 
     pid_of_app > /dev/null
     RETVAL=$?


### PR DESCRIPTION
This patch changes the random source of the java programs to /dev/urandom (instead of the default /dev/random). This fixes issues with the startup time of the java apps (see OpenConext/OpenConext-voot#3), while sacrificing no security. /dev/urandom is s perfectly fine source for random data, and as even openssl uses /dev/urandom for seeding its PRNG, it should also be fine for our java apps.

See also http://www.2uo.de/myths-about-urandom/, http://sockpuppet.org/blog/2014/02/25/safely-generate-random-numbers/