### PR TITLE
Add coin:original_metadata_certData key

### DIFF
--- a/roles/manage-server/files/metadata_configuration/saml20_sp.schema.json
+++ b/roles/manage-server/files/metadata_configuration/saml20_sp.schema.json
@@ -413,6 +413,11 @@
           "format": "url",
           "info": "The provided URL to the metadata of the service."
         },
+        "coin:original_metadata_certData": {
+          "type": "string",
+          "format": "certificate",
+          "info": "The signing certificate of the metadata of the service. This must be a PEM encoded certificate. DER, CRT or CER are not supported."
+        },
         "coin:service_team_id": {
           "type": "string",
           "info": "Enter the team name as used in the SP Dashboard. e.g. urn:collab:group:example-teams.nl:nl:surfnet:services:spd_example. "


### PR DESCRIPTION
Add coin:original_metadata_certData key to support automated metadata validation in case of SP metadata updates. Especially useful for edugain SPs because of the need to publish original metadata.