### PR TITLE
Allow DELETE requests to engine-api for the new deprovision API

### DIFF
--- a/roles/engineblock/templates/engine-api.conf.j2
+++ b/roles/engineblock/templates/engine-api.conf.j2
@@ -32,7 +32,7 @@ Listen {{ apache_app_listen_address.engine_api }}:{{ loadbalancing.engine_api.po
 
     RewriteEngine On
     # We support only GET/POST/HEAD
-    RewriteCond %{REQUEST_METHOD} !^(POST|GET|HEAD)$
+    RewriteCond %{REQUEST_METHOD} !^(POST|DELETE|GET|HEAD)$
     RewriteRule .* - [R=405,L]
 
     #Proxy the requests to FPM


### PR DESCRIPTION
Currently only POST, GET and HEAD requests are allowed on the
EngineBlock API. The new deprovision API requires DELETE requests
which we now explicitly allow in the nginx configuration for
engine-api.

See: https://github.com/OpenConext/OpenConext-engineblock/pull/538