### PR TITLE
Make cutoff point for IdPs on the WAYF configurable

### DIFF
--- a/roles/engineblock/defaults/main.yml
+++ b/roles/engineblock/defaults/main.yml
@@ -13,6 +13,9 @@ engine_api_feature_metadata_push: 1
 engine_api_feature_consent_listing: 1
 engine_api_feature_metadata_api: 1
 
+# Cutoff point for showing unfiltered IdPs on the WAYF
+engine_wayf_cutoff_point_for_showing_unfiltered_idps: 50
+
 ## Engine installer specific variables.
 engine_version_dir: "{{ engine_version | replace('/', '-') }}"
 engine_branch_dir: "{{ openconext_builds_dir }}/OpenConext-engineblock-{{ engine_branch | replace('/', '-') }}"

--- a/roles/engineblock/templates/engineblock.ini.j2
+++ b/roles/engineblock/templates/engineblock.ini.j2
@@ -17,6 +17,10 @@ engineApi.features.metadataPush = {{ engine_api_feature_metadata_push }}
 engineApi.features.consentListing = {{ engine_api_feature_consent_listing }}
 engineApi.features.metadataApi = {{ engine_api_feature_metadata_api }}
 
+;; Cutoff point for showing unfiltered IdPs on the WAYF
+; Unfiltered IdPs on the WAYF are hidden if there are more IdPs than the cutoff point
+wayf.cutoffPointForShowingUnfilteredIdps = {{ engine_wayf_cutoff_point_for_showing_unfiltered_idps }}
+
 ; Whether or not the LDAP should be used as secondary backend for the UserDirectory
 ; (database is considered primary).
 engineblock.feature.ldap_integration = {{ engine_feature_ldap_integration }}


### PR DESCRIPTION
This PR makes it possible to configure the cutoff point regarding whether or not unfiltered IdPs should be shown on the WAYF. 

This functionality will be added in [EngineBlock PR #337](https://github.com/OpenConext/OpenConext-engineblock/pull/337).