### PR TITLE
Bring provision-vm.yml and provision-docker.yml in sync

### DIFF
--- a/provision-docker.yml
+++ b/provision-docker.yml
@@ -11,9 +11,9 @@
   gather_facts: yes
   become: true
   roles:
-    - common
-    - { role: tls, tags: [tls] }
-    - { role: rsyslog, tags: [rsyslog] }
+    - { role: common,  tags: ['common'] }
+    - { role: tls,     tags: ['tls'] }
+    - { role: rsyslog, tags: ['rsyslog'] }
   handlers:
     - include: roles/httpd/handlers/main.yml
 
@@ -21,22 +21,23 @@
   gather_facts: yes
   become: true
   roles:
-    - { role: mysql, tags: [mysql] }
-    - { role: ldap,  tags: [ldap] }
+    - { role: mysql,                   tags: ['mysql'] }
+    - { role: ldap,                    tags: ['ldap'] }
     - { role: vm_only_provision_eb_sr, tags: ['vm_only_provision_eb_sr'] }
 
+- hosts: loadbalancer
+  gather_facts: true
+  become: true
+  roles:
+    - { role: haproxy, tags: ['lb'] }
 
 - hosts: php-apps:java-apps
   gather_facts: yes
   become: true
   roles:
     - httpd
-
-- hosts: loadbalancer
-  gather_facts: no
-  become: true
-  roles:
-    - { role: haproxy, tags: [lb] }
+  handlers:
+    - include: roles/httpd/handlers/main.yml
 
 - hosts: php-apps
   gather_facts: no
@@ -44,37 +45,38 @@
   vars:
     env_lang: php
   roles:
-    - { role: php56fpm,          tags: ['php56fpm'] }
-    - { role: static,            tags: ['static'] }
-    - { role: welcome,           tags: ['welcome'] }
-    - { role: openconext-common, tags: ['eb','sr','profile'] }
-    - { role: engineblock,      tags: ['eb'     ] }
-    - { role: janus,             tags: ['sr'     ] }
-    - { role: vm_only_bootstrap_ldap_attributes,       tags: ['ldap'     ] }
-    - { role: profile,           tags: ['profile'] }
-
-  handlers: 
+    - { role: php56fpm,                          tags: ['php56fpm'] }
+    - { role: static,                            tags: ['static'] }
+    - { role: welcome,                           tags: ['welcome'] }
+    - { role: openconext-common,                 tags: ['eb','sr','profile'] }
+    - { role: engineblock,                       tags: ['eb'     ] }
+    - { role: janus,                             tags: ['sr'     ] }
+    - { role: vm_only_bootstrap_ldap_attributes, tags: ['ldap'     ] }
+    - { role: profile,                           tags: ['profile'] }
+  handlers:
     - include: roles/httpd/handlers/main.yml
 
 - hosts: java-apps
-  gather_facts: yes
+  gather_facts: true
   become: true
+  vars:
+    env_lang: java
   roles:
-    - { role: tomcat,             tags: ['tomcat'] }
-    - { role: java,              	tags: ['java'] }
-    - { role: shibboleth,  				tags: [shib] }
-    - { role: metadata-exporter, 	tags: ['metadata-exporter'] }
-    - { role: grouper,           	tags: ['grouper'] }
-    - { role: pdp, 								tags: [pdp] }
-    - { role: teams, 							tags: [teams] }
-    - { role: mujina-idp, 				tags: [mujina-idp] }
-    - { role: mujina-sp, 					tags: [mujina-idp] }
-    - { role: authz-server,      	tags: ['oauth', 'authz-server'    ] }
-    - { role: authz-admin,       	tags: ['oauth', 'authz-admin'     ] }
-    - { role: authz-playground,  	tags: ['oauth', 'authz-playground'] }
-    - { role: pdp,               	tags: ['pdp'] }
-    - { role: voot,              	tags: ['oauth', 'voot'            ] }
-    - { role: aa,               	tags: ['aa' ] }
-
+    - { role: tomcat,            tags: ['tomcat'] }
+    - { role: java,              tags: ['java'] }
+    - { role: shibboleth,        tags: ['shib'   ] }
+    - { role: metadata-exporter, tags: ['metadata-exporter'] }
+    - { role: grouper,           tags: ['grouper'] }
+    - { role: teams,             tags: ['teams'  ] }
+    - { role: mujina-idp,        tags: ['legacy' ] }
+    - { role: mujina-sp,         tags: ['legacy' ] }
+    - { role: authz-server,      tags: ['oauth', 'authz-server'    ] }
+    - { role: authz-admin,       tags: ['oauth', 'authz-admin'     ] }
+    - { role: voot,              tags: ['oauth', 'voot'            ] }
+    - { role: authz-playground,  tags: ['oauth', 'authz-playground'] }
+    - { role: pdp,               tags: ['pdp'] }
+    - { role: oidc,              tags: ['oidc'] }
+    - { role: vm_only_oidc,      tags: ['oidc'] }
+    - { role: aa,                tags: ['aa'] }
   handlers:
     - include: roles/httpd/handlers/main.yml

--- a/provision-docker.yml
+++ b/provision-docker.yml
@@ -5,7 +5,7 @@
     - name: Read vars from secrets file
       include_vars: "{{ secrets_file }}"
       tags: always
-      always_run: yes
+      check_mode: no
 
 - hosts: all
   gather_facts: yes

--- a/provision-vm.yml
+++ b/provision-vm.yml
@@ -5,7 +5,7 @@
     - name: Read vars from secrets file
       include_vars: "{{ secrets_file }}"
       tags: always
-      always_run: yes
+      check_mode: no
 
 - hosts: all
   gather_facts: yes

--- a/provision-vm.yml
+++ b/provision-vm.yml
@@ -2,20 +2,29 @@
 - hosts: all
   gather_facts: no
   tasks:
-  - name: Read vars from secrets file
-    include_vars: "{{ secrets_file }}"
-    tags:
-      - always
+    - name: Read vars from secrets file
+      include_vars: "{{ secrets_file }}"
+      tags: always
+      always_run: yes
 
-- hosts: loadbalancer:php-apps:java-apps:storage
+- hosts: all
   gather_facts: yes
   become: true
   roles:
-    - { role: common, tags: ['common'] }
-    - { role: hosts,  tags: ['hosts'] }
-    - { role: tls, tags: ['tls'] }
+    - { role: common,  tags: ['common'] }
+    - { role: tls,     tags: ['tls'] }
+    - { role: hosts,   tags: ['hosts'] }
+    - { role: rsyslog, tags: ['rsyslog'] }
   handlers:
     - include: roles/httpd/handlers/main.yml
+
+- hosts: storage
+  gather_facts: yes
+  become: true
+  roles:
+    - { role: mysql,                   tags: ['mysql'] }
+    - { role: ldap,                    tags: ['ldap'] }
+    - { role: vm_only_provision_eb_sr, tags: ['vm_only_provision_eb_sr'] }
 
 - hosts: loadbalancer
   gather_facts: true
@@ -31,28 +40,20 @@
   handlers:
     - include: roles/httpd/handlers/main.yml
 
-- hosts: storage
-  gather_facts: no
-  become: true
-  roles:
-    - { role: mysql, tags: ['mysql'] }
-    - { role: ldap,  tags: ['ldap' ] }
-    - { role: vm_only_provision_eb_sr, tags: ['vm_only_provision_eb_sr'] }
-
 - hosts: php-apps
   gather_facts: no
   become: true
   vars:
     env_lang: php
   roles:
-    - { role: php56fpm,          tags: ['php56fpm'] }
-    - { role: static,            tags: ['static'] }
-    - { role: welcome,           tags: ['welcome'] }
-    - { role: openconext-common, tags: ['eb','sr','profile'] }
-    - { role: engineblock,      tags: ['eb'     ] }
-    - { role: janus,             tags: ['sr'     ] }
-    - { role: vm_only_bootstrap_ldap_attributes,       tags: ['ldap'     ] }
-    - { role: profile,           tags: ['profile'] }
+    - { role: php56fpm,                          tags: ['php56fpm'] }
+    - { role: static,                            tags: ['static'] }
+    - { role: welcome,                           tags: ['welcome'] }
+    - { role: openconext-common,                 tags: ['eb','sr','profile'] }
+    - { role: engineblock,                       tags: ['eb'     ] }
+    - { role: janus,                             tags: ['sr'     ] }
+    - { role: vm_only_bootstrap_ldap_attributes, tags: ['ldap'     ] }
+    - { role: profile,                           tags: ['profile'] }
   handlers:
     - include: roles/httpd/handlers/main.yml
 
@@ -67,7 +68,6 @@
     - { role: shibboleth,        tags: ['shib'   ] }
     - { role: metadata-exporter, tags: ['metadata-exporter'] }
     - { role: grouper,           tags: ['grouper'] }
-    - { role: oidc,              tags: ['oidc'] }
     - { role: teams,             tags: ['teams'  ] }
     - { role: mujina-idp,        tags: ['legacy' ] }
     - { role: mujina-sp,         tags: ['legacy' ] }
@@ -76,14 +76,8 @@
     - { role: voot,              tags: ['oauth', 'voot'            ] }
     - { role: authz-playground,  tags: ['oauth', 'authz-playground'] }
     - { role: pdp,               tags: ['pdp'] }
+    - { role: oidc,              tags: ['oidc'] }
+    - { role: vm_only_oidc,      tags: ['oidc'] }
     - { role: aa,                tags: ['aa'] }
   handlers:
     - include: roles/httpd/handlers/main.yml
-
-- hosts: java-apps
-  gather_facts: true
-  become: true
-  vars:
-    env_lang: java
-  roles:
-    - { role: vm_only_oidc,      tags: ['oidc'] }

--- a/roles/vm_only_oidc/tasks/main.yml
+++ b/roles/vm_only_oidc/tasks/main.yml
@@ -1,8 +1,13 @@
 ---
 - name: copy default oidc client vm
   copy: src=defaults.vm.sql dest=/tmp
-  when: env == 'vm'
+
+- name: check if oidc database is present
+  mysql_db: name=oidc-server state=present
+  register: oidc_db_present
+
+- debug: var=oidc_db_present
 
 - name: insert default oidc client vm
   mysql_db: name=oidc-server state=import target=/tmp/defaults.vm.sql
-  when: env == 'vm'
+  when: oidc_db_present.changed


### PR DESCRIPTION
Provision-vm,yml and provision-docker.yml are almost identical; this change makes this obvious.

As a consequence, we are now deploying oidc in docker/travis.  This required a minor change to the vm_only_oidc task to make it reentrant and safe to run twice.