### PR TITLE
Resolve file module symlink issue with Ansible 2.5

### DIFF
--- a/roles/java/tasks/main.yml
+++ b/roles/java/tasks/main.yml
@@ -10,7 +10,7 @@
   tags: java
 
 - name: Link JDK alternatives to 1.7
-  file: src=/usr/lib/jvm/jre-1.7.0-openjdk/{{ item.path }} dest=/usr/bin/{{ item.name }} state=link force=yes
+  file: src=/usr/lib/jvm/jre-1.7.0-openjdk/{{ item.path }} dest=/usr/bin/{{ item.name }} state=link force=yes follow=no
   with_items:
       - { name: 'java', path: 'bin/java' }
       - { name: 'javaws', path: 'bin/javaws' }


### PR DESCRIPTION
According to the Readme, Ansible versions >2.3 aren't supported yet, but this seems to be the only issue we've encountered when deploying fresh app servers with 2.5.

In the `file` module in Ansible 2.5, the default of  `follow=no`  was changed to `follow=yes` (https://docs.ansible.com/ansible/2.5/modules/file_module.html#parameters)

This causes a `roles/java` playbook run failure since the `javaws` is symlinked and the file doesn't exist anywhere. `javaws` is part of the `icedtea-web` package and isn't installed by OpenConext-deploy.

Another option is removing the `javaws` symlink line entirely, but I wasn't sure if it was needed by the SURFconext platform for another reason. If you'd prefer this option, I can change my branch to do that instead. Let me know

Cheers