### PR TITLE
Add checks to prevent undefined variable errors

### DIFF
--- a/roles/attribute-aggregation-gui/templates/attribute_aggregation.conf.j2
+++ b/roles/attribute-aggregation-gui/templates/attribute_aggregation.conf.j2
@@ -1,4 +1,4 @@
-{% if apache_app_listen_address.aa is defined %}
+{% if apache_app_listen_address is defined and apache_app_listen_address.aa is defined %}
 Listen {{ apache_app_listen_address.aa }}:{{ loadbalancing.aa.port }}
 <Virtualhost {{ apache_app_listen_address.aa }}:{{ loadbalancing.aa.port }}>
 {% else %}
@@ -70,7 +70,7 @@ Listen {{ apache_app_listen_address.aa }}:{{ loadbalancing.aa.port }}
     Include ssl_backend.conf
     {% endif %}
 
-    {% if apache_app_listen_address.all is defined %}
+    {% if apache_app_listen_address is defined and apache_app_listen_address.all is defined %}
     SSLEngine on
     SSLCertificateFile      {{ tls.cert_path }}/{{ tls_star_cert }}
     SSLCertificateKeyFile   {{ tls.cert_private_path }}/{{ tls_star_cert_key }}
@@ -79,7 +79,7 @@ Listen {{ apache_app_listen_address.aa }}:{{ loadbalancing.aa.port }}
     {% endif %}
 </VirtualHost>
 
-{% if apache_app_listen_address.aa is defined %}
+{% if apache_app_listen_address is defined and apache_app_listen_address.aa is defined %}
 <Virtualhost {{ apache_app_listen_address.aa }}:{{ loadbalancing.aa.port }}>
 {% else %}
 <Virtualhost *:443 >
@@ -138,7 +138,7 @@ Listen {{ apache_app_listen_address.aa }}:{{ loadbalancing.aa.port }}
     Include ssl_backend.conf
     {% endif %}
 
-    {% if apache_app_listen_address.all is defined %}
+    {% if apache_app_listen_address is defined and apache_app_listen_address.all is defined %}
     SSLEngine on
     SSLCertificateFile      {{ tls.cert_path }}/{{ tls_star_cert }}
     SSLCertificateKeyFile   {{ tls.cert_private_path }}/{{ tls_star_cert_key }}

--- a/roles/authz-admin/templates/authz_admin.conf.j2
+++ b/roles/authz-admin/templates/authz_admin.conf.j2
@@ -1,4 +1,4 @@
-{% if apache_app_listen_address.authz_admin is defined %}
+{% if apache_app_listen_address is defined and apache_app_listen_address.authz_admin is defined %}
 Listen {{ apache_app_listen_address.authz_admin }}:{{ loadbalancing.authz_admin.port }}
 <VirtualHost {{ apache_app_listen_address.authz_admin }}:{{ loadbalancing.authz_admin.port }}>
 {% else %}
@@ -36,7 +36,7 @@ Listen {{ apache_app_listen_address.authz_admin }}:{{ loadbalancing.authz_admin.
     Include ssl_backend.conf
     {% endif %}
 
-    {% if apache_app_listen_address.all is defined %}
+    {% if apache_app_listen_address is defined and apache_app_listen_address.all is defined %}
     SSLEngine on
     SSLCertificateFile      {{ tls.cert_path }}/{{ tls_star_cert }}
     SSLCertificateKeyFile   {{ tls.cert_private_path }}/{{ tls_star_cert_key }}

--- a/roles/authz-playground/templates/authz_playground.conf.j2
+++ b/roles/authz-playground/templates/authz_playground.conf.j2
@@ -1,4 +1,4 @@
-{% if apache_app_listen_address.authz_playground is defined %}
+{% if apache_app_listen_address is defined and apache_app_listen_address.authz_playground is defined %}
 Listen {{ apache_app_listen_address.authz_playground }}:{{ loadbalancing.authz_playground.port }}
 <VirtualHost {{ apache_app_listen_address.authz_playground }}:{{ loadbalancing.authz_playground.port }}>
 {% else %}
@@ -20,7 +20,7 @@ Listen {{ apache_app_listen_address.authz_playground }}:{{ loadbalancing.authz_p
     Include ssl_backend.conf
     {% endif %}
 
-    {% if apache_app_listen_address.all is defined %}
+    {% if apache_app_listen_address is defined and apache_app_listen_address.all is defined %}
     SSLEngine on
     SSLCertificateFile      {{ tls.cert_path }}/{{ tls_star_cert }}
     SSLCertificateKeyFile   {{ tls.cert_private_path }}/{{ tls_star_cert_key }}

--- a/roles/authz-server/templates/authz.conf.j2
+++ b/roles/authz-server/templates/authz.conf.j2
@@ -1,4 +1,4 @@
-{% if apache_app_listen_address.authzserver is defined %}
+{% if apache_app_listen_address is defined and apache_app_listen_address.authzserver is defined %}
 Listen {{ apache_app_listen_address.authzserver }}:{{ loadbalancing.authzserver.port }}
 <VirtualHost {{ apache_app_listen_address.authzserver }}:{{ loadbalancing.authzserver.port }}>
 {% else %}
@@ -42,7 +42,7 @@ Listen {{ apache_app_listen_address.authzserver }}:{{ loadbalancing.authzserver.
     Include ssl_backend.conf
     {% endif %}
 
-    {% if apache_app_listen_address.all is defined %}
+    {% if apache_app_listen_address is defined and apache_app_listen_address.all is defined %}
     SSLEngine on
     SSLCertificateFile      {{ tls.cert_path }}/{{ tls_star_cert }}
     SSLCertificateKeyFile   {{ tls.cert_private_path }}/{{ tls_star_cert_key }}

--- a/roles/engineblock/templates/engine-api.conf.j2
+++ b/roles/engineblock/templates/engine-api.conf.j2
@@ -1,4 +1,4 @@
-{% if apache_app_listen_address.engine_api is defined %}
+{% if apache_app_listen_address is defined and apache_app_listen_address.engine_api is defined %}
 Listen {{ apache_app_listen_address.engine_api }}:{{ loadbalancing.engine_api.port }}
 <Virtualhost {{ apache_app_listen_address.engine_api }}:{{ loadbalancing.engine_api.port }}>
 {% else %}
@@ -17,7 +17,7 @@ Listen {{ apache_app_listen_address.engine_api }}:{{ loadbalancing.engine_api.po
         RewriteCond %{REQUEST_FILENAME} !-f
         RewriteRule ^(.*)$ app{% if develop %}_dev{% endif %}.php [QSA,L]
     </Directory>
-{% if apache_app_listen_address.all is defined %}
+{% if apache_app_listen_address is defined and apache_app_listen_address.all is defined %}
     SSLEngine on
     SSLCertificateFile      {{ tls.cert_path }}/{{ tls_star_cert }}
     SSLCertificateKeyFile   {{ tls.cert_private_path }}/{{ tls_star_cert_key }}

--- a/roles/engineblock/templates/engine.conf.j2
+++ b/roles/engineblock/templates/engine.conf.j2
@@ -1,4 +1,4 @@
-{% if apache_app_listen_address.engine is defined %}
+{% if apache_app_listen_address is defined and apache_app_listen_address.engine is defined %}
 Listen {{ apache_app_listen_address.engine }}:{{ loadbalancing.engine.port }}
 <Virtualhost {{ apache_app_listen_address.engine }}:{{ loadbalancing.engine.port }}>
 {% else %}
@@ -39,7 +39,7 @@ Listen {{ apache_app_listen_address.engine }}:{{ loadbalancing.engine.port }}
     SSLCertificateKeyFile   {{ tls.cert_private_path }}/backend.{{ base_domain }}.key
     Include ssl_backend.conf
     {% endif %}
-    {% if apache_app_listen_address.all is defined %}
+    {% if apache_app_listen_address is defined and apache_app_listen_address.all is defined %}
     SSLEngine on
     SSLCertificateFile      {{ tls.cert_path }}/{{ tls_star_cert }}
     SSLCertificateKeyFile   {{ tls.cert_private_path }}/{{ tls_star_cert_key }}

--- a/roles/httpd/templates/01_default.conf.j2
+++ b/roles/httpd/templates/01_default.conf.j2
@@ -7,7 +7,7 @@ RewriteEngine On
 RewriteCond %{HTTPS} off
 RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI}
 
-{% if apache_app_listen_address.all is defined %}
+{% if apache_app_listen_address is defined and apache_app_listen_address.all is defined %}
 # listen to the HTTPS port only
 Listen *:443
 {% else %}

--- a/roles/janus/templates/serviceregistry.conf.j2
+++ b/roles/janus/templates/serviceregistry.conf.j2
@@ -1,4 +1,4 @@
-{% if apache_app_listen_address.serviceregistry is defined %}
+{% if apache_app_listen_address is defined and apache_app_listen_address.serviceregistry is defined %}
 Listen {{ apache_app_listen_address.serviceregistry }}:{{ loadbalancing.serviceregistry.port }}
 <Virtualhost {{ apache_app_listen_address.serviceregistry }}:{{ loadbalancing.serviceregistry.port }}>
 {% else %}
@@ -34,7 +34,7 @@ Listen {{ apache_app_listen_address.serviceregistry }}:{{ loadbalancing.servicer
     Include ssl_backend.conf
     {% endif %}
     
-    {% if apache_app_listen_address.all is defined %}
+    {% if apache_app_listen_address is defined and apache_app_listen_address.all is defined %}
     SSLEngine on
     SSLCertificateFile      {{ tls.cert_path }}/{{ tls_star_cert }}
     SSLCertificateKeyFile   {{ tls.cert_private_path }}/{{ tls_star_cert_key }}

--- a/roles/manage-gui/templates/manage.conf.backdoor.j2
+++ b/roles/manage-gui/templates/manage.conf.backdoor.j2
@@ -1,4 +1,4 @@
-{% if apache_app_listen_address.manage is defined %}
+{% if apache_app_listen_address is defined and apache_app_listen_address.manage is defined %}
 Listen {{ apache_app_listen_address.manage }}:{{ loadbalancing.manage.port }}
 <Virtualhost {{ apache_app_listen_address.manage }}:{{ loadbalancing.manage.port }}>
 {% else %}

--- a/roles/manage-gui/templates/manage.conf.j2
+++ b/roles/manage-gui/templates/manage.conf.j2
@@ -1,4 +1,4 @@
-{% if apache_app_listen_address.manage is defined %}
+{% if apache_app_listen_address is defined and apache_app_listen_address.manage is defined %}
 Listen {{ apache_app_listen_address.manage }}:{{ loadbalancing.manage.port }}
 <Virtualhost {{ apache_app_listen_address.manage }}:{{ loadbalancing.manage.port }}>
 {% else %}
@@ -75,7 +75,7 @@ Listen {{ apache_app_listen_address.manage }}:{{ loadbalancing.manage.port }}
     Include ssl_backend.conf
     {% endif %}
     
-    {% if apache_app_listen_address.all is defined %}
+    {% if apache_app_listen_address is defined and apache_app_listen_address.all is defined %}
     SSLEngine on
     SSLCertificateFile      {{ tls.cert_path }}/{{ tls_star_cert }}
     SSLCertificateKeyFile   {{ tls.cert_private_path }}/{{ tls_star_cert_key }}

--- a/roles/metadata-exporter/templates/metadata_exporter.conf.j2
+++ b/roles/metadata-exporter/templates/metadata_exporter.conf.j2
@@ -1,4 +1,4 @@
-{% if apache_app_listen_address.metadata_exporter is defined %}
+{% if apache_app_listen_address is defined and apache_app_listen_address.metadata_exporter is defined %}
 Listen {{ apache_app_listen_address.metadata_exporter }}:{{ loadbalancing.metadata_exporter.port }}
 <VirtualHost {{ apache_app_listen_address.metadata_exporter }}:{{ loadbalancing.metadata_exporter.port }}>
 {% else %}
@@ -28,7 +28,7 @@ Listen {{ apache_app_listen_address.metadata_exporter }}:{{ loadbalancing.metada
     Include ssl_backend.conf
     {% endif %}
 
-    {% if apache_app_listen_address.all is defined %}
+    {% if apache_app_listen_address is defined and apache_app_listen_address.all is defined %}
     SSLEngine on
     SSLCertificateFile      {{ tls.cert_path }}/{{ tls_star_cert }}
     SSLCertificateKeyFile   {{ tls.cert_private_path }}/{{ tls_star_cert_key }}

--- a/roles/metadata/templates/metadata.conf.j2
+++ b/roles/metadata/templates/metadata.conf.j2
@@ -1,4 +1,4 @@
-{% if apache_app_listen_address.metadata is defined %}
+{% if apache_app_listen_address is defined and apache_app_listen_address.metadata is defined %}
 Listen {{ apache_app_listen_address.metadata }}:{{ loadbalancing.metadata.port }}
 <Virtualhost {{ apache_app_listen_address.metadata }}:{{ loadbalancing.metadata.port }}>
 {% else %}
@@ -11,7 +11,7 @@ Listen {{ apache_app_listen_address.metadata }}:{{ loadbalancing.metadata.port }
           Require all granted
     </Directory>
 
-{% if apache_app_listen_address.all is defined %}
+{% if apache_app_listen_address is defined and apache_app_listen_address.all is defined %}
     SSLEngine on
     SSLCertificateFile      {{ tls.cert_path }}/{{ tls_star_cert }}
     SSLCertificateKeyFile   {{ tls.cert_private_path }}/{{ tls_star_cert_key }}
@@ -27,7 +27,7 @@ Listen {{ apache_app_listen_address.metadata }}:{{ loadbalancing.metadata.port }
     SSLCertificateKeyFile   {{ tls.cert_private_path }}/backend.{{ base_domain }}.key
     Include ssl_backend.conf
     {% endif %}
-    {% if apache_app_listen_address.all is defined %}
+    {% if apache_app_listen_address is defined and apache_app_listen_address.all is defined %}
     SSLEngine on
     SSLCertificateFile      {{ tls.cert_path }}/{{ tls_star_cert }}
     SSLCertificateKeyFile   {{ tls.cert_private_path }}/{{ tls_star_cert_key }}

--- a/roles/mujina-idp/templates/mujina_idp.conf.j2
+++ b/roles/mujina-idp/templates/mujina_idp.conf.j2
@@ -1,4 +1,4 @@
-{% if apache_app_listen_address.mujina_idp is defined %}
+{% if apache_app_listen_address is defined and apache_app_listen_address.mujina_idp is defined %}
 Listen {{ apache_app_listen_address.mujina_idp }}:{{ loadbalancing.mujina_idp.port }}
 <VirtualHost {{ apache_app_listen_address.mujina_idp }}:{{ loadbalancing.mujina_idp.port }}>
 {% else %}
@@ -21,7 +21,7 @@ Listen {{ apache_app_listen_address.mujina_idp }}:{{ loadbalancing.mujina_idp.po
     Include ssl_backend.conf
     {% endif %}
 
-    {% if apache_app_listen_address.all is defined %}
+    {% if apache_app_listen_address is defined and apache_app_listen_address.all is defined %}
     SSLEngine on
     SSLCertificateFile      {{ tls.cert_path }}/{{ tls_star_cert }}
     SSLCertificateKeyFile   {{ tls.cert_private_path }}/{{ tls_star_cert_key }}

--- a/roles/mujina-sp/templates/mujina_sp.conf.j2
+++ b/roles/mujina-sp/templates/mujina_sp.conf.j2
@@ -1,4 +1,4 @@
-{% if apache_app_listen_address.mujina_sp is defined %}
+{% if apache_app_listen_address is defined and apache_app_listen_address.mujina_sp is defined %}
 Listen {{ apache_app_listen_address.mujina_sp }}:{{ loadbalancing.mujina_sp.port }}
 <VirtualHost {{ apache_app_listen_address.mujina_sp }}:{{ loadbalancing.mujina_sp.port }}>
 {% else %}
@@ -23,7 +23,7 @@ Listen {{ apache_app_listen_address.mujina_sp }}:{{ loadbalancing.mujina_sp.port
     Include ssl_backend.conf
     {% endif %}
 
-    {% if apache_app_listen_address.all is defined %}
+    {% if apache_app_listen_address is defined and apache_app_listen_address.all is defined %}
     SSLEngine on
     SSLCertificateFile      {{ tls.cert_path }}/{{ tls_star_cert }}
     SSLCertificateKeyFile   {{ tls.cert_private_path }}/{{ tls_star_cert_key }}

--- a/roles/oidc/templates/oidc.conf.j2
+++ b/roles/oidc/templates/oidc.conf.j2
@@ -1,4 +1,4 @@
-{% if apache_app_listen_address.oidc is defined %}
+{% if apache_app_listen_address is defined and apache_app_listen_address.oidc is defined %}
 Listen {{ apache_app_listen_address.oidc }}:{{ loadbalancing.oidc.port }}
 <Virtualhost {{ apache_app_listen_address.oidc }}:{{ loadbalancing.oidc.port }}>
 {% else %}
@@ -29,7 +29,7 @@ Listen {{ apache_app_listen_address.oidc }}:{{ loadbalancing.oidc.port }}
     Require env env_allow_1
     </Location>
 {% endif %}
-    {% if apache_app_listen_address.all is defined %}
+    {% if apache_app_listen_address is defined and apache_app_listen_address.all is defined %}
     SSLEngine on
     SSLCertificateFile      {{ tls.cert_path }}/{{ tls_star_cert }}
     SSLCertificateKeyFile   {{ tls.cert_private_path }}/{{ tls_star_cert_key }}

--- a/roles/pdp/templates/pdp.conf.j2
+++ b/roles/pdp/templates/pdp.conf.j2
@@ -1,4 +1,4 @@
-{% if apache_app_listen_address.pdp is defined %}
+{% if apache_app_listen_address is defined and apache_app_listen_address.pdp is defined %}
 Listen {{ apache_app_listen_address.pdp }}:{{ loadbalancing.pdp.port }}
 <Virtualhost {{ apache_app_listen_address.pdp }}:{{ loadbalancing.pdp.port }}>
 {% else %}
@@ -67,7 +67,7 @@ Listen {{ apache_app_listen_address.pdp }}:{{ loadbalancing.pdp.port }}
     Include ssl_backend.conf
     {% endif %}
 
-    {% if apache_app_listen_address.all is defined %}
+    {% if apache_app_listen_address is defined and apache_app_listen_address.all is defined %}
     SSLEngine on
     SSLCertificateFile      {{ tls.cert_path }}/{{ tls_star_cert }}
     SSLCertificateKeyFile   {{ tls.cert_private_path }}/{{ tls_star_cert_key }}

--- a/roles/profile/templates/profile.conf.j2
+++ b/roles/profile/templates/profile.conf.j2
@@ -1,4 +1,4 @@
-{% if apache_app_listen_address.profile is defined %}
+{% if apache_app_listen_address is defined and apache_app_listen_address.profile is defined %}
 Listen {{ apache_app_listen_address.profile }}:{{ loadbalancing.profile.port }}
 <Virtualhost {{ apache_app_listen_address.profile }}:{{ loadbalancing.profile.port }}>
 {% else %}
@@ -11,7 +11,7 @@ Listen {{ apache_app_listen_address.profile }}:{{ loadbalancing.profile.port }}
 
     SetEnv SYMFONY_ENV {{ profile_apache_symfony_environment }}
     SetEnv HTTPS on
-{% if apache_app_listen_address.all is defined %}
+{% if apache_app_listen_address is defined and apache_app_listen_address.all is defined %}
     SSLEngine on
     SSLCertificateFile      {{ tls.cert_path }}/{{ tls_star_cert }}
     SSLCertificateKeyFile   {{ tls.cert_private_path }}/{{ tls_star_cert_key }}
@@ -39,7 +39,7 @@ Listen {{ apache_app_listen_address.profile }}:{{ loadbalancing.profile.port }}
     Include ssl_backend.conf
     {% endif %}
 
-    {% if apache_app_listen_address.all is defined %}
+    {% if apache_app_listen_address is defined and apache_app_listen_address.all is defined %}
     SSLEngine on
     SSLCertificateFile      {{ tls.cert_path }}/{{ tls_star_cert }}
     SSLCertificateKeyFile   {{ tls.cert_private_path }}/{{ tls_star_cert_key }}

--- a/roles/static/templates/static.conf.j2
+++ b/roles/static/templates/static.conf.j2
@@ -1,4 +1,4 @@
-{% if apache_app_listen_address.static is defined %}
+{% if apache_app_listen_address is defined and apache_app_listen_address.static is defined %}
 Listen {{ apache_app_listen_address.static }}:{{ loadbalancing.static.port }}
 <Virtualhost {{ apache_app_listen_address.static }}:{{ loadbalancing.static.port }}>
 {% else %}
@@ -7,7 +7,7 @@ Listen {{ apache_app_listen_address.static }}:{{ loadbalancing.static.port }}
     ServerName static.{{ base_domain }}:443
 
     DocumentRoot {{ static_dir }}
-{% if apache_app_listen_address.all is defined %}
+{% if apache_app_listen_address is defined and apache_app_listen_address.all is defined %}
     SSLEngine on
     SSLCertificateFile      {{ tls.cert_path }}/{{ tls_star_cert }}
     SSLCertificateKeyFile   {{ tls.cert_private_path }}/{{ tls_star_cert_key }}
@@ -24,7 +24,7 @@ Listen {{ apache_app_listen_address.static }}:{{ loadbalancing.static.port }}
     Include ssl_backend.conf
     {% endif %}
 
-    {% if apache_app_listen_address.all is defined %}
+    {% if apache_app_listen_address is defined and apache_app_listen_address.all is defined %}
     SSLEngine on
     SSLCertificateFile      {{ tls.cert_path }}/{{ tls_star_cert }}
     SSLCertificateKeyFile   {{ tls.cert_private_path }}/{{ tls_star_cert_key }}

--- a/roles/teams-gui/templates/teams.conf.j2
+++ b/roles/teams-gui/templates/teams.conf.j2
@@ -1,4 +1,4 @@
-{% if apache_app_listen_address.teams is defined %}
+{% if apache_app_listen_address is defined and apache_app_listen_address.teams is defined %}
 Listen {{ apache_app_listen_address.teams }}:{{ loadbalancing.teams.port }}
 <Virtualhost {{ apache_app_listen_address.teams }}:{{ loadbalancing.teams.port }}> 
 {% else %}
@@ -75,7 +75,7 @@ Listen {{ apache_app_listen_address.teams }}:{{ loadbalancing.teams.port }}
     Include ssl_backend.conf
     {% endif %}
     
-    {% if apache_app_listen_address.all is defined %}
+    {% if apache_app_listen_address is defined and apache_app_listen_address.all is defined %}
     SSLEngine on
     SSLCertificateFile      {{ tls.cert_path }}/{{ tls_star_cert }}
     SSLCertificateKeyFile   {{ tls.cert_private_path }}/{{ tls_star_cert_key }}

--- a/roles/teams-legacy/templates/teams.conf.j2
+++ b/roles/teams-legacy/templates/teams.conf.j2
@@ -42,7 +42,7 @@ Listen {{ apache_app_listen_address.teams }}:{{ loadbalancing.teams.port }}
     Include ssl_backend.conf
     {% endif %}
     
-    {% if apache_app_listen_address.all is defined %}
+    {% if apache_app_listen_address is defined and apache_app_listen_address.all is defined %}
     SSLEngine on
     SSLCertificateFile      {{ tls.cert_path }}/{{ tls_star_cert }}
     SSLCertificateKeyFile   {{ tls.cert_private_path }}/{{ tls_star_cert_key }}

--- a/roles/voot/templates/voot.conf.j2
+++ b/roles/voot/templates/voot.conf.j2
@@ -1,4 +1,4 @@
-{% if apache_app_listen_address.voot is defined %}
+{% if apache_app_listen_address is defined and apache_app_listen_address.voot is defined %}
 Listen {{ apache_app_listen_address.voot }}:{{ loadbalancing.voot.port }}
 <Virtualhost {{ apache_app_listen_address.voot }}:{{ loadbalancing.voot.port }}>
 {% else %}
@@ -19,7 +19,7 @@ Listen {{ apache_app_listen_address.voot }}:{{ loadbalancing.voot.port }}
     Include ssl_backend.conf
     {% endif %}
 
-    {% if apache_app_listen_address.all is defined %}
+    {% if apache_app_listen_address is defined and apache_app_listen_address.all is defined %}
     SSLEngine on
     SSLCertificateFile      {{ tls.cert_path }}/{{ tls_star_cert }}
     SSLCertificateKeyFile   {{ tls.cert_private_path }}/{{ tls_star_cert_key }}

--- a/roles/welcome/templates/welcome-vm.conf.j2
+++ b/roles/welcome/templates/welcome-vm.conf.j2
@@ -1,4 +1,4 @@
-{% if apache_app_listen_address.welcome is defined %}
+{% if apache_app_listen_address is defined and apache_app_listen_address.welcome is defined %}
 Listen {{ apache_app_listen_address.welcome }}:{{ loadbalancing.welcome.port }}
 <Virtualhost {{ apache_app_listen_address.welcome }}:{{ loadbalancing.welcome.port }}>
 {% else %}
@@ -8,7 +8,7 @@ Listen {{ apache_app_listen_address.welcome }}:{{ loadbalancing.welcome.port }}
     ServerName {{ base_domain }}:443
 
     DocumentRoot /var/www/welcome
-{% if apache_app_listen_address.all is defined %}
+{% if apache_app_listen_address is defined and apache_app_listen_address.all is defined %}
     SSLEngine on
     SSLCertificateFile      {{ tls.cert_path }}/{{ tls_star_cert }}
     SSLCertificateKeyFile   {{ tls.cert_private_path }}/{{ tls_star_cert_key }}
@@ -25,7 +25,7 @@ Listen {{ apache_app_listen_address.welcome }}:{{ loadbalancing.welcome.port }}
     Include ssl_backend.conf
     {% endif %}
 
-    {% if apache_app_listen_address.all is defined %}
+    {% if apache_app_listen_address is defined and apache_app_listen_address.all is defined %}
     SSLEngine on
     SSLCertificateFile      {{ tls.cert_path }}/{{ tls_star_cert }}
     SSLCertificateKeyFile   {{ tls.cert_private_path }}/{{ tls_star_cert_key }}


### PR DESCRIPTION
Before checking whether an attribute of a variable is defined, first check
whether the variable itself is defined.
This prevents errors if the variables themselves aren't (properly) defined while
executing the playbook and roles.