### PR TITLE
URI format for OIDC RP redirects

### DIFF
--- a/environments/template/group_vars/template.yml
+++ b/environments/template/group_vars/template.yml
@@ -412,6 +412,7 @@ manage:
   loa_values_supported:
     - http://{{ base_domain }}/assurance/loa2
     - http://{{ base_domain }}/assurance/loa3
+  oidc_rp_redirect_url_format: "uri"
 
 loadbalancing:
   engine:

--- a/environments/vm/group_vars/vm.yml
+++ b/environments/vm/group_vars/vm.yml
@@ -454,6 +454,7 @@ manage:
   loa_values_supported:
     - http://{{ base_domain }}/assurance/loa2
     - http://{{ base_domain }}/assurance/loa3
+  oidc_rp_redirect_url_format: "url"
 
 loadbalancing:
   engine:

--- a/roles/manage-server/files/metadata_configuration/oidc10_rp.schema.json.j2
+++ b/roles/manage-server/files/metadata_configuration/oidc10_rp.schema.json.j2
@@ -433,9 +433,9 @@
           "type": "array",
           "items": {
             "type": "string",
-            "format": "url"
+            "format": "{{ manage.oidc_rp_redirect_url_format }}"
           },
-          "info": "The redirect URLS of this Relying Party."
+          "info": "The redirect URI's of this Relying Party."
         },
         "scopes": {
           "type": "array",


### PR DESCRIPTION
The validation currently rejects URI's like this: nl.uva.myuva://redirect

Support such redirect URIs, for support of mobile apps.
See https://www.pivotaltracker.com/story/show/167285472