### PR TITLE
add check for correctly setup hostname

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -2,6 +2,10 @@
 - name: set timezone
   file: state=link src=/usr/share/zoneinfo/{{ timezone }} dest=/etc/localtime force=True
 
+- name: check that hostname and fqdn are set up correctly
+  command: "/usr/bin/hostname --fqdn"
+  any_errors_fatal: true
+
 - name: Add Epel repo
   yum: name=epel-release.noarch state=present
 


### PR DESCRIPTION
The java spring boot apps need a correctly setup hostname, but the error for failure is rather unclear. This adds an explicit check.