### PR TITLE
Removing extra '/' that is being added by install-release.yml

### DIFF
--- a/roles/attribute-mapper/vars/main.yml
+++ b/roles/attribute-mapper/vars/main.yml
@@ -1,6 +1,6 @@
 springapp_artifact_id: attribute-mapper
 springapp_artifact_type: jar
-springapp_artifact_group_dir: /org/openconext
+springapp_artifact_group_dir: org/openconext
 springapp_version: "{{ attribute_mapper_version }}"
 springapp_snapshot_timestamp: "{{ attribute_mapper_snapshot_timestamp }}"
 springapp_dir: "{{ attribute_mapper_dir }}"

--- a/roles/authz-admin/vars/main.yml
+++ b/roles/authz-admin/vars/main.yml
@@ -1,6 +1,6 @@
 springapp_artifact_id: authz-admin
 springapp_artifact_type: jar
-springapp_artifact_group_dir: /org/openconext
+springapp_artifact_group_dir: org/openconext
 springapp_version: "{{ authz_admin_version }}"
 springapp_snapshot_timestamp: "{{ authz_admin_snapshot_timestamp }}"
 springapp_dir: "{{ authz_admin_dir }}"

--- a/roles/authz-playground/vars/main.yml
+++ b/roles/authz-playground/vars/main.yml
@@ -1,6 +1,6 @@
 springapp_artifact_id: authz-playground
 springapp_artifact_type: jar
-springapp_artifact_group_dir: /org/openconext
+springapp_artifact_group_dir: org/openconext
 springapp_version: "{{ authz_playground_version }}"
 springapp_snapshot_timestamp: "{{ authz_playground_snapshot_timestamp }}"
 springapp_dir: "{{ authz_playground_dir }}"

--- a/roles/authz-server/vars/main.yml
+++ b/roles/authz-server/vars/main.yml
@@ -1,6 +1,6 @@
 springapp_artifact_id: authz-server
 springapp_artifact_type: jar
-springapp_artifact_group_dir: /org/openconext
+springapp_artifact_group_dir: org/openconext
 springapp_version: "{{ authz_server_version }}"
 springapp_snapshot_timestamp: "{{ authz_server_snapshot_timestamp }}"
 springapp_dir: "{{ authz_server_dir }}"

--- a/roles/eduproxy/vars/main.yml
+++ b/roles/eduproxy/vars/main.yml
@@ -1,6 +1,6 @@
 springapp_artifact_id: eduproxy
 springapp_artifact_type: jar
-springapp_artifact_group_dir: /org/openconext
+springapp_artifact_group_dir: org/openconext
 springapp_version: "{{ eduproxy_version }}"
 springapp_snapshot_timestamp: "{{ eduproxy_snapshot_timestamp }}"
 springapp_dir: "{{ eduproxy_dir }}"

--- a/roles/metadata-exporter/vars/main.yml
+++ b/roles/metadata-exporter/vars/main.yml
@@ -1,6 +1,6 @@
 springapp_artifact_id: metadata-exporter
 springapp_artifact_type: jar
-springapp_artifact_group_dir: /org/openconext
+springapp_artifact_group_dir: org/openconext
 springapp_version: "{{ metadata_exporter_version }}"
 springapp_snapshot_timestamp: "{{ metadata_exporter_snapshot_timestamp }}"
 springapp_dir: "{{ metadata_exporter_dir }}"

--- a/roles/monitoring-tests/vars/main.yml
+++ b/roles/monitoring-tests/vars/main.yml
@@ -1,6 +1,6 @@
 springapp_artifact_id: monitoring-tests
 springapp_artifact_type: jar
-springapp_artifact_group_dir: /org/openconext
+springapp_artifact_group_dir: org/openconext
 springapp_version: "{{ monitoring_tests_version }}"
 springapp_snapshot_timestamp: "{{ monitoring_tests_snapshot_timestamp }}"
 springapp_dir: "{{ monitoring_tests_dir }}"

--- a/roles/mujina-idp/vars/main.yml
+++ b/roles/mujina-idp/vars/main.yml
@@ -1,6 +1,6 @@
 springapp_artifact_id: mujina-idp
 springapp_artifact_type: jar
-springapp_artifact_group_dir: /org/openconext
+springapp_artifact_group_dir: org/openconext
 springapp_version: "{{ mujina_version }}"
 springapp_snapshot_timestamp: "{{ mujina_idp_snapshot_timestamp }}"
 springapp_dir: "{{ mujina_idp_dir }}"

--- a/roles/mujina-sp/vars/main.yml
+++ b/roles/mujina-sp/vars/main.yml
@@ -1,6 +1,6 @@
 springapp_artifact_id: mujina-sp
 springapp_artifact_type: jar
-springapp_artifact_group_dir: /org/openconext
+springapp_artifact_group_dir: org/openconext
 springapp_version: "{{ mujina_version }}"
 springapp_snapshot_timestamp: "{{ mujina_sp_snapshot_timestamp }}"
 springapp_dir: "{{ mujina_sp_dir }}"

--- a/roles/pdp/defaults/main.yml
+++ b/roles/pdp/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 pdp_dir: /opt/pdp/
-pdp_group_url: org/openconext/
+pdp_group_url: org/openconext
 pdp_version: ''
 pdp_snapshot_timestamp: ''
 pdp_local_jar: ''

--- a/roles/pdp/vars/main.yml
+++ b/roles/pdp/vars/main.yml
@@ -1,6 +1,6 @@
 springapp_artifact_id: pdp-server
 springapp_artifact_type: jar
-springapp_artifact_group_dir: /org/openconext
+springapp_artifact_group_dir: org/openconext
 springapp_version: "{{ pdp_version }}"
 springapp_snapshot_timestamp: "{{ pdp_snapshot_timestamp }}"
 springapp_dir: "{{ pdp_dir }}"

--- a/roles/teams-legacy/vars/main.yml
+++ b/roles/teams-legacy/vars/main.yml
@@ -1,6 +1,6 @@
 springapp_artifact_id: coin-teams-war
 springapp_artifact_type: war
-springapp_artifact_group_dir: /org/surfnet/coin
+springapp_artifact_group_dir: org/surfnet/coin
 springapp_version: "{{ teams_version }}"
 springapp_snapshot_timestamp: "{{ teams_snapshot_timestamp }}"
 springapp_dir: "{{ teams_dir }}"

--- a/roles/voot/vars/main.yml
+++ b/roles/voot/vars/main.yml
@@ -1,6 +1,6 @@
 springapp_artifact_id: voot-service
 springapp_artifact_type: jar
-springapp_artifact_group_dir: /org/openconext
+springapp_artifact_group_dir: org/openconext
 springapp_version: "{{ voot_version }}"
 springapp_snapshot_timestamp: "{{ voot_snapshot_timestamp }}"
 springapp_dir: "{{ voot_dir }}"

--- a/tasks/springbootapp/install-snapshot.yml
+++ b/tasks/springbootapp/install-snapshot.yml
@@ -2,7 +2,7 @@
 
 - name: download snapshot
   get_url:
-    url: "{{ maven_snapshot_repo }}{{ springapp_artifact_group_dir }}/{{ springapp_artifact_id }}/{{ springapp_version }}-SNAPSHOT/{{ springapp_artifact_id }}-{{ springapp_version }}-{{ springapp_snapshot_timestamp }}.{{ springapp_artifact_type }}"
+    url: "{{ maven_snapshot_repo }}/{{ springapp_artifact_group_dir }}/{{ springapp_artifact_id }}/{{ springapp_version }}-SNAPSHOT/{{ springapp_artifact_id }}-{{ springapp_version }}-{{ springapp_snapshot_timestamp }}.{{ springapp_artifact_type }}"
     dest: "{{ springapp_dir }}/{{ springapp_artifact_id }}-{{ springapp_version }}-{{ springapp_snapshot_timestamp }}.{{ springapp_artifact_type }}"
     owner: "{{ springapp_user }}"
     group: "{{ springapp_user }}"


### PR DESCRIPTION
Hello,

When maven artifacts were being downloaded, using the `springbootapp/install-release.yml` method, an extra '/' is being added to the URL. This seems to pose an issue when the repository is being hosted by an object storage repo (such as OpenStack swift). The extra '/' isn't ignored and causes the task to fail due to invalid URL.

In the following install-release.yml file: 
https://github.com/OpenConext/OpenConext-deploy/blob/a993e41f2a226b72ad01ad14ea908ca69541c6ea/tasks/springbootapp/install-release.yml#L3

As part of the URL aggregation, a  '/' is already being added between `maven_repo` and `springapp_artifact_group_dir`. Having the '/' in the `springapp_artifact_group_dir` is causing the URL to turn into something like:
```https://build.openconext.org/repository/public/releases//org/openconext/pdp-gui/VER/pdp-gui-VER.zip```.  (note the '//' between releases and org).

In the `springbootapps/install-snapshot.yml` url line, the '/' didn't exist. Since this request removes the pre-pending slash from the variable, I added it into the intall-snapshot.yml so that it won't break.

Andrew