### PR TITLE
Adding coin:supports_idp_init_login metadata field for service providers

### DIFF
--- a/roles/manage-server/files/metadata_configuration/saml20_sp.schema.json
+++ b/roles/manage-server/files/metadata_configuration/saml20_sp.schema.json
@@ -378,6 +378,11 @@
           "format": "url",
           "info": "The URL of the service used to log on."
         },
+        "coin:supports_idp_init_login": {
+          "type": "string",
+          "format": "boolean",
+          "info": "The service provider supports IDP initiated login."
+        },
         "coin:transparant_issuer": {
           "type": "string",
           "format": "boolean",


### PR DESCRIPTION
As per Issue https://github.com/OpenConext/OpenConext-deploy/issues/183, this adds supports to Manage SP metadata on whether the SP supports IDP initiated login.

