### PR TITLE
Install PHP 7.2 alongside 5.6, 7.3

### DIFF
--- a/environments/vm/playbook.yml
+++ b/environments/vm/playbook.yml
@@ -2,4 +2,3 @@
 - hosts: php-apps
   roles:
         - { role: '../../roles/vm_only_provision_manage_eb', tags: ['vm_only_provision_manage_eb'] }
-

--- a/roles/php/files/php72-fpm.conf
+++ b/roles/php/files/php72-fpm.conf
@@ -1,0 +1,138 @@
+;;;;;;;;;;;;;;;;;;;;;
+; FPM Configuration ;
+;;;;;;;;;;;;;;;;;;;;;
+
+; All relative paths in this configuration file are relative to PHP's install
+; prefix.
+
+; Include one or more files. If glob(3) exists, it is used to include a bunch of
+; files from a glob(3) pattern. This directive can be used everywhere in the
+; file.
+include=/etc/opt/remi/php72/php-fpm.d/*.conf
+
+;;;;;;;;;;;;;;;;;;
+; Global Options ;
+;;;;;;;;;;;;;;;;;;
+
+[global]
+; Pid file
+; Default Value: none
+pid = /var/opt/remi/php72/run/php-fpm/php-fpm.pid
+
+; Error log file
+; If it's set to "syslog", log is sent to syslogd instead of being written
+; in a local file.
+; Default Value: /var/opt/remi/php72/log/php-fpm.log
+;error_log = /var/opt/remi/php72/log/php-fpm/error.log
+error_log = syslog
+
+; syslog_facility is used to specify what type of program is logging the
+; message. This lets syslogd specify that messages from different facilities
+; will be handled differently.
+; See syslog(3) for possible values (ex daemon equiv LOG_DAEMON)
+; Default Value: daemon
+;syslog.facility = daemon
+
+; syslog_ident is prepended to every message. If you have multiple FPM
+; instances running on the same server, you can change the default value
+; which must suit common needs.
+; Default Value: php-fpm
+;syslog.ident = php-fpm
+
+; Log level
+; Possible Values: alert, error, warning, notice, debug
+; Default Value: notice
+;log_level = notice
+
+; Log limit on number of characters in the single line (log entry). If the
+; line is over the limit, it is wrapped on multiple lines. The limit is for
+; all logged characters including message prefix and suffix if present. However
+; the new line character does not count into it as it is present only when
+; logging to a file descriptor. It means the new line character is not present
+; when logging to syslog.
+; Default Value: 1024
+;log_limit = 4096
+
+; Log buffering specifies if the log line is buffered which means that the
+; line is written in a single write operation. If the value is false, then the
+; data is written directly into the file descriptor. It is an experimental
+; option that can potentionaly improve logging performance and memory usage
+; for some heavy logging scenarios. This option is ignored if logging to syslog
+; as it has to be always buffered.
+; Default value: yes
+;log_buffering = no
+
+; If this number of child processes exit with SIGSEGV or SIGBUS within the time
+; interval set by emergency_restart_interval then FPM will restart. A value
+; of '0' means 'Off'.
+; Default Value: 0
+;emergency_restart_threshold = 0
+
+; Interval of time used by emergency_restart_interval to determine when
+; a graceful restart will be initiated.  This can be useful to work around
+; accidental corruptions in an accelerator's shared memory.
+; Available Units: s(econds), m(inutes), h(ours), or d(ays)
+; Default Unit: seconds
+; Default Value: 0
+;emergency_restart_interval = 0
+
+; Time limit for child processes to wait for a reaction on signals from master.
+; Available units: s(econds), m(inutes), h(ours), or d(ays)
+; Default Unit: seconds
+; Default Value: 0
+;process_control_timeout = 0
+
+; The maximum number of processes FPM will fork. This has been designed to control
+; the global number of processes when using dynamic PM within a lot of pools.
+; Use it with caution.
+; Note: A value of 0 indicates no limit
+; Default Value: 0
+;process.max = 128
+
+; Specify the nice(2) priority to apply to the master process (only if set)
+; The value can vary from -19 (highest priority) to 20 (lowest priority)
+; Note: - It will only work if the FPM master process is launched as root
+;       - The pool process will inherit the master process priority
+;         unless specified otherwise
+; Default Value: no set
+;process.priority = -19
+
+; Send FPM to background. Set to 'no' to keep FPM in foreground for debugging.
+; Default Value: yes
+daemonize = yes
+
+; Set open file descriptor rlimit for the master process.
+; Default Value: system defined value
+;rlimit_files = 1024
+
+; Set max core size rlimit for the master process.
+; Possible Values: 'unlimited' or an integer greater or equal to 0
+; Default Value: system defined value
+;rlimit_core = 0
+
+; Specify the event mechanism FPM will use. The following is available:
+; - select     (any POSIX os)
+; - poll       (any POSIX os)
+; - epoll      (linux >= 2.5.44)
+; Default Value: not set (auto detection)
+;events.mechanism = epoll
+
+; When FPM is built with systemd integration, specify the interval,
+; in seconds, between health report notification to systemd.
+; Set to 0 to disable.
+; Available Units: s(econds), m(inutes), h(ours)
+; Default Unit: seconds
+; Default value: 10
+;systemd_interval = 10
+
+;;;;;;;;;;;;;;;;;;;;
+; Pool Definitions ;
+;;;;;;;;;;;;;;;;;;;;
+
+; Multiple pools of child processes may be started with different listening
+; ports and different management options.  The name of the pool will be
+; used in logs and stats. There is no limitation on the number of pools which
+; FPM can handle. Your system will tell you anyway :)
+
+; See /etc/opt/remi/php73/php-fpm.d/*.conf
+

--- a/roles/php/files/remi-php72.repo
+++ b/roles/php/files/remi-php72.repo
@@ -1,0 +1,34 @@
+# This repository only provides PHP 7.2 and its extensions
+# NOTICE: common dependencies are in "remi-safe"
+
+[remi-php72]
+name=Remi's PHP 7.2 RPM repository for Enterprise Linux 7 - $basearch
+#baseurl=http://rpms.remirepo.net/enterprise/7/php72/$basearch/
+#mirrorlist=https://rpms.remirepo.net/enterprise/7/php72/httpsmirror
+mirrorlist=http://cdn.remirepo.net/enterprise/7/php72/mirror
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-remi
+
+[remi-php72-debuginfo]
+name=Remi's PHP 7.2 RPM repository for Enterprise Linux 7 - $basearch - debuginfo
+baseurl=http://rpms.remirepo.net/enterprise/7/debug-php72/$basearch/
+enabled=0
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-remi
+
+[remi-php72-test]
+name=Remi's PHP 7.2 test RPM repository for Enterprise Linux 7 - $basearch
+#baseurl=http://rpms.remirepo.net/enterprise/7/test72/$basearch/
+#mirrorlist=https://rpms.remirepo.net/enterprise/7/test72/httpsmirror
+mirrorlist=http://cdn.remirepo.net/enterprise/7/test72/mirror
+enabled=0
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-remi
+
+[remi-php72-test-debuginfo]
+name=Remi's PHP 7.2 test RPM repository for Enterprise Linux 7 - $basearch - debuginfo
+baseurl=http://rpms.remirepo.net/enterprise/7/debug-test72/$basearch/
+enabled=0
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-remi

--- a/roles/php/handlers/main.yml
+++ b/roles/php/handlers/main.yml
@@ -4,6 +4,11 @@
     name: php-fpm
     state: restarted
 
+- name: restart php72-php-fpm
+  service:
+    name: php72-php-fpm
+    state: restarted
+
 - name: restart php73-php-fpm
   service:
     name: php73-php-fpm

--- a/roles/php/tasks/main.yml
+++ b/roles/php/tasks/main.yml
@@ -35,10 +35,22 @@
   - php-gd
   - composer
 
+- name: check for presence of the remi 72 repository file
+  stat:
+    path: "/etc/yum.repos.d/remi-php72.repo"
+  register: remi_php72_config
+
 - name: check for presence of the remi 73 repository file
   stat:
     path: "/etc/yum.repos.d/remi-php73.repo"
   register: remi_php73_config
+
+- name: Enable REMI 72 repo
+  copy:
+    src: remi-php72.repo
+    dest: /etc/yum.repos.d/remi-php72.repo
+  when:
+    - remi_php72_config.stat.exists == False
 
 - name: Enable REMI 73 repo
   copy:
@@ -46,6 +58,22 @@
       dest: /etc/yum.repos.d/remi-php73.repo
   when:
     - remi_php73_config.stat.exists == False
+
+- name: Install php-(cli,fpm) 7.2
+  yum:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - php72-php-fpm
+    - php72-php-cli
+    - php72-php-pecl-apcu
+    - php72-php-curl
+    - php72-php-mbstring
+    - php72-php-mysql
+    - php72-php-soap
+    - php72-php-xml
+    - php72-php-gd
+    - php72-php-pecl-apcu-bc
 
 - name: Install php-(cli,fpm) 7.3
   yum:
@@ -77,6 +105,16 @@
   notify:
     - "restart php-fpm"
 
+- name: Install custom PHP configuration for 7.2
+  template:
+    src: "{{ item }}.j2"
+    dest: "/etc/opt/remi/php72/php.d/{{ item }}"
+  with_items:
+    - 40-apcu.ini
+    - openconext.ini
+  notify:
+    - "restart php72-fpm"
+
 - name: Install custom PHP configuration for 7.3
   template:
     src: "{{ item }}.j2"
@@ -93,6 +131,7 @@
     state: present
   with_items:
     - php-pecl-xdebug
+    - php72-php-pecl-xdebug
     - php73-php-pecl-xdebug
   when:
     - develop
@@ -105,6 +144,15 @@
     - develop
   notify:
     - "restart php-fpm"
+
+- name: Configure PHP Xdebug for 7.2
+  template:
+    src: "xdebug.ini.j2"
+    dest: "/etc/opt/remi/php72/php.d/15-xdebug.ini"
+  when:
+    - develop
+  notify:
+    - "restart php72-fpm"
 
 - name: Configure PHP Xdebug for 7.3
   template:
@@ -122,6 +170,13 @@
   notify:
     - "restart php-fpm"
 
+- name: Put 7.2 php-fpm.conf
+  copy:
+    src: "php72-fpm.conf"
+    dest: "/etc/opt/remi/php72/php-fpm.conf"
+  notify:
+    - "restart php72-fpm"
+
 - name: Put 7.3 php-fpm.conf
   copy:
     src: "php73-fpm.conf"
@@ -132,6 +187,11 @@
 - name: Enable php-fpm
   service:
     name: php-fpm
+    enabled: yes
+
+- name: Enable php72-php-fpm
+  service:
+    name: php72-php-fpm
     enabled: yes
 
 - name: Enable php73-php-fpm
@@ -146,7 +206,14 @@
   notify:
     - "restart php-fpm"
 
-- name: Remove default www pool
+- name: Remove default www pool 7.2
+  file:
+    path: /etc/opt/remi/php72/php-fpm.d/www.conf
+    state: absent
+  notify:
+    - "restart php72-fpm"
+
+- name: Remove default www pool 7.3
   file:
     path: /etc/opt/remi/php73/php-fpm.d/www.conf
     state: absent

--- a/roles/profile/handlers/main.yml
+++ b/roles/profile/handlers/main.yml
@@ -4,6 +4,11 @@
     name: php-fpm
     state: restarted
 
+- name: restart php72-fpm
+  service:
+    name: php72-php-fpm
+    state: restarted
+
 - name: restart php73-fpm
   service:
     name: php73-php-fpm


### PR DESCRIPTION
In order to test PHP 7.2 for compatibility issues, PHP 7.2 with the PHP-FPM  and extensions are installed.