### PR TITLE
keepalived & HAproxy template 

### DIFF
--- a/roles/haproxy/templates/haproxy_backend_multiple.cfg.j2
+++ b/roles/haproxy/templates/haproxy_backend_multiple.cfg.j2
@@ -18,7 +18,8 @@
      option httpclose
      cookie HTTPSERVERID insert nocache indirect httponly secure maxidle {{ haproxy_cookie_max_idle }}
      {% for server in application.servers_fourthset %}
-     server {{ server.label }} {{ server.ip }}:{{ application.port }} cookie {{ server.label }} check inter 8000 fall 5 rise 2 maxconn 1024 {% if application.sslbackend is defined%} ssl verify required verifyhost {{ application.backend_vhost_name }} ca-file {{ application.backend_ca_file }} {% endif %}
+     server {{ server.label }} {{ server.ip }}:{{ application.port }} cookie {{ server.label }} check inter 8000 fall 5 rise 2 maxconn 1024 {% if application.sslbackend is defined%} ssl verify required verifyhost {{ application.backend_vhost_name }} ca-file {{ application.backend_ca_file }} 
+     {% endif %}
      {% endfor %}
     {% endfor %}
 {% else %}
@@ -39,13 +40,13 @@ backend {{ item.name }}_be
     option allbackups
     cookie HTTPSERVERID insert nocache indirect httponly secure maxidle {{ haproxy_cookie_max_idle }}
     {% for server in item.servers %}
-    server {{ server.label }} {{ server.ip }}:{{ item.port }} cookie {{ server.label }} check inter 8000 fall 5 rise 2 maxconn 1024  {% if item.sslbackend is defined %} ssl verify required verifyhost {{ item.backend_vhost_name }} ca-file {{ item.backend_ca_file }} {% endif %}
-
+    server {{ server.label }} {{ server.ip }}:{{ item.port }} cookie {{ server.label }} check inter 8000 fall 5 rise 2 maxconn 1024  {% if item.sslbackend is defined %} ssl verify required verifyhost {{ item.backend_vhost_name }} ca-file {{ item.backend_ca_file }} 
+    {% endif %}
     {% endfor %}
     {% if item.servers_backup is defined %}
     {% for server in item.servers_backup %}
-    server {{ server.label }} {{ server.ip }}:{{ item.port }} cookie {{ server.label }} check inter 8000 fall 5 rise 2 maxconn 1024 backup {% if item.sslbackend is defined%} ssl verify required verifyhost {{ item.backend_vhost_name }} ca-file {{ item.backend_ca_file }} {% endif %}
-
+    server {{ server.label }} {{ server.ip }}:{{ item.port }} cookie {{ server.label }} check inter 8000 fall 5 rise 2 maxconn 1024 backup {% if item.sslbackend is defined%} ssl verify required verifyhost {{ item.backend_vhost_name }} ca-file {{ item.backend_ca_file }} 
+    {% endif %}
     {% endfor %}
     {% endif %}
 {% endif %}

--- a/roles/keepalived/templates/keepalived_loadbalancer.conf.j2
+++ b/roles/keepalived/templates/keepalived_loadbalancer.conf.j2
@@ -8,8 +8,7 @@ vrrp_instance master {
    advert_int 5
    virtual_ipaddress {
        {{ engine_ip }}
-       {{ bind_ip }}
-   
+       {{ bind_ip }} 
    }
    virtual_ipaddress_excluded {
        {% if engine_ipv6 is defined %}


### PR DESCRIPTION
Removed an newline in the keepalived template & Edited the HAproxy template, so a new line is used after the backend and frondend server definition.