### PR TITLE
Adding remaining engineblock.ini customizable vars

### DIFF
--- a/environments/docker/group_vars/docker.yml
+++ b/environments/docker/group_vars/docker.yml
@@ -118,6 +118,10 @@ engine_database_password: "{{ mysql_passwords.eb }}"
 engine_apache_environment: vm
 engine_apache_symfony_environment: prod
 
+engine_edugain_registration_authority: "http://www.surfnet.nl"
+engine_edugain_registration_policy: "https://wiki.surfnet.nl/display/eduGAIN/EduGAIN"
+engine_openconext_termsofuse_url: "https://wiki.surfnet.nl/display/conextsupport/Terms+of+Service+%28EN%29"
+
 janus_database_name: sr
 janus_database_host: localhost
 janus_database_user: srrw

--- a/environments/template/group_vars/template.yml
+++ b/environments/template/group_vars/template.yml
@@ -101,6 +101,10 @@ engine_database_password: "{{ mysql_passwords.eb }}"
 engine_apache_environment: test
 engine_apache_symfony_environment: prod
 
+engine_edugain_registration_authority: "http://www.{{ base_domain }}"
+engine_edugain_registration_policy: "https://wiki.{{ base_domain }}/display/eduGAIN/EduGAIN"
+engine_openconext_termsofuse_url: "https://wiki.{{ base_domain }}/display/conextsupport/Terms+of+Service+%28EN%29"
+
 janus_database_name: sr
 janus_database_host: "{{ mysql_host }}"
 janus_database_user: srrw

--- a/environments/vm/group_vars/vm.yml
+++ b/environments/vm/group_vars/vm.yml
@@ -110,6 +110,10 @@ engine_database_password: "{{ mysql_passwords.eb }}"
 engine_apache_environment: vm
 engine_apache_symfony_environment: prod
 
+engine_edugain_registration_authority: "http://www.surfnet.nl"
+engine_edugain_registration_policy: "https://wiki.surfnet.nl/display/eduGAIN/EduGAIN"
+engine_openconext_termsofuse_url: "https://wiki.surfnet.nl/display/conextsupport/Terms+of+Service+%28EN%29"
+
 janus_database_name: sr
 janus_database_host: localhost
 janus_database_user: srrw

--- a/roles/engineblock/defaults/main.yml
+++ b/roles/engineblock/defaults/main.yml
@@ -85,3 +85,9 @@ engine_idp_debugging_from_address: "{{ noreply_email }}"
 engine_idp_debugging_to_name: "{{ instance_name }} Admin"
 engine_idp_debugging_email_address: "{{ support_email }}"
 engine_idp_debugging_subject: "IdP debug info from %1$s"
+
+engine_php_sendmail_from: "{{ instance_name }} EngineBlock <engineblock@{{ base_domain }}>"
+
+engine_edugain_publication_publisher: "https://engine.{{ base_domain }}/authentication/proxy/edugain-metadata"
+engine_edugain_publication_policy_url: "http://www.edugain.org/policy/metadata-tou_1_0.txt"
+engine_edugain_termsofuse: "Use of this metadata is subject to the Terms of Use at http://www.edugain.org/policy/metadata-tou_1_0.txt"

--- a/roles/engineblock/templates/engineblock.ini.j2
+++ b/roles/engineblock/templates/engineblock.ini.j2
@@ -58,6 +58,14 @@ database.dbname = {{ engine_database_name }}
 
 debug = {{ engine_debug }}
 
+edugain.publication.publisher = "{{ engine_edugain_publication_publisher }}"
+edugain.publication.policy = "{{ engine_edugain_publication_policy_url }}"
+edugain.registration.authority = "{{ engine_edugain_registration_authority }}"
+edugain.registration.policy = "{{ engine_edugain_registration_policy }}"
+edugain.termsOfUse = "{{ engine_edugain_termsofuse }}"
+
+email.help = "{{ support_email }}"
+
 email.idpDebugging.from.name  = "{{ engine_idp_debugging_from_name }}"
 email.idpDebugging.from.address = "{{ engine_idp_debugging_from_address }}"
 email.idpDebugging.to.address = {{ engine_idp_debugging_email_address }}
@@ -79,6 +87,7 @@ metadataRepositories[{{ repository.index }}] = {{ repository.type }}
 
 phpSettings.display_errors = {{ php_display_errors }}
 phpSettings.date.timezone = {{ timezone }}
+phpSettings.sendmail_from = "{{ engine_php_sendmail_from }}"
 
 serviceRegistry.caching.lifetime = {{ engine_janus_cache_lifetime }}
 serviceRegistry.location = {{ engine_janus_url }}
@@ -105,3 +114,5 @@ minimumExecutionTimeOnInvalidReceivedResponse = {{ engine_minimum_execution_time
 ; how many authentication procedures for the same SP are allowed (default: 5)
 engineblock.timeFrameForAuthenticationLoopInSeconds = {{ engine_time_frame_for_authentication_loop_in_seconds }}
 engineblock.maximumAuthenticationProceduresAllowed  = {{ engine_maximum_authentication_procedures_allowed }}
+
+openconext.termsOfUse = "{{ engine_openconext_termsofuse_url }}"


### PR DESCRIPTION
This covers the rest of the SURF branded variables in engineblock.ini. Some of the URLs still need to be configured per-instance (wiki links, etc), but this makes it possible using Ansible group_vars.

However, there's still the en.php and nl.php language files that aren't part of OpenConext-deploy that have a lot of hardcoded SURFnet/conext branding. Including these files in OpenConext-deploy would essentially mean maintaining a second set of files, which is far from ideal (it's what we're doing).