### PR TITLE
Deploy pdp role after manage role

### DIFF
--- a/provision-template.yml
+++ b/provision-template.yml
@@ -72,6 +72,8 @@
   roles:
     - { role: java,              tags: ['java'                     ]  }
     - { role: shibboleth,        tags: ['shib'                     ]  }
+    - { role: manage-gui,        tags: ['manage', 'manage-gui'] }
+    - { role: manage-server,     tags: ['manage', 'manage-server'] }
     - { role: teams-gui,         tags: ['teams', 'teams-gui'       ], when: not minimal_install }
     - { role: teams-server,      tags: ['teams', 'teams-server'    ], when: not minimal_install }
     - { role: mujina-idp,        tags: ['legacy','mujina'          ], when: not minimal_install }
@@ -84,8 +86,6 @@
     - { role: pdp-gui,           tags: ['pdp', 'pdp-gui'           ], when: not minimal_install  }
     - { role: attribute-aggregation-gui,    tags: ['attribute-aggregation', 'attribute-aggregation-gui'], when: not minimal_install }
     - { role: attribute-aggregation-server, tags: ['attribute-aggregation', 'attribute-aggregation-server'] ,when: not minimal_install }
-    - { role: manage-gui,        tags: ['manage', 'manage-gui'] }
-    - { role: manage-server,     tags: ['manage', 'manage-server'] }
     - { role: vm_only_provision_manage_eb, tags: ['vm_only_provision_manage_eb'] }
 
 

--- a/provision-test2.yml
+++ b/provision-test2.yml
@@ -77,6 +77,8 @@
     - { role: tomcat,                       tags: ['tomcat'] }
     - { role: java,                         tags: ['java'] }
     - { role: shibboleth,                   tags: ['shib'   ] }
+    - { role: manage-gui,                   tags: ['manage', 'manage-gui'] }
+    - { role: manage-server,                tags: ['manage', 'manage-server'] }
     - { role: teams-gui,                    tags: ['teams', 'teams-gui'  ] }
     - { role: teams-server,                 tags: ['teams', 'teams-server'  ] }
     - { role: mujina-idp,                   tags: ['mujina','mujina-idp' ] }
@@ -90,8 +92,6 @@
     - { role: oidc,                         tags: ['oidc'] }
     - { role: attribute-aggregation-gui,    tags: ['attribute-aggregation', 'attribute-aggregation-gui'] }
     - { role: attribute-aggregation-server, tags: ['attribute-aggregation', 'attribute-aggregation-server'] }
-    - { role: manage-gui,                   tags: ['manage', 'manage-gui'] }
-    - { role: manage-server,                tags: ['manage', 'manage-server'] }
     - { role: dashboard-gui,                tags: ['dashboard', 'dashboard-gui'] }
     - { role: dashboard-server,             tags: ['dashboard', 'dashboard-server'] }
     - { role: attribute-mapper,             tags: ['attribute-mapper'] }

--- a/provision-vm.yml
+++ b/provision-vm.yml
@@ -67,6 +67,8 @@
     - { role: tomcat,            tags: ['tomcat'] }
     - { role: java,              tags: ['java'] }
     - { role: shibboleth,        tags: ['shib'   ] }
+    - { role: manage-gui,        tags: ['manage', 'manage-gui'] }
+    - { role: manage-server,     tags: ['manage', 'manage-server'] }
     - { role: teams-gui,         tags: ['teams', 'teams-gui' ] }
     - { role: teams-server,      tags: ['teams', 'teams-server' ] }
     - { role: mujina-idp,        tags: ['legacy' ] }
@@ -82,8 +84,6 @@
     - { role: oidc,              tags: ['oidc'] }
     - { role: vm_only_oidc,      tags: ['oidc'] }
     - { role: mongo,             tags: ['mongo'] }
-    - { role: manage-gui,        tags: ['manage', 'manage-gui'] }
-    - { role: manage-server,     tags: ['manage', 'manage-server'] }
     - { role: vm_only_provision_manage_eb, tags: ['vm_only_provision_manage_eb'] }
 
   handlers:


### PR DESCRIPTION
I've found that when deploying a new environment, PDP continually sends email errors about being unable to access the Manage API (since Manage isn't setup yet).

In the `provision-test.yml` file, Manage is deployed before PDP is, which is likely why this issue doesn't show up. We've recently implemented this fix and it has resolved all email errors during a fresh deployment.