### PR TITLE
Adding configurable StemName for Teams

### DIFF
--- a/roles/teams/defaults/main.yml
+++ b/roles/teams/defaults/main.yml
@@ -7,3 +7,4 @@ teams_jar: teams-current.war
 teams_random_source: 'file:///dev/urandom'
 teams_provision_users: false
 teams_cronjobmaster: true
+teams_stemname: 'nl:surfnet:diensten'

--- a/roles/teams/templates/application.properties.j2
+++ b/roles/teams/templates/application.properties.j2
@@ -38,7 +38,7 @@ datasource.groupzy.validation-query=SELECT 1
 datasource.groupzy.testWhileIdle=true
 
 #the stem name to find all groups
-defaultStemName=nl:surfnet:diensten
+defaultStemName={{ teams_stemname }}
 
 # App id displayed in the updates / invites section of the portal
 appId={{ instance_name }} Teams


### PR DESCRIPTION
As per the https://github.com/OpenConext/OpenConext-deploy/issues/134  issue, here's the patch to make Teams' StemName configurable by Ansible.

Note: I never added the variable to the group_vars environment template.