### PR TITLE
Rename option to skip engine db migrations.

### DIFF
--- a/roles/engineblock/tasks/install-release.yml
+++ b/roles/engineblock/tasks/install-release.yml
@@ -3,8 +3,6 @@
   stat: path={{ engine_current_release_symlink }} follow=no
   register: eb_dir
 
-- debug: var=eb_dir
-
 - name: Download current version
   get_url: url="{{ engine_download_url }}" dest="{{ engine_build_path }}"
   register: eb_download

--- a/roles/engineblock/tasks/main.yml
+++ b/roles/engineblock/tasks/main.yml
@@ -74,7 +74,7 @@
   register: migrate_output
   changed_when: "'no update needed' not in migrate_output.stderr"
   tags: enginemigrations
-  when: engine_db_migration is undefined
+  when: engine_skip_db_migration is undefined
 
 - name: Run EngineBlock Doctrine migrations
   command: "app/console doctrine:migrations:migrate -n --env={{ engine_apache_symfony_environment }}"
@@ -83,7 +83,7 @@
   register: doctrine_migrations_output
   changed_when: "'No migrations to execute' not in doctrine_migrations_output.stdout"
   tags: enginemigrations
-  when: engine_db_migration is undefined
+  when: engine_skip_db_migration is undefined
 
 - name: Make sure cache dir has correct permissions
   file: path={{engine_current_release_symlink}}/app/cache owner={{ engine_fpm_user }} group={{ engine_fpm_user }} recurse=yes


### PR DESCRIPTION
This should make it more evident what it does.