### PR TITLE
Adding timezone variable to engineblock.ini template

### DIFF
--- a/roles/engineblock/templates/engineblock.ini.j2
+++ b/roles/engineblock/templates/engineblock.ini.j2
@@ -71,6 +71,7 @@ metadataRepositories[{{ repository.index }}] = {{ repository.type }}
 {% endfor %}
 
 phpSettings.display_errors = {{ php_display_errors }}
+phpSettings.date.timezone = {{ timezone }}
 
 serviceRegistry.caching.lifetime = {{ engine_janus_cache_lifetime }}
 serviceRegistry.location = {{ engine_janus_url }}


### PR DESCRIPTION
It seems to be using default Europe/Amsterdam from the OpenConextengineblock/application/configs/application.ini file set here: https://github.com/OpenConext/OpenConext-engineblock/blob/master/application/configs/application.ini#L28

We're trying to log everything in UTC, so this fixes the time that appears in syslog from EngineBlock