### PR TITLE
Move Travis build instructions into a proper shell script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - sudo docker build --rm -t surfnet/centos7-openconext -f tests/Dockerfile.centos-7 .
 
 script:
-  - sudo /bin/bash -x ./tests/travis-build.sh
+  - sudo /bin/bash ./tests/travis-build.sh
 
 after_failure:
   - sudo docker exec -t ansible-test yum install -y net-tools

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,58 +7,7 @@ before_install:
   - sudo docker build --rm -t surfnet/centos7-openconext -f tests/Dockerfile.centos-7 .
 
 script:
-  - >
-    sudo docker run --detach
-    -v "${PWD}":/ansible:rw
-    -v /sys/fs/cgroup:/sys/fs/cgroup:ro --privileged
-    --add-host static.vm.openconext.org:127.0.0.1
-    --add-host serviceregistry.vm.openconext.org:127.0.0.1
-    --add-host engine.vm.openconext.org:127.0.0.1
-    --add-host profile.vm.openconext.org:127.0.0.1
-    --add-host mujina-sp.vm.openconext.org:127.0.0.1
-    --add-host mujina-idp.vm.openconext.org:127.0.0.1
-    --add-host grouper.vm.openconext.org:127.0.0.1
-    --add-host teams.vm.openconext.org:127.0.0.1
-    --add-host authz.vm.openconext.org:127.0.0.1
-    --add-host authz-admin.vm.openconext.org:127.0.0.1
-    --add-host authz-playground.vm.openconext.org:127.0.0.1
-    --add-host voot.vm.openconext.org:127.0.0.1
-    --add-host lb.vm.openconext.org:127.0.0.1
-    --add-host apps.vm.openconext.org:127.0.0.1
-    --add-host ldap.vm.openconext.org:127.0.0.1
-    --add-host db.vm.openconext.org:127.0.0.1
-    --add-host pdp.vm.openconext.org:127.0.0.1
-    --add-host engine-api.vm.openconext.org:127.0.0.1
-    --add-host aa.vm.openconext.org:127.0.0.1
-    --add-host multidata.vm.openconext.org:127.0.0.1
-    --add-host oidc.vm.openconext.org:127.0.0.1
-    --hostname test.openconext.org
-    --name ansible-test surfnet/centos7-openconext
-  - sudo docker exec -t ansible-test sh -c 'echo -e "[defaults]\ncallback_plugins=/ansible/callback_plugins\ncallback_whitelist=profile_tasks\n[ssh_connection]\nssh_args=-o ControlMaster=auto -o ControlPersist=60m\npipelining=True" > /ansible/ansible.cfg '
-  - >
-    sudo docker exec -t ansible-test
-    env TERM=xterm ANSIBLE_CONFIG=/ansible/ansible.cfg
-    ansible-playbook -i /ansible/environments/docker/inventory /ansible/provision-docker.yml -e secrets_file=/ansible/environments/vm/secrets/vm.yml --syntax-check
-  - >
-    sudo docker exec -t ansible-test
-    env TERM=xterm ANSIBLE_CONFIG=/ansible/ansible.cfg
-    ansible-playbook -i /ansible/environments/docker/inventory /ansible/provision-docker.yml -e secrets_file=/ansible/environments/vm/secrets/vm.yml
-  - >
-    echo "=================================================================";
-    echo "=================================================================";
-    echo "== STARTING IDEMPOTENCY TEST ====================================";
-    echo "=================================================================";
-    echo "================================================================="
-  - >
-    TMPOUT=$(tempfile) &&
-    sudo docker exec -t ansible-test
-    env TERM=xterm ANSIBLE_CONFIG=/ansible/ansible.cfg
-    ansible-playbook -i /ansible/environments/docker/inventory /ansible/provision-docker.yml -e secrets_file=/ansible/environments/vm/secrets/vm.yml | tee $TMPOUT
-    &&
-    grep -q 'changed=0.*failed=0' $TMPOUT && (echo 'Idempotence test: pass' && exit 0) || (echo 'Idempotence test: fail' && exit 1)
-  - >
-    sudo docker exec -t ansible-test env TERM=xterm
-    ansible-playbook -i /ansible/environments/docker/inventory /ansible/tests/all_services_are_up.yml
+  - sudo /bin/bash ./tests/travis-build.sh
 
 after_failure:
   - sudo docker exec -t ansible-test yum install -y net-tools

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 sudo: required
 
+language:
+  - bash
+
 services:
   - docker
 
@@ -7,7 +10,7 @@ before_install:
   - sudo docker build --rm -t surfnet/centos7-openconext -f tests/Dockerfile.centos-7 .
 
 script:
-  - sudo /bin/bash ./tests/travis-build.sh
+  - sudo /bin/bash -x ./tests/travis-build.sh
 
 after_failure:
   - sudo docker exec -t ansible-test yum install -y net-tools

--- a/tests/travis-build.sh
+++ b/tests/travis-build.sh
@@ -97,7 +97,7 @@ docker exec -t ansible-test                                      \
 	ansible-playbook                                             \
 		-i $ANSIBLE_INVENTORY                                    \
 		-e secrets_file=$ANSIBLE_SECRETS                         \
-		$ANSIBLE_PLAYBOOK
+		$ANSIBLE_PLAYBOOK                                        \
  | tee $TMPOUT
 
 echo
@@ -117,6 +117,6 @@ echo
 docker exec -t ansible-test                                      \
 	ansible-playbook                                             \
 		-i $ANSIBLE_INVENTORY                                    \
-		/ansible/tests/all_services_are_up.yml                   \
+		/ansible/tests/all_services_are_up.yml
 
 exit $status

--- a/tests/travis-build.sh
+++ b/tests/travis-build.sh
@@ -6,7 +6,7 @@ set -e
 status=0
 
 ANSIBLE_CONFIG=/ansible/ansible.cfg
-ANSIBLE_PLAYBOOK=/ansible/provision-vm.yml
+ANSIBLE_PLAYBOOK=/ansible/provision-docker.yml
 ANSIBLE_INVENTORY=/ansible/environments/docker/inventory
 ANSIBLE_SECRETS=/ansible/environments/vm/secrets/vm.yml
 

--- a/tests/travis-build.sh
+++ b/tests/travis-build.sh
@@ -5,7 +5,11 @@ set -e
 # keep exit status
 status=0
 
-export ANSIBLE_CONFIG=/ansible/ansible.cfg
+ANSIBLE_CONFIG=/ansible/ansible.cfg
+ANSIBLE_PLAYBOOK=/ansible/provision-vm.yml
+ANSIBLE_INVENTORY=/ansible/environments/docker/inventory
+ANSIBLE_SECRETS=/ansible/environments/vm/secrets/vm.yml
+
 
 # start docker container
 docker run --detach                                         \
@@ -61,9 +65,9 @@ echo
 
 docker exec -t ansible-test                                      \
 	ansible-playbook                                             \
-		-i /ansible/environments/docker/inventory                \
-		-e secrets_file=/ansible/environments/vm/secrets/vm.yml  \
-		/ansible/provision-docker.yml                            \
+		-i $ANSIBLE_INVENTORY                                    \
+		-e secrets_file=$ANSIBLE_SECRETS                         \
+		$ANSIBLE_PLAYBOOK                                        \
 		--syntax-check
 
 echo
@@ -76,9 +80,9 @@ echo
 
 docker exec -t ansible-test                                      \
 	ansible-playbook                                             \
-		-i /ansible/environments/docker/inventory                \
-		-e secrets_file=/ansible/environments/vm/secrets/vm.yml  \
-		/ansible/provision-docker.yml 
+		-i $ANSIBLE_INVENTORY                                    \
+		-e secrets_file=$ANSIBLE_SECRETS                         \
+		$ANSIBLE_PLAYBOOK
 
 echo
 echo "================================================================="
@@ -91,9 +95,9 @@ echo
 TMPOUT=$(tempfile)
 docker exec -t ansible-test                                      \
 	ansible-playbook                                             \
-		-i /ansible/environments/docker/inventory                \
-		-e secrets_file=/ansible/environments/vm/secrets/vm.yml  \
-		/ansible/provision-docker.yml                            \
+		-i $ANSIBLE_INVENTORY                                    \
+		-e secrets_file=$ANSIBLE_SECRETS                         \
+		$ANSIBLE_PLAYBOOK
  | tee $TMPOUT
 
 echo
@@ -112,7 +116,7 @@ echo
 
 docker exec -t ansible-test                                      \
 	ansible-playbook                                             \
-		-i /ansible/environments/docker/inventory                \
+		-i $ANSIBLE_INVENTORY                                    \
 		/ansible/tests/all_services_are_up.yml                   \
 
 exit $status

--- a/tests/travis-build.sh
+++ b/tests/travis-build.sh
@@ -5,6 +5,8 @@ set -e
 # keep exit status
 status=0
 
+export ANSIBLE_CONFIG=/ansible/ansible.cfg
+
 # start docker container
 docker run --detach                                         \
 	-v "${PWD}":/ansible:rw                                 \
@@ -34,7 +36,7 @@ docker run --detach                                         \
 	--add-host oidc.vm.openconext.org:127.0.0.1             \
 	--hostname test.openconext.org                          \
 	-e TERM=xterm                                           \
-	-e ANSIBLE_CONFIG=/ansible/ansible.cfg                  \
+	-e ANSIBLE_CONFIG=${ANSIBLE_CONFIG}                     \
 	surfnet/centos7-openconext
 
 # initialize ansible.cfg
@@ -46,7 +48,6 @@ cat <<-'EOF' > /tmp/ansible.cfg
 	ssh_args=-o ControlMaster=auto -o ControlPersist=60m
 	pipelining=True
 EOF
-cat /tmp/ansible.cfg
 # and copy it into the container
 docker cp /tmp/ansible.cfg ansible-test:${ANSIBLE_CONFIG}
 

--- a/tests/travis-build.sh
+++ b/tests/travis-build.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+
+set -e
+
+# keep exit status
+status=0
+
+# start docker container
+docker run --detach                                         \
+	-v "${PWD}":/ansible:rw                                 \
+	-v /sys/fs/cgroup:/sys/fs/cgroup:ro                     \
+	--privileged                                            \
+	--name ansible-test                                     \
+	--add-host static.vm.openconext.org:127.0.0.1           \
+	--add-host serviceregistry.vm.openconext.org:127.0.0.1  \
+	--add-host engine.vm.openconext.org:127.0.0.1           \
+	--add-host profile.vm.openconext.org:127.0.0.1          \
+	--add-host mujina-sp.vm.openconext.org:127.0.0.1        \
+	--add-host mujina-idp.vm.openconext.org:127.0.0.1       \
+	--add-host grouper.vm.openconext.org:127.0.0.1          \
+	--add-host teams.vm.openconext.org:127.0.0.1            \
+	--add-host authz.vm.openconext.org:127.0.0.1            \
+	--add-host authz-admin.vm.openconext.org:127.0.0.1      \
+	--add-host authz-playground.vm.openconext.org:127.0.0.1 \
+	--add-host voot.vm.openconext.org:127.0.0.1             \
+	--add-host lb.vm.openconext.org:127.0.0.1               \
+	--add-host apps.vm.openconext.org:127.0.0.1             \
+	--add-host ldap.vm.openconext.org:127.0.0.1             \
+	--add-host db.vm.openconext.org:127.0.0.1               \
+	--add-host pdp.vm.openconext.org:127.0.0.1              \
+	--add-host engine-api.vm.openconext.org:127.0.0.1       \
+	--add-host aa.vm.openconext.org:127.0.0.1               \
+	--add-host multidata.vm.openconext.org:127.0.0.1        \
+	--add-host oidc.vm.openconext.org:127.0.0.1             \
+	--hostname test.openconext.org                          \
+	-e TERM=xterm                                           \
+	-e ANSIBLE_CONFIG=/ansible/ansible.cfg                  \
+	surfnet/centos7-openconext
+
+# initialize ansible.cfg
+cat > /tmp/ansible.cfg <<-EOF
+	[defaults]
+	callback_plugins=/ansible/callback_plugins
+	callback_whitelist=profile_tasks
+	[ssh_connection]
+	ssh_args=-o ControlMaster=auto -o ControlPersist=60m
+	pipelining=True
+EOF
+# and copy it into the container
+docker cp /tmp/ansible.cfg ansible-test:${ANSIBLE_CONFIG}
+
+echo
+echo "================================================================="
+echo "================================================================="
+echo "== STARTING SYNTAX CHECK ========================================"
+echo "================================================================="
+echo "================================================================="
+echo
+
+docker exec -t ansible-test                                      \
+	ansible-playbook                                             \
+		-i /ansible/environments/docker/inventory                \
+		-e secrets_file=/ansible/environments/vm/secrets/vm.yml  \
+		/ansible/provision-docker.yml                            \
+		--syntax-check
+
+echo
+echo "================================================================="
+echo "================================================================="
+echo "== STARTING MAIN PLAYBOOK RUN ==================================="
+echo "================================================================="
+echo "================================================================="
+echo
+
+docker exec -t ansible-test                                      \
+	ansible-playbook                                             \
+		-i /ansible/environments/docker/inventory                \
+		-e secrets_file=/ansible/environments/vm/secrets/vm.yml  \
+		/ansible/provision-docker.yml 
+
+echo
+echo "================================================================="
+echo "================================================================="
+echo "== STARTING IDEMPOTENCY TEST ===================================="
+echo "================================================================="
+echo "================================================================="
+echo
+
+TMPOUT=$(tempfile)
+docker exec -t ansible-test                                      \
+	ansible-playbook                                             \
+		-i /ansible/environments/docker/inventory                \
+		-e secrets_file=/ansible/environments/vm/secrets/vm.yml  \
+		/ansible/provision-docker.yml                            \
+ | tee $TMPOUT
+
+echo
+echo "================================================================="
+echo "================================================================="
+if grep -q 'changed=0.*failed=0' $TMPOUT
+then
+	echo "== IDEMPOTENCY CHECK: PASS ======================================"
+else
+	echo "== IDEMPOTENCY CHECK: FAILED! ==================================="
+	status=1
+fi
+echo "================================================================="
+echo "================================================================="
+echo
+
+docker exec -t ansible-test                                      \
+	ansible-playbook                                             \
+		-i /ansible/environments/docker/inventory                \
+		/ansible/tests/all_services_are_up.yml                   \
+
+exit $status

--- a/tests/travis-build.sh
+++ b/tests/travis-build.sh
@@ -38,7 +38,7 @@ docker run --detach                                         \
 	surfnet/centos7-openconext
 
 # initialize ansible.cfg
-cat > /tmp/ansible.cfg <<-EOF
+cat <<-'EOF' > /tmp/ansible.cfg
 	[defaults]
 	callback_plugins=/ansible/callback_plugins
 	callback_whitelist=profile_tasks
@@ -46,6 +46,7 @@ cat > /tmp/ansible.cfg <<-EOF
 	ssh_args=-o ControlMaster=auto -o ControlPersist=60m
 	pipelining=True
 EOF
+cat /tmp/ansible.cfg
 # and copy it into the container
 docker cp /tmp/ansible.cfg ansible-test:${ANSIBLE_CONFIG}
 


### PR DESCRIPTION
The current travis build commands (in ``.travis.yml``) are quite hard to read, edit and debug.  This PR moves all of the build stuff into a proper shell script, which is called from ``.travis.yml``.  This simplifies the build process quite a lot, because we are no longer dependent on unreadable shell oneliners wrapped in  yaml.