### PR TITLE
Add EB AuthnContextClassRef blacklist regex parameter

### DIFF
--- a/roles/engineblock/defaults/main.yml
+++ b/roles/engineblock/defaults/main.yml
@@ -64,6 +64,10 @@ engine_minimum_execution_time_on_invalid_received_response: 5000
 engine_time_frame_for_authentication_loop_in_seconds: 60
 engine_maximum_authentication_procedures_allowed: 5
 
+# Regex used to blacklist AuthnContextClassRef attributes from IDP's
+engine_sfo_authn_context_class_ref_blacklist_regex: ''
+
+
 ## The priority of messages that should be logged to syslog
 ## 7 = debug
 ## 6 = notices

--- a/roles/engineblock/templates/engineblock.ini.j2
+++ b/roles/engineblock/templates/engineblock.ini.j2
@@ -43,6 +43,8 @@ attributeAggregation.baseUrl = {{ engine_attribute_aggregation_baseurl }}
 attributeAggregation.username = {{engine_attribute_aggregation_username }}
 attributeAggregation.password = "{{engine_attribute_aggregation_password }}"
 
+sfo.authn_context_class_ref_blacklist_regex = "{{ engine_sfo_authn_context_class_ref_blacklist_regex }}"
+
 engineblock.metadata_push_memory_limit = {{ engine_metadata_push_memory_limit }}
 
 cookie.lang.domain = .{{ base_domain }}


### PR DESCRIPTION
Add a parameter to allow blacklist support for AuthnContextClassRef
attributes. This is used to block internallly used AuthnContextClassRef
attributes to support SFO in EB.