### PR TITLE
Remove duplicate configuration for SSL

### DIFF
--- a/roles/metadata/templates/metadata.conf.j2
+++ b/roles/metadata/templates/metadata.conf.j2
@@ -11,13 +11,6 @@ Listen {{ apache_app_listen_address.metadata }}:{{ loadbalancing.metadata.port }
           Require all granted
     </Directory>
 
-{% if apache_app_listen_address.all is defined %}
-    SSLEngine on
-    SSLCertificateFile      {{ tls.cert_path }}/{{ tls_star_cert }}
-    SSLCertificateKeyFile   {{ tls.cert_private_path }}/{{ tls_star_cert_key }}
-    SSLCertificateChainFile {{ tls.cert_path_ca }}/{{ tls_ca }}
-{% endif %}
-
     ErrorLog "|/usr/bin/logger -p local3.err  -t 'Apache-METADATA'"
     CustomLog "|/usr/bin/logger -p local3.info  -t 'Apache-METADATA'" combined
     

--- a/roles/profile/templates/profile.conf.j2
+++ b/roles/profile/templates/profile.conf.j2
@@ -11,12 +11,6 @@ Listen {{ apache_app_listen_address.profile }}:{{ loadbalancing.profile.port }}
 
     SetEnv SYMFONY_ENV {{ profile_apache_symfony_environment }}
     SetEnv HTTPS on
-{% if apache_app_listen_address.all is defined %}
-    SSLEngine on
-    SSLCertificateFile      {{ tls.cert_path }}/{{ tls_star_cert }}
-    SSLCertificateKeyFile   {{ tls.cert_private_path }}/{{ tls_star_cert_key }}
-    SSLCertificateChainFile {{ tls.cert_path_ca }}/{{ tls_ca }}
-{% endif %}
 
     <Directory "{{ profile_current_release_symlink }}/web">
         Require all granted

--- a/roles/static/templates/static.conf.j2
+++ b/roles/static/templates/static.conf.j2
@@ -7,12 +7,6 @@ Listen {{ apache_app_listen_address.static }}:{{ loadbalancing.static.port }}
     ServerName static.{{ base_domain }}:443
 
     DocumentRoot {{ static_dir }}
-{% if apache_app_listen_address.all is defined %}
-    SSLEngine on
-    SSLCertificateFile      {{ tls.cert_path }}/{{ tls_star_cert }}
-    SSLCertificateKeyFile   {{ tls.cert_private_path }}/{{ tls_star_cert_key }}
-    SSLCertificateChainFile {{ tls.cert_path_ca }}/{{ tls_ca }}
-{% endif %}
 
     ErrorLog "|/usr/bin/logger -p local3.err  -t 'Apache-STATIC'"
     CustomLog "|/usr/bin/logger -p local3.info  -t 'Apache-STATIC'" combined

--- a/roles/welcome/templates/welcome-vm.conf.j2
+++ b/roles/welcome/templates/welcome-vm.conf.j2
@@ -8,12 +8,6 @@ Listen {{ apache_app_listen_address.welcome }}:{{ loadbalancing.welcome.port }}
     ServerName {{ base_domain }}:443
 
     DocumentRoot /var/www/welcome
-{% if apache_app_listen_address.all is defined %}
-    SSLEngine on
-    SSLCertificateFile      {{ tls.cert_path }}/{{ tls_star_cert }}
-    SSLCertificateKeyFile   {{ tls.cert_private_path }}/{{ tls_star_cert_key }}
-    SSLCertificateChainFile {{ tls.cert_path_ca }}/{{ tls_ca }}
-{% endif %}
 
     ErrorLog "|/usr/bin/logger -p local3.err  -t 'Apache-Welcome'"
     CustomLog "|/usr/bin/logger -p local3.info  -t 'Apache-Welcome'" combined


### PR DESCRIPTION
Some configuration files for Apache define SSL certificates twice. This
is not supported and breaks the deployment, as Apache will not start.