### PR TITLE
Add configuration settings for memory limit for push

### DIFF
--- a/roles/engineblock/defaults/main.yml
+++ b/roles/engineblock/defaults/main.yml
@@ -80,6 +80,9 @@ engine_fpm_memory: 128M
 # When using vagrant for provisioning, it's not possible to put something in the inventory dir
 engine_crt_not_in_inventory: false
 
+# The memory limit used for the metadata push
+engine_metadata_push_memory_limit: 256M
+
 engine_idp_debugging_from_name: "{{ instance_name }} EngineBlock"
 engine_idp_debugging_from_address: "{{ noreply_email }}"
 engine_idp_debugging_to_name: "{{ instance_name }} Admin"

--- a/roles/engineblock/templates/engineblock.ini.j2
+++ b/roles/engineblock/templates/engineblock.ini.j2
@@ -43,6 +43,7 @@ attributeAggregation.baseUrl = {{ engine_attribute_aggregation_baseurl }}
 attributeAggregation.username = {{engine_attribute_aggregation_username }}
 attributeAggregation.password = "{{engine_attribute_aggregation_password }}"
 
+engineblock.metadata_push_memory_limit = {{ engine_metadata_push_memory_limit }}
 
 cookie.lang.domain = .{{ base_domain }}
 


### PR DESCRIPTION
The metadata memory limit needs to be configurable. Therefore we
need to add this setting to deploy.