### PR TITLE
Keepalived changes

### DIFF
--- a/roles/keepalived/templates/keepalived_dbcluster.conf.j2
+++ b/roles/keepalived/templates/keepalived_dbcluster.conf.j2
@@ -1,6 +1,8 @@
 vrrp_script chk_cluster {
         script "/usr/local/bin/clustercheck clustercheck {{ galera_clustercheck_password }} 0"
-        interval 1
+        interval 5
+	fall 3
+	rise 1
 }
 
 vrrp_instance galera {


### PR DESCRIPTION
Change the galera check interval from 1 to 5 seconds, and change the keeplived state when 3 consecutive checks have failed. This prevents false positives during small network hickups, or temporary database connection issues, eg during backing windows.