### PR TITLE
Allowing specifying metadata-exporter refresh interval

### DIFF
--- a/roles/metadata-exporter/defaults/main.yml
+++ b/roles/metadata-exporter/defaults/main.yml
@@ -4,3 +4,4 @@ metadata_exporter_version: ''
 metadata_exporter_snapshot_timestamp: ''
 metadata_exporter_local_jar: ''
 metadata_exporter_jar: metadata-exporter-current.jar
+metadata_exporter_refresh_minutes: 15

--- a/roles/metadata-exporter/templates/application.properties.j2
+++ b/roles/metadata-exporter/templates/application.properties.j2
@@ -17,7 +17,7 @@ spring.datasource.testWhileIdle=true
 
 flyway.enabled=false
 
-metadata.refresh.minutes=15
+metadata.refresh.minutes={{ metadata_exporter_refresh_minutes }}
 
 client.username=metadata.client
 client.password={{ metadata_exporter_password }}


### PR DESCRIPTION
For our dev environment we've wanted to have a bit quicker updating of the metadata export and so I made it a configurable variable -- defaulting to the original value of 15 minutes. 

Hope it's useful for others.