### PR TITLE
Update EB roles to work with 5.7 ini settings

### DIFF
--- a/environments/docker/files/eb/languages/overrides.en.php
+++ b/environments/docker/files/eb/languages/overrides.en.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'suite_name' => '{{ instance_name }}',
+];

--- a/environments/docker/files/eb/languages/overrides.nl.php
+++ b/environments/docker/files/eb/languages/overrides.nl.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'suite_name' => '{{ instance_name }}',
+];

--- a/environments/template/files/eb/languages/overrides.en.php
+++ b/environments/template/files/eb/languages/overrides.en.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'suite_name' => '{{ instance_name }}',
+];

--- a/environments/template/files/eb/languages/overrides.nl.php
+++ b/environments/template/files/eb/languages/overrides.nl.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'suite_name' => '{{ instance_name }}',
+];

--- a/environments/vm/files/eb/languages/overrides.en.php
+++ b/environments/vm/files/eb/languages/overrides.en.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'suite_name' => '{{ instance_name }}',
+];

--- a/environments/vm/files/eb/languages/overrides.nl.php
+++ b/environments/vm/files/eb/languages/overrides.nl.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'suite_name' => '{{ instance_name }}',
+];

--- a/roles/engineblock/defaults/main.yml
+++ b/roles/engineblock/defaults/main.yml
@@ -2,7 +2,6 @@
 ## Version of EngineBlock that is installable by this role
 engine_version: ''
 #engine_branch: "develop"
-
 # Feature toggles
 engine_feature_encrypted_assertions: 1
 engine_feature_encrypted_assertions_require_outer_signature: 1
@@ -87,3 +86,8 @@ engine_idp_debugging_from_address: "{{ noreply_email }}"
 engine_idp_debugging_to_name: "{{ instance_name }} Admin"
 engine_idp_debugging_email_address: "{{ support_email }}"
 engine_idp_debugging_subject: "IdP debug info from %1$s"
+
+eb_edugain_authority_url: "https://example.org"
+eb_edugain_policy_url: "https://example.org"
+eb_support_url: "https://example.org"
+eb_tos_url: "https://example.org"

--- a/roles/engineblock/tasks/main.yml
+++ b/roles/engineblock/tasks/main.yml
@@ -17,6 +17,9 @@
 - include: develop.yml
   when: develop
 
+- name: Copy language specific overrides
+  copy: src="{{ inventory_dir }}/files/eb/languages/" dest="{{ openconext_releases_dir }}/OpenConext-engineblock/languages"
+
 - name: Install Apache vhost
   template: src={{ item }}.j2 dest=/etc/httpd/conf.d/{{ item }}
   with_items:

--- a/roles/engineblock/tasks/main.yml
+++ b/roles/engineblock/tasks/main.yml
@@ -62,7 +62,6 @@
 # configuration is loaded correctly.
 - name: Prepare EngineBlock5 environment
   shell: SYMFONY_ENV=prod composer prepare-env
-  become: no
   args:
       chdir: "{{ openconext_releases_dir }}/OpenConext-engineblock"
   changed_when: False

--- a/roles/engineblock/templates/engineblock.ini.j2
+++ b/roles/engineblock/templates/engineblock.ini.j2
@@ -5,11 +5,6 @@ base_domain = {{ engine_base_domain }}
 hostname = engine.{{ engine_base_domain }}
 
 ;; Engineblock API Configuration
-;; DEPRECATED, use the newer version below
-engineApi.user     = {{ engine_api_janus_user }}
-engineApi.password = {{ engine_api_janus_password }}
-
-;; New version that allows for multiple different API users
 engineApi.users.janus.username = {{ engine_api_janus_user }}
 engineApi.users.janus.password = {{ engine_api_janus_password }}
 engineApi.users.profile.username = {{ engine_api_profile_user }}
@@ -80,18 +75,20 @@ encryption.keys.{{ key }}.publicFile = {{ value.publicFile }}
 
 {% endif %}
 
-{% for repository in engine_block.metadataRepositories %}
-metadataRepository.{{ repository.type }}.type = {{ repository.value }}
-metadataRepositories[{{ repository.index }}] = {{ repository.type }}
-{% endfor %}
-
-phpSettings.display_errors = {{ php_display_errors }}
-phpSettings.date.timezone = {{ timezone }}
-
+{% if  engine_version | version_compare('5.7.0', '<')  %}
 serviceRegistry.caching.lifetime = {{ engine_janus_cache_lifetime }}
 serviceRegistry.location = {{ engine_janus_url }}
 serviceRegistry.user = "{{ engine_janus_user }}"
 serviceRegistry.user_secret = "{{ engine_janus_secret }}"
+{% for repository in engine_block.metadataRepositories %}
+metadataRepository.{{ repository.type }}.type = {{ repository.value }}
+metadataRepositories[{{ repository.index }}] = {{ repository.type }}
+{% endfor %}
+{% endif %}
+
+phpSettings.display_errors = {{ php_display_errors }}
+phpSettings.date.timezone = {{ timezone }}
+
 {% if engine_trusted_proxy_ips is defined %}
 
 {% for engine_trusted_proxy_ip in engine_trusted_proxy_ips %}

--- a/roles/engineblock/templates/engineblock.ini.j2
+++ b/roles/engineblock/templates/engineblock.ini.j2
@@ -69,6 +69,7 @@ database.test.dbname = {{ engine_test_database_name }}
 
 debug = {{ engine_debug }}
 
+email.help = "{{ support_email }}"
 email.idpDebugging.from.name  = "{{ engine_idp_debugging_from_name }}"
 email.idpDebugging.from.address = "{{ engine_idp_debugging_from_address }}"
 email.idpDebugging.to.address = {{ engine_idp_debugging_email_address }}
@@ -116,3 +117,12 @@ minimumExecutionTimeOnInvalidReceivedResponse = {{ engine_minimum_execution_time
 ; how many authentication procedures for the same SP are allowed (default: 5)
 engineblock.timeFrameForAuthenticationLoopInSeconds = {{ engine_time_frame_for_authentication_loop_in_seconds }}
 engineblock.maximumAuthenticationProceduresAllowed  = {{ engine_maximum_authentication_procedures_allowed }}
+
+; Edugain URLs
+edugain.publication.publisher = "https://engine.{{ base_domain }}/authentication/proxy/edugain-metadata"
+edugain.registration.authority = "{{ eb_edugain_authority_url }}"
+edugain.registration.policy = "{{ eb_edugain_policy_url }}"
+
+; General URLs
+openconext.supportUrl = "{{ eb_support_url }}"
+openconext.termsOfUse = "{{ eb_tos_url }}"

--- a/roles/engineblock/templates/engineblock.ini.j2
+++ b/roles/engineblock/templates/engineblock.ini.j2
@@ -1,6 +1,9 @@
 ;; EngineBlock version
 version = {{ engine_version }}
 
+base_domain = {{ engine_base_domain }}
+hostname = engine.{{ engine_base_domain }}
+
 ;; Engineblock API Configuration
 ;; DEPRECATED, use the newer version below
 engineApi.user     = {{ engine_api_janus_user }}
@@ -99,8 +102,6 @@ trustedProxyIps[] = {{ engine_trusted_proxy_ip }}
 {% endfor %}
 
 {% endif %}
-
-base_domain = {{ engine_base_domain }}
 
 profile.baseUrl = "{{ engine_profile_baseurl }}"
 

--- a/roles/engineblock/templates/engineblock.ini.j2
+++ b/roles/engineblock/templates/engineblock.ini.j2
@@ -32,10 +32,6 @@ engineblock.feature.encrypted_assertions_require_outer_signature = {{ engine_fea
 ; Whether or not all input and output filter should run prior to consent.
 engineblock.feature.run_all_manipulations_prior_to_consent = {{ engine_feature_run_all_manipulations_prior_to_consent }}
 
-;; Symfony specific variables
-symfony.cachePath = "{{ engineblock_symfony_cache_path }}"
-symfony.logPath = "{{ engineblock_symfony_log_path }}"
-
 pdp.baseUrl = {{ engine_pdp_baseurl }}{{ engine_pdp_path }}
 pdp.host = {{ engine_pdp_baseurl }}
 pdp.policy_decision_point_path = {{ engine_pdp_path }}


### PR DESCRIPTION
EngineBlock 5.7 does not work without an explicitly configured hostname, see:

 - https://www.pivotaltracker.com/story/show/155617973
 - https://github.com/OpenConext/OpenConext-engineblock/pull/515

@quartje lots of options are obsolete in 5.7 and can be removed, they are listed under the headings "Removed metadata backends" and "Removal of legacy INI settings" in https://github.com/OpenConext/OpenConext-engineblock/blob/master/UPGRADING.md.