### PR TITLE
Adding backup opensuse repo for shibboleth yum packages

### DIFF
--- a/roles/shibboleth/files/shibboleth-centos7.repo
+++ b/roles/shibboleth/files/shibboleth-centos7.repo
@@ -2,6 +2,7 @@
 name=Shibboleth (CentOS_7)
 type=rpm-md
 baseurl=http://download.opensuse.org/repositories/security:/shibboleth/CentOS_7/
+        http://downloadcontent.opensuse.org/repositories/security:/shibboleth/CentOS_7/
 gpgcheck=1
 gpgkey=file:///etc/yum.repos.d/shibboleth.repo.gpgkey
 enabled=1


### PR DESCRIPTION
For the last week or so, there's been issues when installing libcurl-openssl has been timing out like so:
```
libcurl-openssl-7.57.0-1.1.x86 FAILED                                          
http://download.opensuse.org/repositories/security%3A/shibboleth/CentOS_7/x86_64/libcurl-openssl-7.57.0-1.1.x86_64.rpm: [Errno 12] Timeout on http://provo-mirror.op
ensuse.org/repositories/security:/shibboleth/CentOS_7/x86_64/libcurl-openssl-7.57.0-1.1.x86_64.rpm: (28, 'Operation too slow. Less than 1000 bytes/sec transferred t
he last 30 seconds')
Trying other mirror.
<repeat.. repeat>
```
I noticed that the Travis CI openconext-deploy builds have been failing with this exact error as well.
This thread talks more about it: https://www.linuxquestions.org/questions/linux-general-1/yum-update-failed-because-of-timeout-4175625075/

Yum supports multiple urls under baseurl, and this adds an extra repo to fix this issue.

I left the original repo, since that's the official Shibboleth yum repo according to their site and I imagine they'll resolve the issue at some point.