### PR TITLE
Remove Janus references from eb.ini file

### DIFF
--- a/environments/template/secrets/skeleton.yml
+++ b/environments/template/secrets/skeleton.yml
@@ -21,7 +21,7 @@ mongo_passwords:
 mongo_admin_password: secret 
 
 engine_janus_secret: secret
-engine_api_janus_password: secret
+engine_api_metadata_push_password: secret
 engine_api_profile_password: secret
 engine_api_deprovision_password: secret
 

--- a/environments/vm/secrets/vm.yml
+++ b/environments/vm/secrets/vm.yml
@@ -39,7 +39,7 @@ teams_authz_client_secret: secret
 teams_migration_secret_key: secret
 
 engineblock_authz_client_secret: secret
-engine_api_janus_password: secret
+engine_api_metadata_push_password: secret
 engine_api_profile_password: secret
 engine_api_deprovision_password: secret
 

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -25,7 +25,7 @@ tls_dh_param_keysize: 2048
 
 # Some engineblock variables are shared between applications
 engine_api_domain: engine-api.{{ base_domain }}
-engine_api_janus_user: serviceregistry
+engine_api_metadata_push_user: serviceregistry
 
 # Some deprovision variables are shared between applications
 authz_server_api_lifecycle_username: authz_server_api_lifecycle_user

--- a/roles/engineblock/templates/engineblock.ini.j2
+++ b/roles/engineblock/templates/engineblock.ini.j2
@@ -5,8 +5,8 @@ base_domain = {{ engine_base_domain }}
 hostname = engine.{{ engine_base_domain }}
 
 ;; Engineblock API Configuration
-engineApi.users.janus.username = {{ engine_api_janus_user }}
-engineApi.users.janus.password = {{ engine_api_janus_password }}
+engineApi.users.metadataPush.username = {{ engine_api_metadata_push_user }}
+engineApi.users.metadataPush.password = {{ engine_api_metadata_push_password }}
 engineApi.users.profile.username = {{ engine_api_profile_user }}
 engineApi.users.profile.password = {{ engine_api_profile_password }}
 engineApi.users.deprovision.username = {{ engine_api_deprovision_user }}

--- a/roles/janus/templates/janus/config/config_janus_core.yml.j2
+++ b/roles/janus/templates/janus/config/config_janus_core.yml.j2
@@ -15,7 +15,7 @@ janus_service_registry_core:
         remote:
             test:
                 name: "{{ instance_name }} EngineBlock"
-                url: "https://{{ engine_api_janus_user }}:{{ engine_api_janus_password }}@{{ engine_api_domain }}/api/connections"
+                url: "https://{{ engine_api_metadata_push_user }}:{{ engine_api_metadata_push_password }}@{{ engine_api_domain }}/api/connections"
     entity:
         prettyname: 'name:en'
         useblacklist: false

--- a/roles/manage-server/templates/application.yml.j2
+++ b/roles/manage-server/templates/application.yml.j2
@@ -18,8 +18,8 @@ features: {{ manage.features }}
 
 push:
   url: https://{{ engine_api_domain }}/api/connections
-  user: {{ engine_api_janus_user }}
-  password: {{ engine_api_janus_password }}
+  user: {{ engine_api_metadata_push_user }}
+  password: {{ engine_api_metadata_push_password }}
   name: {{ instance_name }} EngineBlock
 
 product:


### PR DESCRIPTION
This is part of the cleanup that was performed in
OpenConext-engineblock. When building a new EngineBlock development env,
EB will fail on invalid configuration that is provided in the two ini
files. The application.ini file (override) was updated in the EB repo.
The one written to /etc/openconext was yet to be updated.

And that is taken care of in this PR.

See https://github.com/OpenConext/OpenConext-engineblock/pull/581