### PR TITLE
Mongo: lineinfile ansible version issue

### DIFF
--- a/roles/mongo/tasks/main.yml
+++ b/roles/mongo/tasks/main.yml
@@ -27,7 +27,7 @@
   when: mongo_kernel_settings.changed
 
 - name: Add mongo kernel settings script to rc.local
-  lineinfile: path=/etc/rc.local state=present line='/usr/local/sbin/mongo_kernel_settings.sh'
+  lineinfile: dest=/etc/rc.local state=present line='/usr/local/sbin/mongo_kernel_settings.sh'
 
 - name: Make rc.local executable
   file: dest=/etc/rc.d/rc.local mode=0744


### PR DESCRIPTION
The commit below fixes failing provisioning of the Mongo task. 

I'm using an older version of Ansible (2.2.1.0) Should I upgrade to a newer version of ansible or is this proposed changed an approved solution?

The Ansible [docs](http://docs.ansible.com/ansible/latest/lineinfile_module.html)
