### PR TITLE
Set profile.baseUrl during provisioning

### DIFF
--- a/roles/engineblock/templates/engineblock.ini.j2
+++ b/roles/engineblock/templates/engineblock.ini.j2
@@ -39,6 +39,9 @@ pdp.policy_decision_point_path = {{ engine_pdp_path }}
 pdp.username = {{ pdp.username }}
 pdp.password = {{ pdp.password }}
 
+; Location of Profile
+profile.baseUrl = "https://{{ profile_baseurl }}/"
+
 attributeAggregation.baseUrl = {{ engine_attribute_aggregation_baseurl }}
 attributeAggregation.username = {{engine_attribute_aggregation_username }}
 attributeAggregation.password = "{{engine_attribute_aggregation_password }}"

--- a/roles/profile/defaults/main.yml
+++ b/roles/profile/defaults/main.yml
@@ -16,6 +16,8 @@ profile_current_release_symlink: "{{ openconext_releases_dir }}/OpenConext-profi
 # Domain under which profile can be found
 profile_domain: profile.{{ base_domain }}
 
+profile_baseurl: https://{{ profile_domain }}
+
 # Cache and log paths
 profile_symfony_cache_path: "/tmp/profile/symfony-cache/"
 profile_symfony_log_path: "/var/log/profile"


### PR DESCRIPTION
In OpenConext/engineblock [PR#472](https://github.com/OpenConext/OpenConext-engineblock/pull/472) the profile.baseUrl was added. This
commit ensures that the parameter is added during provisioning of
EngineBlock.