### PR TITLE
Adding engine_api_profile_password variable to secrets template

### DIFF
--- a/environments/template/secrets/skeleton.yml
+++ b/environments/template/secrets/skeleton.yml
@@ -25,6 +25,9 @@ janus_ssp_auth_admin_password: secret
 janus_ssp_secretsalt: salt
 engine_janus_secret: secret
 engine_api_janus_password: secret
+engine_api_profile_password: secret
+
+profile_secret: secret
 
 janus_teams_oauth_secret: secret
 

--- a/environments/vm/secrets/vm.yml
+++ b/environments/vm/secrets/vm.yml
@@ -28,6 +28,8 @@ janus_ssp_auth_admin_password: secret
 janus_ssp_secretsalt: 123
 engine_janus_secret: secret
 
+profile_secret: secret
+
 janus_teams_oauth_secret: secret
 
 # tomcat


### PR DESCRIPTION
The variable `engine_api_profile_password` and `profile_secret` weren't set in the secrets template file, so Ansible is defaulting to the default value `secret`  set in the [engineblock default variables](https://github.com/OpenConext/OpenConext-deploy/blob/master/roles/engineblock/defaults/main.yml#L57 )  and [profile default variables](https://github.com/OpenConext/OpenConext-deploy/blob/master/roles/profile/defaults/main.yml#L23-L24) files