### PR TITLE
Modify EngineBlock PDP client base URL for new PDP client

### DIFF
--- a/roles/engineblock/defaults/main.yml
+++ b/roles/engineblock/defaults/main.yml
@@ -41,7 +41,7 @@ engine_debug: false
 engine_vovalidate_baseurl : https://api.{{ base_domain }}
 
 ## PDP endpoint
-engine_pdp_baseurl: https://pdp.{{ base_domain }}/pdp/api/decide/policy
+engine_pdp_baseurl: https://pdp.{{ base_domain }}/pdp/api
 
 ## Attribute Aggregation endpoint
 engine_attribute_aggregation_baseurl: "https://aa.{{ base_domain }}/aa/api/attribute/aggregate"


### PR DESCRIPTION
The modifies the base URI to be used by the new Guzzle 6-based PDP client.

See: OpenConext/OpenConext-engineblock#377