### PR TITLE
added option for redirect ocsp cron log

### DIFF
--- a/roles/haproxy/tasks/multiple-instances.yml
+++ b/roles/haproxy/tasks/multiple-instances.yml
@@ -146,7 +146,7 @@
 - cron:
     name: "update ocsp info"
     special_time: hourly
-    job: /usr/local/sbin/update_ocsp
+    job: /usr/local/sbin/update_ocsp {{ ocsp_log_redirect | default('') }}
 
 - name: stop haproxy instance
   service:


### PR DESCRIPTION
Added option for redirection of oscp cron log. example value for ocsp_log_redirect
`ocsp_log_redirect: '&> /var/log/ocsp.log'`
