### PR TITLE
PDP host and path configuation for EB 5.2

### DIFF
--- a/roles/engineblock/defaults/main.yml
+++ b/roles/engineblock/defaults/main.yml
@@ -41,7 +41,8 @@ engine_debug: false
 engine_vovalidate_baseurl : https://api.{{ base_domain }}
 
 ## PDP endpoint
-engine_pdp_baseurl: https://pdp.{{ base_domain }}/pdp/api/decide/policy
+engine_pdp_baseurl: https://pdp.{{ base_domain }}
+engine_pdp_path: /pdp/api/decide/policy
 
 ## Attribute Aggregation endpoint
 engine_attribute_aggregation_baseurl: "https://aa.{{ base_domain }}/aa/api/attribute/aggregate"

--- a/roles/engineblock/templates/engineblock.ini.j2
+++ b/roles/engineblock/templates/engineblock.ini.j2
@@ -48,7 +48,9 @@ voot.clientId=engineblock
 voot.clientSecret={{ engineblock_authz_client_secret }}
 voot.scopes = groups
 
-pdp.baseUrl = {{ engine_pdp_baseurl }}
+pdp.baseUrl = {{ engine_pdp_baseurl }}{{ engine_pdp_path }}
+pdp.host = {{ engine_pdp_baseurl }}
+pdp.policy_decision_point_path = {{ engine_pdp_path }}
 pdp.username = {{ pdp.username }}
 pdp.password = {{ pdp.password }}
 


### PR DESCRIPTION
Allows the configuration of the PDP host and path for engineblock 5.2 in a backwards compatible way