### PR TITLE
Postfix part of the pseudonymous email functionality

### DIFF
--- a/roles/attribute-aggregation-server/defaults/main.yml
+++ b/roles/attribute-aggregation-server/defaults/main.yml
@@ -5,6 +5,6 @@ attribute_aggregation_snapshot_timestamp: ''
 attribute_aggregation_local_jar: ''
 attribute_aggregation_jar: attribute-aggregation-current.jar
 attribute_aggregation_random_source: 'file:///dev/urandom'
-attribute_aggregation_pseudo_mail_postfix: surfconext.nl
+attribute_aggregation_pseudo_mail_postfix: demo.openconext.org
 attribute_aggregation_pseudo_emails_retention_days_period: 90
 aa_cronjobmaster: true

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -1,1 +1,2 @@
 sendmail_smarthost: localhost
+handle_pseudo_email: false

--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -11,3 +11,8 @@
 
 - name: reload postfix
   service: name=postfix state=reloaded
+
+- name: rebuild header_checks
+  command: /usr/sbin/postmap header_checks
+  args:
+    chdir: /etc/postfix

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -77,9 +77,14 @@
   notify: reload postfix
 
 - name: Copy Postfix pseudo-email config
-  template: src='mysql-pseudo.cf.j2' dest='/etc/postfix/mysql-pseudo.cf' mode=0600
+  template: src='{{item}}.j2' dest='/etc/postfix/{{item}}'
   when: sendmail_smarthost is defined and handle_pseudo_email
-  notify: reload postfix
+  with_items: 
+    - mysql-pseudo.cf
+    - header_checks
+  notify: 
+    - reload postfix
+    - rebuild header_checks
 
 # journald binary logs corrupt on specific engineblock messages.
 # disabling compression fixes that issue

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -76,6 +76,11 @@
   when: sendmail_smarthost is defined
   notify: reload postfix
 
+- name: Copy Postfix pseudo-email config
+  template: src='mysql-pseudo.cf.j2' dest='/etc/postfix/mysql-pseudo.cf' mode=0600
+  when: sendmail_smarthost is defined and handle_pseudo_email
+  notify: reload postfix
+
 # journald binary logs corrupt on specific engineblock messages.
 # disabling compression fixes that issue
 - name: Disable journald compression

--- a/roles/common/templates/header_checks.j2
+++ b/roles/common/templates/header_checks.j2
@@ -1,0 +1,4 @@
+/^Received:/                IGNORE
+/^X-Originating-IP:/        IGNORE
+/^X-Mailer:/                IGNORE
+/^Mime-Version: ([\d.]+)/   REPLACE Mime-Version: $1"

--- a/roles/common/templates/main.cf.j2
+++ b/roles/common/templates/main.cf.j2
@@ -681,3 +681,9 @@ readme_directory = /usr/share/doc/postfix-2.10.1/README_FILES
 
 smtp_tls_loglevel = 1
 smtp_tls_security_level = may
+
+{% if handle_pseudo_email %}
+virtual_alias_domains = {{attribute_aggregation_pseudo_mail_postfix}}
+virtual_alias_maps = mysql:/etc/postfix/mysql-pseudo.cf
+{% endif %}
+

--- a/roles/common/templates/main.cf.j2
+++ b/roles/common/templates/main.cf.j2
@@ -684,7 +684,7 @@ smtp_tls_security_level = may
 
 {% if handle_pseudo_email %}
 canonical_maps = mysql:/etc/postfix/mysql-pseudo.cf
-remote_header_rewrite_domain = anomail.conext.surfnetlabs.nl 
+remote_header_rewrite_domain = {{ attribute_aggregation_pseudo_mail_postfix }}
 smtp_header_checks = pcre:/etc/postfix/header_checks
 smtp_mime_header_checks = pcre:/etc/postfix/header_checks
 {% endif %}

--- a/roles/common/templates/main.cf.j2
+++ b/roles/common/templates/main.cf.j2
@@ -683,7 +683,7 @@ smtp_tls_loglevel = 1
 smtp_tls_security_level = may
 
 {% if handle_pseudo_email %}
-virtual_alias_domains = {{attribute_aggregation_pseudo_mail_postfix}}
-virtual_alias_maps = mysql:/etc/postfix/mysql-pseudo.cf
+canonical_maps = mysql:/etc/postfix/mysql-pseudo.cf
+remote_header_rewrite_domain = anomail.conext.surfnetlabs.nl 
 {% endif %}
 

--- a/roles/common/templates/main.cf.j2
+++ b/roles/common/templates/main.cf.j2
@@ -685,5 +685,7 @@ smtp_tls_security_level = may
 {% if handle_pseudo_email %}
 canonical_maps = mysql:/etc/postfix/mysql-pseudo.cf
 remote_header_rewrite_domain = anomail.conext.surfnetlabs.nl 
+smtp_header_checks = pcre:/etc/postfix/header_checks
+smtp_mime_header_checks = pcre:/etc/postfix/header_checks
 {% endif %}
 

--- a/roles/common/templates/mysql-pseudo.cf.j2
+++ b/roles/common/templates/mysql-pseudo.cf.j2
@@ -1,0 +1,10 @@
+hosts    = {{ aa.db_host }}
+user     = {{ aa.db_user }}
+password = {{ aa.db_password }}
+dbname   = {{ aa.db_name }}
+
+query = SELECT email FROM pseudo_emails WHERE pseudo_email='%s'
+expansion_limit = 1
+
+domain = {{ attribute_aggregation_pseudo_mail_postfix }}
+


### PR DESCRIPTION
These is the setup for the mailserver (postfix) on an Openconext machine to forward and rewrite emails for a pseudonymous email domain.  

The corresponding code in AA-server, to rewrite the addresses during a SAML session, was implemented here: https://github.com/OpenConext/OpenConext-attribute-aggregation/commit/b51acea570470defcfdd8a5afa727b4e62df3f05