### PR TITLE
Mongo: Added variable mongo_bind_listen_address with default of 0.0.0.0 for the mongod.conf bindIp setting.

### DIFF
--- a/roles/mongo/defaults/main.yml
+++ b/roles/mongo/defaults/main.yml
@@ -30,3 +30,5 @@ mongo:
     - { name: managerw, db_name: metadata, password: "{{ mongo_passwords.manage }}" }
     - { name: oidcsrw, db_name: oidc, password: "{{ mongo_passwords.oidcng }}" }
 
+# Listen on all addresses by default
+mongo_bind_listen_address: "0.0.0.0"

--- a/roles/mongo/files/mongo.repo
+++ b/roles/mongo/files/mongo.repo
@@ -4,3 +4,15 @@ baseurl=https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/3.4/x86_64/
 gpgcheck=1
 enabled=1
 gpgkey=https://www.mongodb.org/static/pgp/server-3.4.asc
+[mongodb-org-3.6]
+name=MongoDB Repository
+baseurl=https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/3.6/x86_64/
+gpgcheck=1
+enabled=1
+gpgkey=https://www.mongodb.org/static/pgp/server-3.6.asc
+[mongodb-org-4.0]
+name=MongoDB Repository
+baseurl=https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/4.0/x86_64/
+gpgcheck=1
+enabled=1
+gpgkey=https://www.mongodb.org/static/pgp/server-4.0.asc

--- a/roles/mongo/templates/mongod.conf.j2
+++ b/roles/mongo/templates/mongod.conf.j2
@@ -10,6 +10,7 @@ processManagement:
 
 # network interfaces
 net:
+  bindIp: {{ mongo_bind_listen_address }}
   port: 27017
 {% if mongo_tls %}
   ssl:


### PR DESCRIPTION
Mongo > 3.6 defaults the bindIp setting to localhost.