### PR TITLE
Feature/lifecycle provisioning

### DIFF
--- a/environments/template/group_vars/template.yml
+++ b/environments/template/group_vars/template.yml
@@ -28,7 +28,7 @@ authz_server_version: 1.3.10
 engine_version: "5.9.4"
 manage_gui_version: 3.2.13
 manage_server_version: 3.2.13
-lifecycle_version: "0.0.3"
+lifecycle_version: "0.0.5"
 monitoring_tests_version: 6.0.5
 mujina_version: 7.0.7
 oidc_version: 1.3.4

--- a/environments/template/group_vars/template.yml
+++ b/environments/template/group_vars/template.yml
@@ -28,6 +28,7 @@ authz_server_version: 1.3.10
 engine_version: "5.9.4"
 manage_gui_version: 3.2.13
 manage_server_version: 3.2.13
+lifecycle_version: "0.0.3"
 monitoring_tests_version: 6.0.5
 mujina_version: 7.0.7
 oidc_version: 1.3.4

--- a/environments/template/group_vars/template.yml
+++ b/environments/template/group_vars/template.yml
@@ -47,6 +47,7 @@ databases:
     - oidc-server
     - aaserver
     - shibboleth
+    - eb_logins 
   users:
     - { name: teamsrw, db_name: teams, password: "{{ mysql_passwords.teams }}" }
     - { name: "{{ engine_database_user }}", db_name: "{{ engine_database_name }}", password: "{{ mysql_passwords.eb }}" }
@@ -55,6 +56,7 @@ databases:
     - { name: oidc-serverrw, db_name: oidc-server, password: "{{ mysql_passwords.oidc_server }}" }
     - { name: aa-serverrw, db_name: aaserver, password: "{{ mysql_passwords.aa_server }}" }
     - { name: shibrw, db_name: shibboleth, password: "{{ mysql_passwords.shibboleth }}" }
+    - { name: lifecyclerw, db_name: eb_logins, password: "{{ mysql_passwords.lifecycle }}" }
 
 mongo_port: 27017
 mongo_cluster: false

--- a/environments/template/secrets/skeleton.yml
+++ b/environments/template/secrets/skeleton.yml
@@ -15,6 +15,7 @@ mysql_passwords:
   oidc_server: secret
   aa_server: secret
   shibboleth: secret
+  lifecycle: secret
 
 mongo_passwords:
    manage: secret

--- a/environments/template/secrets/skeleton.yml
+++ b/environments/template/secrets/skeleton.yml
@@ -105,6 +105,7 @@ manage_sp_dashboard_secret: secret
 manage_sysadmin_secret: secret
 
 lifecycle_symfony_secret: secret
+lifecycle_api_password: secret
 
 stats_oidc_client_secret: secret
 stats_oidc_crypto_pass: secret

--- a/environments/vm/secrets/vm.yml
+++ b/environments/vm/secrets/vm.yml
@@ -94,7 +94,7 @@ manage_stats_api_password: secret
 manage_prod_sp_dashboard_secret: secret
 spdashboard_symfony_secret: secret
 lifecycle_symfony_secret: secret
-
+lifecycle_api_password: secret
 monitoring_oidc_client_secret: secret
 
 engineblock_private_keys:

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -31,6 +31,7 @@ authz_server_api_lifecycle_username: authz_server_api_lifecycle_user
 teams_api_lifecycle_username: teams_api_lifecycle_user
 attribute_aggregator_api_lifecycle_username: attribute_aggregator_api_lifecycle_user
 engine_api_deprovision_user: lifecycle
+lifecycle_api_username: lifecycle
 
 influx_stats_db: log_logins
 influxdb_admin_user: admin

--- a/provision.yml
+++ b/provision.yml
@@ -85,6 +85,7 @@
     - { role: openconext-common, tags: ['eb','profile'] }
     - { role: engineblock,       tags: ['eb'      ] }
     - { role: profile,           tags: ['profile' ] }
+    - { role: lifecycle,         tags: ['lifecycle' ] }
   handlers:
     - include: roles/httpd/handlers/main.yml
 

--- a/provision.yml
+++ b/provision.yml
@@ -7,7 +7,7 @@
     tags:
      - always
 
-- hosts: loadbalancer:loadbalancer-vm:php-apps:java-apps:storage:oidc:dbcluster:sysloghost:elk
+- hosts: loadbalancer:loadbalancer-vm:php-apps:java-apps:storage:oidc:dbcluster:sysloghost:elk:lifecycle
   gather_facts: yes
   become: true
   roles:
@@ -41,7 +41,7 @@
     - { role: haproxy, tags: ['lb'] }
     - { role: bind, tags: ['bind'] }
 
-- hosts: php-apps:java-apps:oidc
+- hosts: php-apps:java-apps:oidc:lifecycle
   gather_facts: no
   become: true
   roles:
@@ -85,9 +85,16 @@
     - { role: openconext-common, tags: ['eb','profile'] }
     - { role: engineblock,       tags: ['eb'      ] }
     - { role: profile,           tags: ['profile' ] }
-    - { role: lifecycle,         tags: ['lifecycle' ] }
   handlers:
     - include: roles/httpd/handlers/main.yml
+
+- hosts: lifecycle
+  gather_facts: no
+  become: true
+  roles:
+    - { role: php56fpm,          tags: ['php'     ] }
+    - { role: lifecycle,         tags: ['lifecycle' ] }
+  handlers:
 
 - hosts: java-apps-common
   gather_facts: true

--- a/roles/keepalived/templates/keepalived_loadbalancer.conf.j2
+++ b/roles/keepalived/templates/keepalived_loadbalancer.conf.j2
@@ -100,6 +100,9 @@ vrrp_instance ipv4_apps {        # No more than 20 ip addresses in one instance
         {% if stats_ip is defined %}
         {{ stats_ip }}
         {% endif %}
+        {% if lifecycle_ip is defined %}
+        {{ lifecycle_ip }}
+        {% endif %}
    }
 }
 vrrp_instance ipv6_engine {
@@ -205,6 +208,9 @@ vrrp_instance ipv6_apps {
         {% endif %}
         {% if stats_ipv6 is defined %}
         {{ stats_ipv6 }}
+        {% endif %}
+        {% if lifecycle_ipv6 is defined %}
+        {{ lifecycle_ipv6 }}
         {% endif %}
    }
 }

--- a/roles/lifecycle/defaults/main.yml
+++ b/roles/lifecycle/defaults/main.yml
@@ -15,8 +15,10 @@ lifecycle_data_dir: /opt/openconext/OpenConext-lifecycle
 lifecycle_symfony_env: prod
 lifecycle_apache_symfony_environment: prod
 lifecycle_eb_logins_db: eb_logins
+lifecycle_db_host: localhost
 lifecycle_user_quota: 1500
 lifecycle_inactivity_period: 37
 lifecycle_api_enabled: true
 lifecycle_api_password: secret
+lifecycle_api_username: lifecycle
 

--- a/roles/lifecycle/defaults/main.yml
+++ b/roles/lifecycle/defaults/main.yml
@@ -8,3 +8,5 @@ lifecycle_symfony_env: prod
 lifecycle_eb_logins_db: eb_logins
 lifecycle_user_quota: 1500
 lifecycle_inactivity_period: 37
+lifecycle_api_enabled: true
+lifecycle_api_password: secret

--- a/roles/lifecycle/defaults/main.yml
+++ b/roles/lifecycle/defaults/main.yml
@@ -1,12 +1,22 @@
 ---
+#
+lifecycle_version: ''
+# Lifecycle installer specific variables
+lifecycle_version_dir: "{{ lifecycle_version | replace('/', '-') }}" 
+lifecycle_branch_dir: "{{ openconext_builds_dir }}/OpenConext-user-lifecycle-{{ lifecycle_branch | replace('/', '-') }}"
+lifecycle_release_dir: "{{ openconext_releases_dir }}/OpenConext-user-lifecycle-{{ lifecycle_version_dir }}" 
+lifecycle_build_path: "{{ openconext_builds_dir }}/OpenConext-user-lifecycle-{{ lifecycle_version_dir }}.tar.gz"
+lifecycle_download_url: "https://github.com/OpenConext/OpenConext-user-lifecycle/releases/download/{{ lifecycle_version }}/OpenConext-user-lifecycle-{{ lifecycle_version_dir }}.tar.gz"
+lifecycle_current_release_symlink: "{{ openconext_releases_dir }}/OpenConext-user-lifecycle"
+ 
 front_controller: app.php
 lifecycle_user: lifecycle
 lifecycle_data_dir: /opt/openconext/OpenConext-lifecycle
-lifecycle_branch: master
-lifecycle_branch_dir: /opt/openconext/builds/lifecycle
 lifecycle_symfony_env: prod
+lifecycle_apache_symfony_environment: prod
 lifecycle_eb_logins_db: eb_logins
 lifecycle_user_quota: 1500
 lifecycle_inactivity_period: 37
 lifecycle_api_enabled: true
 lifecycle_api_password: secret
+

--- a/roles/lifecycle/tasks/install-branch.yml
+++ b/roles/lifecycle/tasks/install-branch.yml
@@ -1,32 +1,21 @@
-- name: Create the shared and releases directory for the User Lifecycle app
-  file:
-    path: "{{ lifecycle_data_dir }}/{{ item }}"
-    state: directory
-    owner: root
-    group: root
-    mode: 0775
-  with_items:
-    - releases
+---
+- name: Check if target dir exists
+  stat:
+    path: "{{ lifecycle_release_dir }}"
+  register: lifecycle_dir
 
-- name: Create shared and writeable directories for logs and data
-  file:
-    path: "{{ lifecycle_data_dir }}/shared/{{ item }}"
-    state: directory
-    owner: "{{ lifecycle_user }}"
-    group: root
-    mode: 0775
-  with_items:
-    - logs
-    - sessions
-    - cache
-
-- name: Create lifecycle build dir
+- name: Create build dir
   file:
     path: "{{ lifecycle_branch_dir }}"
     state: directory
-    owner: root
-    mode: 0775
 
+  #- name: Checkout lifecycle branch
+  #git:
+  #  repo: https://github.com/OpenConext/OpenConext-lifecycle-user.git
+  #  dest: "{{ lifecycle_branch_dir }}"
+  #  version: "{{ lifecycle_branch }}"
+  #  force: yes
+  #register: lifecycle_gitclone
 - name: Copy makerelease.sh
   template:
     src: "makeRelease.sh.j2"
@@ -43,55 +32,14 @@
 - name: Unpack current version
   unarchive:
     src: "{{ openconext_builds_dir }}/Releases/OpenConext-user-lifecycle-{{ lifecycle_branch | replace('/', '_') }}.tar.gz"
-    dest: "{{ lifecycle_data_dir }}/releases"
+    dest: "{{ openconext_releases_dir }}"
     copy: no
 
-- name: Create current symlink
+- name: Activate new lifecycle branch
   file:
-    src: "{{ lifecycle_data_dir }}/releases/OpenConext-user-lifecycle-{{ lifecycle_branch | replace('/', '_') }}"
-    dest: "{{ lifecycle_data_dir }}/current"
+    src: "{{ openconext_releases_dir }}/OpenConext-user-lifecycle-{{ lifecycle_branch | replace('/', '_') }}"
+    dest: "{{ lifecycle_current_release_symlink }}"
     state: link
-
-- name: Delete config
-  file:
-    path: "{{ lifecycle_data_dir }}/current/app/{{ item }}"
-    state: absent
-  with_items:
-    - config/parameters.yml
-
-- name: Delete cache, log and sessions
-  file:
-    path: "{{ lifecycle_data_dir }}/current/var/{{ item }}"
-    state: absent
-  with_items:
-    - logs
-    - sessions
-    - cache
-
-- name: Create symlink to logs,sessions and cache
-  file:
-    src: "{{ lifecycle_data_dir }}/shared/{{ item }}"
-    dest: "{{ lifecycle_data_dir }}/releases/OpenConext-user-lifecycle-{{ lifecycle_branch | replace('/', '_') }}/var/{{ item }}"
-    owner: root
-    group: root
-    state: link
-  with_items:
-    - logs
-    - sessions
-    - cache
-
-- name: Install config file
-  template:
-    src: "parameters.yml.j2"
-    dest: "{{ lifecycle_data_dir}}/current/app/config/parameters.yml"
-
-- name: Clean the cache
-  command: bin/console cache:clear --env=prod
-  args:
-    chdir: "{{ lifecycle_data_dir }}/current/"
-
-- name: Chown the cachedir recursively again
-  file:
-    dest: "{{lifecycle_data_dir}}/shared/cache"
-    owner: "{{ lifecycle_user }}"
-    recurse: yes
+  notify:
+    - "restart httpd"
+    - "restart php-fpm"

--- a/roles/lifecycle/tasks/install-branch.yml
+++ b/roles/lifecycle/tasks/install-branch.yml
@@ -20,6 +20,13 @@
     - sessions
     - cache
 
+- name: Create lifecycle build dir
+  file:
+    path: "{{ lifecycle_branch_dir }}"
+    state: directory
+    owner: root
+    mode: 0775
+
 - name: Copy makerelease.sh
   template:
     src: "makeRelease.sh.j2"

--- a/roles/lifecycle/tasks/install-release.yml
+++ b/roles/lifecycle/tasks/install-release.yml
@@ -1,0 +1,32 @@
+---
+- name: Check if target dir exists
+  stat:
+    path: "{{ lifecycle_current_release_symlink }}" 
+    follow: no
+  register: lifecycle_dir
+
+- name: Download current version
+  get_url:
+    url: "{{ lifecycle_download_url }}" 
+    dest: "{{ lifecycle_build_path }}" 
+  register: lifecycle_download
+
+- name: Unpack current version
+  unarchive:
+    src: "{{ lifecycle_build_path }}" 
+    dest: "{{ openconext_releases_dir }}" 
+    copy: no
+  when:
+    - lifecycle_download.changed or lifecycle_dir.stat.lnk_source != lifecycle_release_dir
+
+- name: Activate new Lifecycle release
+  file:
+    src: "{{ lifecycle_release_dir }}" 
+    dest: "{{ lifecycle_current_release_symlink }}" 
+    state: link
+  notify:
+    - "restart httpd"
+    - "restart php-fpm"
+  when:
+    - lifecycle_download.changed or lifecycle_dir.stat.lnk_source != lifecycle_release_dir
+

--- a/roles/lifecycle/tasks/main.yml
+++ b/roles/lifecycle/tasks/main.yml
@@ -10,9 +10,29 @@
     createhome: no
     state: present
 
+- name: Create php session dir for lifecycle
+  file:
+    path: "{{ php_session_dir }}/lifecycle"
+    state: directory
+    owner: "{{ lifecycle_user }}"
+    group: root
+    mode: 0770
+
+- name: Install Apache vhost
+  template:
+    src: lifecycle.conf.j2
+    dest: /etc/httpd/conf.d/lifecycle.conf
+  notify: "reload httpd"
+
+- name: Install php-fpm file
+  template:
+    src: lifecycle-pool.conf.j2
+    dest: /etc/php-fpm.d/lifecycle-pool.conf
+  notify: "restart php-fpm"
+
 - name: Check if latest version is installed
   stat:
-    path: "{{ lifecycle_data_dir}}/releases/sp-dashboard-{{ lifecycle_branch }}"
+    path: "{{ lifecycle_data_dir}}/releases/OpenConext-user-lifecycle-{{ lifecycle_branch }}"
   register: branch_installed
 
 - name: Include install-branch.yml

--- a/roles/lifecycle/tasks/main.yml
+++ b/roles/lifecycle/tasks/main.yml
@@ -64,8 +64,8 @@
 
 - name: Make sure log dir has correct permissions
   file:
-    path: "{{ lifecycle_current_release_symlink }}/var/logs 
-    owner={{ lifecycle_user }}"
+    path: "{{ lifecycle_current_release_symlink }}/var/logs" 
+    owner: "{{ lifecycle_user }}"
     group: "{{ lifecycle_user }}"
     recurse: yes
   changed_when: false

--- a/roles/lifecycle/tasks/main.yml
+++ b/roles/lifecycle/tasks/main.yml
@@ -30,12 +30,55 @@
     dest: /etc/php-fpm.d/lifecycle-pool.conf
   notify: "restart php-fpm"
 
-- name: Check if latest version is installed
-  stat:
-    path: "{{ lifecycle_data_dir}}/releases/OpenConext-user-lifecycle-{{ lifecycle_branch }}"
-  register: branch_installed
-
 - name: Include install-branch.yml
   include: install-branch.yml
+  when: lifecycle_branch is defined and lifecycle_branch != ''
+
+- name: Include install-release.yml
+  include: install-release.yml
+  when: lifecycle_branch is not defined or lifecycle_branch == ''
+
+- name: Place parameters.yml
+  template:
+    src: "{{ item }}.j2"
+    dest: "{{ lifecycle_current_release_symlink }}/app/config/{{ item }}"
+    mode: 0644
+  with_items:
+    - parameters.yml
+
+- name: Create the symfony cache
+  command: bin/console cache:clear --env={{ lifecycle_apache_symfony_environment }} --no-debug
+  args:
+    chdir: "{{ lifecycle_current_release_symlink }}/"
   when:
-    - branch_installed.stat.exists == false
+    - not develop
+  changed_when: false
+
+- name: Make sure cache dir has correct permissions
+  file:
+    path: "{{ lifecycle_current_release_symlink }}/var/cache"
+    owner: "{{ lifecycle_user }}"
+    group: "{{ lifecycle_user }}"
+    recurse: yes
+  changed_when: false
+
+- name: Make sure log dir has correct permissions
+  file:
+    path: "{{ lifecycle_current_release_symlink }}/var/logs 
+    owner={{ lifecycle_user }}"
+    group: "{{ lifecycle_user }}"
+    recurse: yes
+  changed_when: false
+
+  # Remove all dirs, but keep the current version and from the rest the most recent one.
+- name: Clean up old releases
+  shell: ls -td {{ openconext_releases_dir }}/OpenConext-user-lifecycle-* | grep -v $(readlink {{ lifecycle_current_release_symlink }}) | tail -n +2 | xargs --no-run-if-empty rm -rv
+  register: clean_releases
+  changed_when: '"removed" in clean_releases.stdout'
+
+# Remove all tarballs, but keep the current version and from the rest the most recent one.
+- name: Clean up old builds
+  shell: ls -td {{ openconext_builds_dir }}/OpenConext-user-lifecycle-* {{ openconext_builds_dir }}/Releases/ | grep -v {{ lifecycle_build_path }} | tail -n +2 | xargs --no-run-if-empty rm -rv
+  register: clean_builds
+  changed_when: '"removed" in clean_builds.stdout'
+

--- a/roles/lifecycle/templates/lifecycle-pool.conf.j2
+++ b/roles/lifecycle/templates/lifecycle-pool.conf.j2
@@ -1,0 +1,224 @@
+; Create a new pool named lifecycle.
+[lifecycle]
+
+; The address on which to accept FastCGI requests.
+; Valid syntaxes are:
+;   'ip.add.re.ss:port'    - to listen on a TCP socket to a specific address on
+;                            a specific port;
+;   'port'                 - to listen on a TCP socket to all addresses on a
+;                            specific port;
+;   '/path/to/unix/socket' - to listen on a unix socket.
+; Note: This value is mandatory.
+
+; Use unix socket
+listen = /var/run/php-fpm/lifecycle-pool.sock
+; Set listen(2) backlog. A value of '-1' means unlimited.
+; Default Value: -1
+;listen.backlog = -1
+
+; List of ipv4 addresses of FastCGI clients which are allowed to connect.
+; Equivalent to the FCGI_WEB_SERVER_ADDRS environment variable in the original
+; PHP FCGI (5.2.2+). Makes sense only with a tcp listening socket. Each address
+; must be separated by a comma. If this value is left blank, connections will be
+; accepted from any ip address.
+; Default Value: any
+listen.allowed_clients = 127.0.0.1
+
+; Set permissions for unix socket, if one is used. In Linux, read/write
+; permissions must be set in order to allow connections from a web server. Many
+; BSD-derived systems allow connections regardless of permissions.
+; Default Values: user and group are set as the running user
+;                 mode is set to 0666
+listen.owner = apache
+listen.group = apache
+listen.mode = 0640
+
+; Unix user/group of processes
+; Note: The user is mandatory. If the group is not set, the default user's group
+;       will be used.
+user = {{ lifecycle_user }}
+group = {{ lifecycle_user }}
+
+; Choose how the process manager will control the number of child processes.
+; Possible Values:
+;   static  - a fixed number (pm.max_children) of child processes;
+;   dynamic - the number of child processes are set dynamically based on the
+;             following directives:
+;             pm.max_children      - the maximum number of children that can
+;                                    be alive at the same time.
+;             pm.start_servers     - the number of children created on startup.
+;             pm.min_spare_servers - the minimum number of children in 'idle'
+;                                    state (waiting to process). If the number
+;                                    of 'idle' processes is less than this
+;                                    number then some children will be created.
+;             pm.max_spare_servers - the maximum number of children in 'idle'
+;                                    state (waiting to process). If the number
+;                                    of 'idle' processes is greater than this
+;                                    number then some children will be killed.
+; Note: This value is mandatory.
+pm = ondemand
+
+; The number of child processes to be created when pm is set to 'static' and the
+; maximum number of child processes to be created when pm is set to 'dynamic'.
+; This value sets the limit on the number of simultaneous requests that will be
+; served. Equivalent to the ApacheMaxClients directive with mpm_prefork.
+; Equivalent to the PHP_FCGI_CHILDREN environment variable in the original PHP
+; CGI.
+; Note: Used when pm is set to either 'static' or 'dynamic'
+; Note: This value is mandatory.
+pm.max_children = 20
+
+; The number of child processes created on startup.
+; Note: Used only when pm is set to 'dynamic'
+; Default Value: min_spare_servers + (max_spare_servers - min_spare_servers) / 2
+;pm.start_servers = 2
+
+; The desired minimum number of idle server processes.
+; Note: Used only when pm is set to 'dynamic'
+; Note: Mandatory when pm is set to 'dynamic'
+;pm.min_spare_servers = 1
+
+; The desired maximum number of idle server processes.
+; Note: Used only when pm is set to 'dynamic'
+; Note: Mandatory when pm is set to 'dynamic'
+;pm.max_spare_servers = 5
+
+; The number of requests each child process should execute before respawning.
+; This can be useful to work around memory leaks in 3rd party libraries. For
+; endless request processing specify '0'. Equivalent to PHP_FCGI_MAX_REQUESTS.
+; Default Value: 0
+pm.max_requests = 300
+
+; The URI to view the FPM status page. If this value is not set, no URI will be
+; recognized as a status page. By default, the status page shows the following
+; information:
+;   accepted conn    - the number of request accepted by the pool;
+;   pool             - the name of the pool;
+;   process manager  - static or dynamic;
+;   idle processes   - the number of idle processes;
+;   active processes - the number of active processes;
+;   total processes  - the number of idle + active processes.
+; The values of 'idle processes', 'active processes' and 'total processes' are
+; updated each second. The value of 'accepted conn' is updated in real time.
+; Example output:
+;   accepted conn:   12073
+;   pool:             www
+;   process manager:  static
+;   idle processes:   35
+;   active processes: 65
+;   total processes:  100
+; By default the status page output is formatted as text/plain. Passing either
+; 'html' or 'json' as a query string will return the corresponding output
+; syntax. Example:
+;   http://www.foo.bar/status
+;   http://www.foo.bar/status?json
+;   http://www.foo.bar/status?html
+; Note: The value must start with a leading slash (/). The value can be
+;       anything, but it may not be a good idea to use the .php extension or it
+;       may conflict with a real PHP file.
+; Default Value: not set
+;pm.status_path = /status
+
+; The ping URI to call the monitoring page of FPM. If this value is not set, no
+; URI will be recognized as a ping page. This could be used to test from outside
+; that FPM is alive and responding, or to
+; - create a graph of FPM availability (rrd or such);
+; - remove a server from a group if it is not responding (load balancing);
+; - trigger alerts for the operating team (24/7).
+; Note: The value must start with a leading slash (/). The value can be
+;       anything, but it may not be a good idea to use the .php extension or it
+;       may conflict with a real PHP file.
+; Default Value: not set
+;ping.path = /ping
+
+; This directive may be used to customize the response of a ping request. The
+; response is formatted as text/plain with a 200 response code.
+; Default Value: pong
+;ping.response = pong
+
+; The timeout for serving a single request after which the worker process will
+; be killed. This option should be used when the 'max_execution_time' ini option
+; does not stop script execution for some reason. A value of '0' means 'off'.
+; Available units: s(econds)(default), m(inutes), h(ours), or d(ays)
+; Default Value: 0
+;request_terminate_timeout = 0
+
+; The timeout for serving a single request after which a PHP backtrace will be
+; dumped to the 'slowlog' file. A value of '0s' means 'off'.
+; Available units: s(econds)(default), m(inutes), h(ours), or d(ays)
+; Default Value: 0
+;request_slowlog_timeout = 0
+
+; The log file for slow requests
+; Default Value: not set
+; Note: slowlog is mandatory if request_slowlog_timeout is set
+slowlog = /var/log/php-fpm/www-slow.log
+
+; Set open file descriptor rlimit.
+; Default Value: system defined value
+;rlimit_files = 1024
+
+; Set max core size rlimit.
+; Possible Values: 'unlimited' or an integer greater or equal to 0
+; Default Value: system defined value
+;rlimit_core = 0
+
+; Chroot to this directory at the start. This value must be defined as an
+; absolute path. When this value is not set, chroot is not used.
+; Note: chrooting is a great security feature and should be used whenever
+;       possible. However, all PHP paths will be relative to the chroot
+;       (error_log, sessions.save_path, ...).
+; Default Value: not set
+;chroot =
+
+; Chdir to this directory at the start. This value must be an absolute path.
+; Default Value: current directory or / when chroot
+;chdir = /var/www
+
+; Redirect worker stdout and stderr into main error log. If not set, stdout and
+; stderr will be redirected to /dev/null according to FastCGI specs.
+; Default Value: no
+;catch_workers_output = yes
+
+; Limits the extensions of the main script FPM will allow to parse. This can
+; prevent configuration mistakes on the web server side. You should only limit
+; FPM to .php extensions to prevent malicious users to use other extensions to
+; exectute php code.
+; Note: set an empty value to allow all extensions.
+; Default Value: .php
+;security.limit_extensions = .php .php3 .php4 .php5
+
+; Pass environment variables like LD_LIBRARY_PATH. All $VARIABLEs are taken from
+; the current environment.
+; Default Value: clean env
+;env[HOSTNAME] = $HOSTNAME
+;env[PATH] = /usr/local/bin:/usr/bin:/bin
+;env[TMP] = /tmp
+;env[TMPDIR] = /tmp
+;env[TEMP] = /tmp
+
+; Additional php.ini defines, specific to this pool of workers. These settings
+; overwrite the values previously defined in the php.ini. The directives are the
+; same as the PHP SAPI:
+;   php_value/php_flag             - you can set classic ini defines which can
+;                                    be overwritten from PHP call 'ini_set'.
+;   php_admin_value/php_admin_flag - these directives won't be overwritten by
+;                                     PHP call 'ini_set'
+; For php_*flag, valid values are on, off, 1, 0, true, false, yes or no.
+
+; Defining 'extension' will load the corresponding shared extension from
+; extension_dir. Defining 'disable_functions' or 'disable_classes' will not
+; overwrite previously defined php.ini values, but will append the new value
+; instead.
+
+; Default Value: nothing is defined by default except the values in php.ini and
+;                specified at startup with the -d argument
+;php_admin_value[sendmail_path] = /usr/sbin/sendmail -t -i -f www@my.domain.com
+;php_flag[display_errors] = off
+php_admin_value[error_log] = /var/log/php-fpm/lifecycle-error.log
+php_admin_flag[log_errors] = on
+;php_admin_value[memory_limit] = 128M
+
+; Set session path to a directory owned by process user
+php_value[session.save_handler] = files
+php_value[session.save_path] = {{ php_session_dir }}/lifecycle

--- a/roles/lifecycle/templates/lifecycle.conf.j2
+++ b/roles/lifecycle/templates/lifecycle.conf.j2
@@ -1,0 +1,17 @@
+Listen 127.0.0.1:420
+<VirtualHost localhost:420>
+    ServerAdmin {{ apache_server_admin}}
+    DocumentRoot "{{ lifecycle_data_dir }}/current/web"
+    SetEnv SYMFONY_ENV prod
+    SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
+    <Directory "{{ lifecycle_data_dir }}/current/web">
+        Require all granted
+     	Options -MultiViews
+	RewriteEngine On
+	RewriteCond %{REQUEST_FILENAME} !-f
+	RewriteRule ^(.*)$ app.php [QSA,L]
+    </Directory>
+    ProxyPassMatch ^/(.*\.php(/.*)?)$ unix:/var/run/php-fpm/lifecycle-pool.sock|fcgi://localhost{{ lifecycle_data_dir }}current/web/$1
+    ErrorLog "|/usr/bin/logger -p local3.err  -t 'Apache-LIFECYCLE'"
+    CustomLog "|/usr/bin/logger -p local3.info  -t 'Apache-LIFECYCLE'" combined
+</VirtualHost>

--- a/roles/lifecycle/templates/lifecycle.conf.j2
+++ b/roles/lifecycle/templates/lifecycle.conf.j2
@@ -1,5 +1,9 @@
-Listen 127.0.0.1:420
-<VirtualHost localhost:420>
+{% if apache_app_listen_address.lifecycle is defined %}
+Listen {{ apache_app_listen_address.lifecycle }}:{{ loadbalancing.lifecycle.port }}
+<Virtualhost {{ apache_app_listen_address.lifecycle }}:{{ loadbalancing.lifecycle.port }}>
+{% else %}
+<Virtualhost *:443 >
+{% endif %}
     ServerAdmin {{ apache_server_admin}}
     DocumentRoot "{{ lifecycle_current_release_symlink }}/web"
     SetEnv SYMFONY_ENV prod
@@ -14,4 +18,19 @@ Listen 127.0.0.1:420
     ProxyPassMatch ^/(.*\.php(/.*)?)$ unix:/var/run/php-fpm/lifecycle-pool.sock|fcgi://localhost{{ lifecycle_current_release_symlink }}/web/$1
     ErrorLog "|/usr/bin/logger -p local3.err  -t 'Apache-LIFECYCLE'"
     CustomLog "|/usr/bin/logger -p local3.info  -t 'Apache-LIFECYCLE'" combined
+    
+    {% if haproxy_backend_tls %}
+    SSLEngine on
+    SSLCertificateFile      {{ tls.cert_path }}/backend.{{ base_domain }}.pem
+    SSLCertificateKeyFile   {{ tls.cert_private_path }}/backend.{{ base_domain }}.key
+    Include ssl_backend.conf
+    {% endif %}
+
+    {% if apache_app_listen_address.all is defined %}
+    SSLEngine on
+    SSLCertificateFile      {{ tls.cert_path }}/{{ tls_star_cert }}
+    SSLCertificateKeyFile   {{ tls.cert_private_path }}/{{ tls_star_cert_key }}
+    SSLCertificateChainFile {{ tls.cert_path_ca }}/{{ tls_ca }}
+    Include ssl_backend.conf
+    {% endif %}
 </VirtualHost>

--- a/roles/lifecycle/templates/lifecycle.conf.j2
+++ b/roles/lifecycle/templates/lifecycle.conf.j2
@@ -1,17 +1,17 @@
 Listen 127.0.0.1:420
 <VirtualHost localhost:420>
     ServerAdmin {{ apache_server_admin}}
-    DocumentRoot "{{ lifecycle_data_dir }}/current/web"
+    DocumentRoot "{{ lifecycle_current_release_symlink }}/web"
     SetEnv SYMFONY_ENV prod
     SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
-    <Directory "{{ lifecycle_data_dir }}/current/web">
+    <Directory "{{ lifecycle_current_release_symlink }}/web">
         Require all granted
      	Options -MultiViews
 	RewriteEngine On
 	RewriteCond %{REQUEST_FILENAME} !-f
 	RewriteRule ^(.*)$ app.php [QSA,L]
     </Directory>
-    ProxyPassMatch ^/(.*\.php(/.*)?)$ unix:/var/run/php-fpm/lifecycle-pool.sock|fcgi://localhost{{ lifecycle_data_dir }}current/web/$1
+    ProxyPassMatch ^/(.*\.php(/.*)?)$ unix:/var/run/php-fpm/lifecycle-pool.sock|fcgi://localhost{{ lifecycle_current_release_symlink }}/web/$1
     ErrorLog "|/usr/bin/logger -p local3.err  -t 'Apache-LIFECYCLE'"
     CustomLog "|/usr/bin/logger -p local3.info  -t 'Apache-LIFECYCLE'" combined
 </VirtualHost>

--- a/roles/lifecycle/templates/parameters.yml.j2
+++ b/roles/lifecycle/templates/parameters.yml.j2
@@ -28,8 +28,7 @@ parameters:
             verify_ssl: true
     user_quota: {{ lifecycle_user_quota }}
     inactivity_period: {{ lifecycle_inactivity_period }}
-
     # is the deprovision api enabled?
-    deprovision_api_settings_enabled: true
+    deprovision_api_settings_enabled: {{ lifecycle_api_enabled }}
     deprovision_api_settings_username: "{{ lifecycle_api_username }}"
     deprovision_api_settings_password: "{{ lifecycle_api_password }}"

--- a/roles/lifecycle/templates/parameters.yml.j2
+++ b/roles/lifecycle/templates/parameters.yml.j2
@@ -1,5 +1,5 @@
 parameters:
-    database_host: 127.0.0.1
+    database_host: {{ lifecycle_db_host }}
     database_port: 3306
     database_name: {{ lifecycle_eb_logins_db }}
     database_user: lifecyclerw

--- a/roles/profile/defaults/main.yml
+++ b/roles/profile/defaults/main.yml
@@ -51,3 +51,5 @@ profile_fpm_user: profile
 profile_fpm_port: 802
 
 profile_info_request_email: "{{ support_email }}"
+
+profile_lifecycle_enabled: true

--- a/roles/profile/defaults/main.yml
+++ b/roles/profile/defaults/main.yml
@@ -52,4 +52,5 @@ profile_fpm_port: 802
 
 profile_info_request_email: "{{ support_email }}"
 
-profile_lifecycle_enabled: true
+profile_lifecycle_enabled: false
+lifecycle_url: https://lifecycle.{{ base_domain }}/

--- a/roles/profile/templates/parameters.yml.j2
+++ b/roles/profile/templates/parameters.yml.j2
@@ -23,11 +23,11 @@ parameters:
     engineblock_api_password: '{{ engine_api_profile_password }}'
     engineblock_api_verify_ssl: {{ engine_api_verify_ssl }}
 
-    user_lifecycle_enabled: false
-    user_lifecycle_api_base_url: 'https://userlifecycle.{{ base_domain }}/'
-    user_lifecycle_api_username: dummy
-    user_lifecycle_api_password: dummy
-    user_lifecycle_api_verify_ssl: true
+    user_lifecycle_enabled: {{ profile_lifecycle_enabled }}
+    user_lifecycle_api_base_url: 'http://localhost:420/'
+    user_lifecycle_api_username: lifecycle
+    user_lifecycle_api_password: {{ lifecycle_api_password }}
+    user_lifecycle_api_verify_ssl: false
 
     attribute_aggregation_api_base_url: 'https://aa.{{ base_domain }}/aa/api/internal/'
     attribute_aggregation_api_username: '{{ engine_attribute_aggregation_username }}'

--- a/roles/profile/templates/parameters.yml.j2
+++ b/roles/profile/templates/parameters.yml.j2
@@ -24,10 +24,10 @@ parameters:
     engineblock_api_verify_ssl: {{ engine_api_verify_ssl }}
 
     user_lifecycle_enabled: {{ profile_lifecycle_enabled }}
-    user_lifecycle_api_base_url: 'http://localhost:420/'
-    user_lifecycle_api_username: lifecycle
-    user_lifecycle_api_password: {{ lifecycle_api_password }}
-    user_lifecycle_api_verify_ssl: false
+    user_lifecycle_api_base_url: '{{ lifecycle_url }}'
+    user_lifecycle_api_username: '{{ lifecycle_api_username }}'
+    user_lifecycle_api_password: '{{ lifecycle_api_password }}'
+    user_lifecycle_api_verify_ssl: true
 
     attribute_aggregation_api_base_url: 'https://aa.{{ base_domain }}/aa/api/internal/'
     attribute_aggregation_api_username: '{{ engine_attribute_aggregation_username }}'

--- a/roles/rsyslog/files/lastseen.sql
+++ b/roles/rsyslog/files/lastseen.sql
@@ -1,0 +1,7 @@
+ CREATE TABLE IF NOT EXISTS `last_login` (
+  `userid` varchar(255) NOT NULL,
+  `lastseen` date DEFAULT NULL,
+  PRIMARY KEY (`userid`),
+  UNIQUE KEY `idx_user` (`userid`),
+  KEY `idx_lastseen` (`lastseen`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8

--- a/roles/rsyslog/files/log_logins.sql
+++ b/roles/rsyslog/files/log_logins.sql
@@ -16,11 +16,3 @@ CREATE TABLE  IF NOT EXISTS  `log_logins` (
   KEY `keyid_index` (`keyid`,`loginstamp`,`spentityid`(255)),
   KEY `userid_idp_index` (`userid`(128),`idpentityid`(64))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
- CREATE TABLE IF NOT EXISTS `last_login` (
-  `userid` varchar(255) NOT NULL,
-  `lastseen` date DEFAULT NULL,
-  PRIMARY KEY (`userid`),
-  UNIQUE KEY `idx_user` (`userid`),
-  KEY `idx_lastseen` (`lastseen`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8

--- a/roles/rsyslog/tasks/process_auth_logs.yml
+++ b/roles/rsyslog/tasks/process_auth_logs.yml
@@ -7,21 +7,35 @@
       - php-mysql
     state: present
 
-- name: Copy the log_logins database table definitions
+- name: Copy the log_logins and lastseen database table definitions
   copy:
-    src: log_logins.sql
-    dest: /tmp/log_logins.sql
+    src: "{{ item }}"
+    dest: /tmp/{{ item }}
     owner: root
     mode: 0744
-
-- name: Create tables for each log_login environment
+  with_items:
+    - log_logins.sql
+    - lastseen.sql
+    
+- name: Create log_logins table for each log_login environment
   mysql_db:
-    name: "{{ item.db_name }}"
-    login_user: "{{ item.db_user }}"
-    login_password: "{{ item.db_password }}"
-    login_host: "{{ item.db_host }}"
+    name: "{{ item.db_loglogins_name }}"
+    login_user: "{{ item.db_loglogins_user }}"
+    login_password: "{{ item.db_loglogins_password }}"
+    login_host: "{{ item.db_loglogins_host }}"
     state: import
     target: /tmp/log_logins.sql
+  changed_when: false
+  with_items: "{{ rsyslog_environments.sc }}"
+
+- name: Create lastseen table for each log_login environment
+  mysql_db:
+    name: "{{ item.db_lastseen_name }}"
+    login_user: "{{ item.db_lastseen_user }}"
+    login_password: "{{ item.db_lastseen_password }}"
+    login_host: "{{ item.db_lastseen_host }}"
+    state: import
+    target: /tmp/lastseen.sql
   changed_when: false
   with_items: "{{ rsyslog_environments.sc }}"
 

--- a/roles/rsyslog/templates/parse_ebauth_to_mysql.py.j2
+++ b/roles/rsyslog/templates/parse_ebauth_to_mysql.py.j2
@@ -10,10 +10,10 @@ import json
 import MySQLdb
 from dateutil.parser import parse
 
-mysql_host="{{ item.db_host }}"
-mysql_user="{{ item.db_user }}"
-mysql_password="{{ item.db_password }}"
-mysql_db="{{ item.db_name }}"
+mysql_host="{{ item.db_loglogins_host }}"
+mysql_user="{{ item.db_loglogins_user }}"
+mysql_password="{{ item.db_loglogins_password }}"
+mysql_db="{{ item.db_loglogins_name }}"
 workdir="{{ rsyslog_dir }}/log_logins/{{ item.name}}/"
 
 db = MySQLdb.connect(mysql_host,mysql_user,mysql_password,mysql_db )

--- a/roles/rsyslog/templates/process_lastseen.php.j2
+++ b/roles/rsyslog/templates/process_lastseen.php.j2
@@ -2,9 +2,9 @@
 <?php
 $CONFIG = array(
 	'EB' => array(
-		'dsn'      => 'mysql:host={{ item.db_host }};dbname={{ item.db_name }}',
-		'user'     => '{{ item.db_user }}',
-		'password' => '{{ item.db_password }}',
+		'dsn'      => 'mysql:host={{ item.db_lastseen_host }};dbname={{ item.db_lastseen_name }}',
+		'user'     => '{{ item.db_lastseen_user }}',
+		'password' => '{{ item.db_lastseen_password }}',
 	),
 );
 


### PR DESCRIPTION
This PR adds the user-lifecycle project to OpenConext deploy. 
It also adds the option to process authentication logs from EngineBlock to mySQL, to create a "lastseen" table. This table contains all users with the date they have been 'seen' for the last time , ie the last time they performed a successful authentication.  
The user- lifecycle tool contains a command line interface to delete users that not seen for a configured amount of time. This defaults to 37 months. More information on the user lifecycle tool can be found here:
https://github.com/OpenConext/OpenConext-user-lifecycle/