### PR TITLE
Add EngineBlock test database to provisioning

### DIFF
--- a/environments/vm/group_vars/vm.yml
+++ b/environments/vm/group_vars/vm.yml
@@ -107,6 +107,12 @@ engine_database_port: 3306
 engine_database_user: ebrw
 engine_database_password: "{{ mysql_passwords.eb }}"
 
+engine_test_database_name: eb_test
+engine_test_database_host: localhost
+engine_test_database_port: 3306
+engine_test_database_user: eb_testrw
+engine_test_database_password: "{{ mysql_passwords.eb }}"
+
 engine_apache_environment: vm
 engine_apache_symfony_environment: prod
 

--- a/roles/engineblock/tasks/main.yml
+++ b/roles/engineblock/tasks/main.yml
@@ -66,6 +66,14 @@
       chdir: "{{ openconext_releases_dir }}/OpenConext-engineblock"
   changed_when: False
 
+- name: Create EngineBlock test database
+  mysql_db: name={{ engine_test_database_name }} state=present
+  when: develop
+
+- name: Create EngineBlock test database user
+  mysql_user: name={{ engine_test_database_user }} host={{ engine_test_database_host }} password={{ engine_test_database_password }} priv={{ engine_test_database_name }}.*:ALL state=present
+  when: develop
+
 # Any scripts should be placed below this
 - name: Run EngineBlock DbPatch migrations
   command: ./bin/migrate

--- a/roles/engineblock/templates/engineblock.ini.j2
+++ b/roles/engineblock/templates/engineblock.ini.j2
@@ -56,6 +56,14 @@ database.password = "{{ engine_database_password }}"
 database.user = "{{ engine_database_user }}"
 database.dbname = {{ engine_database_name }}
 
+{% if develop %}
+database.test.host = {{ engine_test_database_host }}
+database.test.port = {{ engine_test_database_port }}
+database.test.password = "{{ engine_test_database_password }}"
+database.test.user = "{{ engine_test_database_user }}"
+database.test.dbname = {{ engine_test_database_name }}
+{% endif %}
+
 debug = {{ engine_debug }}
 
 email.idpDebugging.from.name  = "{{ engine_idp_debugging_from_name }}"


### PR DESCRIPTION
When building a development environment, we also need a test database to be able to run functional tests.

This change adds the eb_test database and provisions a test user. The test database config is also added to the engineblock.ini template file.

@quartje or @thijskh , some questions: 
* I'm not realy sure I also needed to add the eb-test database config to the docker group_vars. Is this a requirement? 
* Are functional tests run in the docker environment? 
* How do I prevent the test database from being provisioned in production builds?