### PR TITLE
Fix for role/common hostname --fqdn flag

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -3,7 +3,7 @@
   file: state=link src=/usr/share/zoneinfo/{{ timezone }} dest=/etc/localtime force=True
 
 - name: check that hostname and fqdn are set up correctly
-  command: "/usr/bin/hostname --fqdn"
+  command: "/usr/bin/hostname --all-fqdn"
   any_errors_fatal: true
   changed_when: false
 


### PR DESCRIPTION
In our case, our OpenStack instances have an internal 10.X and IPv6 addresses. These machines have IPv6 only AAAA records and are therefore failing when using the --fqdn method. 

As per the manpage: If a machine has multiple network interfaces/addresses or is used in a mobile environment, then it may either have multiple FQDNs/domain names or none at all. Therefore avoid using hostname --fqdn.

