### PR TITLE
Feature/manage 40

### DIFF
--- a/environments/template/group_vars/template.yml
+++ b/environments/template/group_vars/template.yml
@@ -26,8 +26,8 @@ authz_admin_version: 2.0.12
 authz_playground_version: 1.7
 authz_server_version: 1.3.10
 engine_version: "5.9.4"
-manage_gui_version: 3.2.13
-manage_server_version: 3.2.13
+manage_gui_version: 4.0.2
+manage_server_version: 4.0.2
 lifecycle_version: "0.0.5"
 monitoring_tests_version: 6.0.5
 mujina_version: 7.0.7

--- a/environments/vm/group_vars/vm.yml
+++ b/environments/vm/group_vars/vm.yml
@@ -19,8 +19,8 @@ authz_server_version: 1.3.10
 engine_version: "5.9.4"
 janus_ssp_version: 1.14.17
 janus_version: 1.23.1
-manage_gui_version: 3.2.13
-manage_server_version: 3.2.13
+manage_gui_version: 4.0.2
+manage_server_version: 4.0.2
 monitoring_tests_version: 6.0.5
 mujina_version: 7.0.7
 oidc_version: "1.3.4"

--- a/roles/manage-server/defaults/main.yml
+++ b/roles/manage-server/defaults/main.yml
@@ -9,5 +9,5 @@ manage_disclaimer_background_color: skyblue
 manage_disclaimer_content: OC
 manage_service_provider_feed_url: "http://mds.edugain.org/"
 manage_exclude_edugain_imports_in_push: true
-mange_show_oidc_rp_tab: true
+manage_show_oidc_rp_tab: false
 manage_exclude_oidc_rp_imports_in_push: false

--- a/roles/manage-server/templates/application.yml.j2
+++ b/roles/manage-server/templates/application.yml.j2
@@ -36,7 +36,7 @@ product:
   organization: {{ instance_name }}
   service_provider_feed_url: {{ manage_service_provider_feed_url }}
   supported_languages: {{ supported_language_codes }}
-  show_oidc_rp: {{ mange_show_oidc_rp_tab }}
+  show_oidc_rp: {{ manage_show_oidc_rp_tab }}
 
 metadata_configuration_path: file://{{ manage_dir }}/metadata_configuration
 metadata_templates_path: file://{{ manage_dir }}/metadata_templates

--- a/tests/travis-build.sh
+++ b/tests/travis-build.sh
@@ -69,6 +69,11 @@ echo "postfix_interfaces: ipv4" >> environments-external/travis/group_vars/travi
 # Do not install Dashboard
 echo "dashboard_install: False" >> environments-external/travis/group_vars/travis.yml
 
+# Enable oidc-ng 
+echo "manage_show_oidc_rp_tab: true" >> environments-external/travis/group_vars/travis.yml
+echo "manage_exclude_oidc_rp_imports_in_push: true" >> environments-external/travis/group_vars/travis.yml
+sed -i 's/oidc_push_enabled: false/oidc_push_enabled: true/g' environments-external/travis/group_vars/travis.yml
+
 # Create the proper host_vars file
 mv environments-external/travis/host_vars/template.yml environments-external/travis/host_vars/localhost.yml
 


### PR DESCRIPTION
This upgrades Manage to 4.0.2. 
Manage 4.0 main feature is the addition of support for oidcng. Since oidcng is still under heavy development, it defaults to disabling support for oidcng