### PR TITLE
Quote yml template strings

### DIFF
--- a/roles/profile/templates/parameters.yml.j2
+++ b/roles/profile/templates/parameters.yml.j2
@@ -20,7 +20,7 @@ parameters:
     engineblock_api_base_url: 'https://{{ engine_api_domain }}/'
     engineblock_api_username: '{{ engine_api_profile_user }}'
     engineblock_api_password: '{{ engine_api_profile_password }}'
-    engineblock_api_verify_ssl: '{{ engine_api_verify_ssl }}'
+    engineblock_api_verify_ssl: {{ engine_api_verify_ssl }}
 
     mailer_transport:  sendmail
     mailer_host:       ~

--- a/roles/profile/templates/parameters.yml.j2
+++ b/roles/profile/templates/parameters.yml.j2
@@ -1,31 +1,31 @@
 parameters:
-    secret: {{ profile_secret }}
-    default_locale: {{ profile_default_locale }}
+    secret: '{{ profile_secret }}'
+    default_locale: '{{ profile_default_locale }}'
     open_conext_locale_cookie_key: lang
     open_conext_locale_cookie_domain: .{{ base_domain }}
     open_conext_locale_cookie_expires_in: "+2 months"
     open_conext_locale_cookie_http_only: false
     open_conext_locale_cookie_secure: false
 
-    saml_sp_publickey: {{ profile_saml_sp_publickey }}
-    saml_sp_privatekey: {{ profile_saml_sp_privatekey }}
-    saml_metadata_publickey: {{ profile_saml_metadata_publickey }}
-    saml_metadata_privatekey: {{ profile_saml_metadata_privatekey }}
+    saml_sp_publickey: '{{ profile_saml_sp_publickey }}'
+    saml_sp_privatekey: '{{ profile_saml_sp_privatekey }}'
+    saml_metadata_publickey: '{{ profile_saml_metadata_publickey }}'
+    saml_metadata_privatekey: '{{ profile_saml_metadata_privatekey }}'
 
-    saml_remote_idp_entity_id: {{ engine_profile_idp_entityid }}
-    saml_remote_idp_sso_url: {{ engine_profile_idp_sso_url }}
-    saml_remote_idp_host: {{ engine_domain }}
-    saml_remote_idp_certificate: {{ engine_profile_idp_certificate }}
+    saml_remote_idp_entity_id: '{{ engine_profile_idp_entityid }}'
+    saml_remote_idp_sso_url: '{{ engine_profile_idp_sso_url }}'
+    saml_remote_idp_host: '{{ engine_domain }}'
+    saml_remote_idp_certificate: '{{ engine_profile_idp_certificate }}'
 
     engineblock_api_base_url: 'https://{{ engine_api_domain }}/'
-    engineblock_api_username: {{ engine_api_profile_user }}
-    engineblock_api_password: {{ engine_api_profile_password }}
-    engineblock_api_verify_ssl: {{ engine_api_verify_ssl }}
+    engineblock_api_username: '{{ engine_api_profile_user }}'
+    engineblock_api_password: '{{ engine_api_profile_password }}'
+    engineblock_api_verify_ssl: '{{ engine_api_verify_ssl }}'
 
     mailer_transport:  sendmail
     mailer_host:       ~
     mailer_user:       ~
     mailer_password:   ~
 
-    attribute_support_email_from: no-reply@surfconext.nl
-    attribute_support_email_to: help@surfconext.nl
+    attribute_support_email_from: 'no-reply@surfconext.nl'
+    attribute_support_email_to: 'help@surfconext.nl'


### PR DESCRIPTION
If strings are unquoted in yaml, a '+' sign (e.g.) wil terminate the string. This is specifally important for all certificate parameters because + is a valid base64 character.