### PR TITLE
Synced Vagrant dev vm group_vars with Docker

### DIFF
--- a/environments/vm/group_vars/vm.yml
+++ b/environments/vm/group_vars/vm.yml
@@ -22,7 +22,7 @@ authz_playground_version: 1.4
 pdp_version: 1.2.7
 attribute_aggregation_server_version: 2.0.0
 attribute_aggregation_gui_version: 2.0.0
-oidc_version: "1.0.6"
+oidc_version: "1.0.8"
 metadata_exporter_version: "2.0.3"
 engine_version: "5.4.0"
 janus_version: 1.23.1
@@ -364,6 +364,10 @@ aa:
   idin_secret: "{{ aa_idin_client_secret }}"
   oidc_client_id: "https@//aa.surfconext.test.nl"
   oidc_secret: "{{ aa_oidc_client_secret }}"
+  orcid_client_id: "APP-IP57TTCD5F8BAIGS"
+  orcid_secret: "{{ aa_orcid_password }}"
+  orcid_authorization_uri: "https://sandbox.orcid.org/oauth/authorize"
+  access_token_uri: "https://sandbox.orcid.org/oauth/token"
   spring_profiles_active: acc
   sab_username: coin-test
   sab_password: "{{ aa_sab_password }}"


### PR DESCRIPTION
While rebuilding my dev environment I ran into some provisioning issues.

A quick look in the logs showed an update to `oidc`. As a quick fix I copied these settings to the vagrant vm `group_vars`.

Can someone who knows the implications of this change review this PR?