### PR TITLE
Use instance_name var for engineblock defaults.title/header config

### DIFF
--- a/roles/engineblock/templates/engineblock.ini.j2
+++ b/roles/engineblock/templates/engineblock.ini.j2
@@ -47,6 +47,9 @@ engine.simplesamlphp.baseurlpath = "{{ engine_engine_idp_baseurlpath }}"
 
 cookie.lang.domain = .{{ base_domain }}
 
+defaults.title  = "{{ instance_name }}"
+defaults.header = "{{ instance_name }}"
+
 database.host = {{ engine_database_host }}
 database.port = {{ engine_database_port }}
 database.password = "{{ engine_database_password }}"


### PR DESCRIPTION
There are some [EngineBlock variables](https://github.com/OpenConext/OpenConext-engineblock/blob/master/application/configs/application.ini#L227-L228)  that have SURFconext hardcoded.

This will use the `instance_name` variable to populate these variables.