### PR TITLE
Removing redundant variable from haproxy.cfg

### DIFF
--- a/roles/haproxy/templates/haproxy.cfg.j2
+++ b/roles/haproxy/templates/haproxy.cfg.j2
@@ -175,7 +175,7 @@ backend {{ application.name }}_be
   	mode http
   	balance roundrobin
   	option httpclose
-  	cookie HTTPSERVERID insert nocache indirect httponly secure maxidle 3600 {{ haproxy_cookie_max_idle }}
+  	cookie HTTPSERVERID insert nocache indirect httponly secure maxidle {{ haproxy_cookie_max_idle }}
   	{% for server in application.servers_fourthset %}
   	server {{ server.label }} {{ server.ip }}:{{ application.port }} cookie {{ server.label }} check inter 8000 fall 5 rise 2 maxconn 1024 {% if application.sslbackend is defined%} ssl verify required verifyhost {{ application.backend_vhost_name }} ca-file {{ application.backend_ca_file }} {% endif %}
 
@@ -213,7 +213,7 @@ backend {{ item.name }}_be
     balance roundrobin
     option httpclose
     option allbackups
-    cookie HTTPSERVERID insert nocache indirect httponly secure maxidle 3600 {{ haproxy_cookie_max_idle }}
+    cookie HTTPSERVERID insert nocache indirect httponly secure maxidle {{ haproxy_cookie_max_idle }}
     {% for server in item.servers %}
     server {{ server.label }} {{ server.ip }}:{{ item.port }} cookie {{ server.label }} check inter 8000 fall 5 rise 2 maxconn 1024  {% if item.sslbackend is defined %} ssl verify required verifyhost {{ item.backend_vhost_name }} ca-file {{ item.backend_ca_file }} {% endif %} 
     {% endfor %}


### PR DESCRIPTION
The 3600 `maxidle` variable is already being set by the Ansible variable, so this removes the redundant digit.