### PR TITLE
Fixing Typo for Apache OIDC  ErrorLog

### DIFF
--- a/roles/oidc/templates/oidc.conf.j2
+++ b/roles/oidc/templates/oidc.conf.j2
@@ -8,7 +8,7 @@ Listen {{ apache_app_listen_address.oidc }}:{{ loadbalancing.oidc.port }}
     # General setup for the virtual host, inherited from global configuration
     ServerName https://oidc.{{ base_domain }}
 
-    ErrorLog "|/usr/bin/logger -p local3.err  -t 'Apache-oicd'"
+    ErrorLog "|/usr/bin/logger -p local3.err  -t 'Apache-oidc'"
     CustomLog "|/usr/bin/logger -p local3.info  -t 'Apache-oidc'" combined
 
     # Proxy requests through to Tomcat using AJP


### PR DESCRIPTION
Small typo correction for the OIDC ErrorLog syslog logger