### PR TITLE
Adding ability to change the guestqualifier value in EngineBlock

### DIFF
--- a/environments/docker/group_vars/docker.yml
+++ b/environments/docker/group_vars/docker.yml
@@ -95,6 +95,8 @@ tls_star_cert_bundle_name: star.{{ base_domain }}_ca_bundle.pem
 tls_star_cert: star.{{ base_domain }}.pem
 tls_star_cert_key: star.{{ base_domain }}.key
 
+guest_qualifier: "urn:collab:org:{{ base_domain }}"
+
 apache_server_admin: unix@prolocation.net
 
 janus_ssp_technicalcontact_name: "Surfconext beheer"

--- a/environments/template/group_vars/template.yml
+++ b/environments/template/group_vars/template.yml
@@ -96,6 +96,7 @@ engine_database_password: "{{ mysql_passwords.eb }}"
 
 engine_apache_environment: test
 engine_apache_symfony_environment: prod
+engine_guestqualifier_value: "urn:collab:org:{{ base_domain }}"
 
 janus_database_name: sr
 janus_database_host: "{{ mysql_host }}"

--- a/environments/template/group_vars/template.yml
+++ b/environments/template/group_vars/template.yml
@@ -65,7 +65,7 @@ mongo:
   manage_user: managerw
   manage_password: "{{ mongo_passwords.manage }}" 
   manage_database: manage
-      
+
 tls:
   cert_path: /etc/pki/tls/certs
   cert_path_ca: /etc/pki/ca-trust/source/anchors/
@@ -86,6 +86,8 @@ tls_https:
     bundle_name: "star.{{ base_domain }}_ca_bundle.pem"
     key_content: "{{ https_star_private_key }}"
 
+guest_qualifier: "urn:collab:org:{{ base_domain }}"
+
 engine_janus_user: engineblock
 
 engine_database_name: eb
@@ -96,7 +98,6 @@ engine_database_password: "{{ mysql_passwords.eb }}"
 
 engine_apache_environment: test
 engine_apache_symfony_environment: prod
-engine_guestqualifier_value: "urn:collab:org:{{ base_domain }}"
 
 janus_database_name: sr
 janus_database_host: "{{ mysql_host }}"

--- a/environments/vm/group_vars/vm.yml
+++ b/environments/vm/group_vars/vm.yml
@@ -83,7 +83,7 @@ tls_https:
     key_content: "{{ https_star_private_key }}"
     crt_content: "{{ https_star_crt }}"
 
-
+guest_qualifier: "urn:collab:org:{{ base_domain }}"
 
 apache_server_admin: unix@prolocation.net
 

--- a/roles/engineblock/defaults/main.yml
+++ b/roles/engineblock/defaults/main.yml
@@ -81,4 +81,4 @@ engine_fpm_port: 801
 engine_crt_not_in_inventory: false
 
 # The value for guest qualifier. Can be overridden for specific non-surfnet environments
-engine_guestqualifier_value: "urn:collab:org:surf.nl"
+engine_guestqualifier_value: "urn:collab:org:openconext.org"

--- a/roles/engineblock/defaults/main.yml
+++ b/roles/engineblock/defaults/main.yml
@@ -79,3 +79,6 @@ engine_fpm_port: 801
 
 # When using vagrant for provisioning, it's not possible to put something in the inventory dir
 engine_crt_not_in_inventory: false
+
+# The value for guest qualifier. Can be overridden for specific non-surfnet environments
+engine_guestqualifier_value: "urn:collab:org:surf.nl"

--- a/roles/engineblock/defaults/main.yml
+++ b/roles/engineblock/defaults/main.yml
@@ -79,6 +79,3 @@ engine_fpm_port: 801
 
 # When using vagrant for provisioning, it's not possible to put something in the inventory dir
 engine_crt_not_in_inventory: false
-
-# The value for guest qualifier. Can be overridden for specific non-surfnet environments
-engine_guestqualifier_value: "urn:collab:org:openconext.org"

--- a/roles/engineblock/templates/engineblock.ini.j2
+++ b/roles/engineblock/templates/engineblock.ini.j2
@@ -88,7 +88,7 @@ trustedProxyIps[] = {{ engine_trusted_proxy_ip }}
 base_domain = {{ engine_base_domain }}
 
 ; the value for guest qualifier. Can be overridden for specific non-surfnet environments
-addgueststatus.guestqualifier = "{{ engine_guestqualifier_value }}"
+addgueststatus.guestqualifier = "{{ guest_qualifier }}"
 
 ; Minimum execution time in milliseconds when a received response is deemed invalid (default: 5000 ms)
 minimumExecutionTimeOnInvalidReceivedResponse = {{ engine_minimum_execution_time_on_invalid_received_response }}

--- a/roles/engineblock/templates/engineblock.ini.j2
+++ b/roles/engineblock/templates/engineblock.ini.j2
@@ -87,6 +87,9 @@ trustedProxyIps[] = {{ engine_trusted_proxy_ip }}
 
 base_domain = {{ engine_base_domain }}
 
+; the value for guest qualifier. Can be overridden for specific non-surfnet environments
+addgueststatus.guestqualifier = "{{ engine_guestqualifier_value }}"
+
 ; Minimum execution time in milliseconds when a received response is deemed invalid (default: 5000 ms)
 minimumExecutionTimeOnInvalidReceivedResponse = {{ engine_minimum_execution_time_on_invalid_received_response }}
 

--- a/roles/teams-server/templates/application.yml.j2
+++ b/roles/teams-server/templates/application.yml.j2
@@ -42,7 +42,7 @@ teams:
   default-stem-name: "{{ teams.default_stem_name }}"
   group-name-context: "{{ teams.group_name_context }}"
   product-name: "{{ teams.product_name }}"
-  non-guest-member-of: "urn:collab:org:surf.nl"
+  non-guest-member-of: "{{ guest_qualifier }}"
 voot:
   serviceUrl: https://voot.{{ base_domain }}
   accessTokenUri: https://authz.{{ base_domain }}/oauth/token


### PR DESCRIPTION
Setting `coin:guest_qualifier = None` in Janus appends `urn:collab:org:surf.nl` to the user's list of attributes. This pull request adds an option to the EngineBlock.ini template to override this value using the variables in Ansible.

Note: this doesn't add the value to the `template/group_vars/template.yml` file since I wasn't sure of the best way for the template. I'm assuming:
```
engine_guestqualifier_value: "urn:collab:org:{{ base_domain }}"
```
would be good. Let me know if so and I can add that to the pull request.

Thanks,
Andrew