### PR TITLE
Fix for teams-server where artifact group_id was set incorrectly

### DIFF
--- a/roles/teams-server/vars/main.yml
+++ b/roles/teams-server/vars/main.yml
@@ -1,6 +1,6 @@
 springapp_artifact_id: teams-server
 springapp_artifact_type: jar
-springapp_artifact_group_dir: /org/openconext
+springapp_artifact_group_dir: org.openconext
 springapp_version: "{{ teams_server_version }}"
 springapp_snapshot_timestamp: "{{ teams_server_snapshot_timestamp }}"
 springapp_dir: "{{ teams_dir }}"


### PR DESCRIPTION
It appears in the teams-gui role, the artifact group id is set to `org.openconext` as seen here: https://github.com/OpenConext/OpenConext-deploy/blob/79b7c4859780f7344c7088c1635cd5435dad5052/roles/teams-gui/tasks/main.yml#L12 

While in the teams-server role, this is set to `/org/openconext`, which is setting `group_id` for `maven_artifact` here: https://github.com/OpenConext/OpenConext-deploy/blob/c53dc47d60b40dbe87a7010a79d8172ad837afaf/tasks/springbootapp/install-maven-release.yml#L3

This is causing the following error for us when trying to deploy teams-ng:
```
TASK [teams-server : download maven-artifact] *******************************************************************************
fatal: [app-0]: FAILED! => {"changed": false, "failed": true, "msg": "unknown url type: /org/openconext/team
s-server/7.0.0-SNAPSHOT/teams-server-7.0.0-20170603.072006-26.jar"}
```

Switching to `org.openconext` seems to resolve the issue.