### PR TITLE
Mongo needs to have a replicaset configured 

### DIFF
--- a/environments/template/group_vars/template.yml
+++ b/environments/template/group_vars/template.yml
@@ -5,7 +5,6 @@ instance_name: OpenConext
 base_domain: "%base_domain%"
 support_email: help@{{ base_domain }}
 noreply_email: no-reply@{{ base_domain }}
-replica_set_name:
 smtp_server: localhost
 error_mail_to: "{{ support_email }}"
 

--- a/environments/template/inventory
+++ b/environments/template/inventory
@@ -19,6 +19,9 @@
 [mongo_servers]
 %target_host%
 
+[mongod_primary]
+%target_host%
+
 [selfsigned_certs]
 %target_host%
 
@@ -30,3 +33,4 @@ php-apps
 loadbalancer-vm
 mongo_servers
 selfsigned_certs
+mongod_primary

--- a/environments/vm/group_vars/vm.yml
+++ b/environments/vm/group_vars/vm.yml
@@ -5,7 +5,6 @@ instance_name: OpenConext
 base_domain: "vm.openconext.org"
 support_email: help@example.org
 noreply_email: no-reply@example.org
-replica_set_name:
 smtp_server: localhost
 error_mail_to: devnull@example.org
 

--- a/roles/mongo/tasks/main.yml
+++ b/roles/mongo/tasks/main.yml
@@ -145,21 +145,20 @@
     dest: "/tmp/repset_init.js"
   when:
     - mongo_primary | bool
-    - mongo_cluster | bool
 
 - name: Initialize the replication set on the primary, tls enabled
   shell: /usr/bin/mongo  -u admin -p {{ mongo_admin_pass }} --ssl --sslCAFile /etc/pki/mongo/mongo.{{ base_domain }}_ca.pem --authenticationDatabase admin /tmp/repset_init.js --host "{{mongo_hostname }}"
   when:
     - mongo_primary | bool
-    - mongo_cluster | bool
     - mongo_tls | bool
+  changed_when: false
 
 - name: Initialize the replication set on the primary
   shell: /usr/bin/mongo  -u admin -p {{ mongo_admin_pass }} --authenticationDatabase admin /tmp/repset_init.js --host 127.0.0.1
   when:
     - mongo_primary | bool
-    - mongo_cluster | bool
     - not mongo_tls | bool
+  changed_when: false
 
 - name: Create mongo database users
   mongodb_user:

--- a/roles/mongo/templates/mongod.conf.j2
+++ b/roles/mongo/templates/mongod.conf.j2
@@ -32,10 +32,8 @@ storage:
     smallFiles: true
 {% endif %}
 
-{% if mongo_tls %}
 replication:
   replSetName: {{ replica_set_name }}
-{% endif %}
 
 security: 
     authorization: enabled

--- a/roles/mongo/templates/repset_init.j2
+++ b/roles/mongo/templates/repset_init.j2
@@ -1,9 +1,13 @@
 rs.initiate( { _id: "{{ replica_set_name }}", members: [ {% for host in groups["mongod_primary"] %} { _id: {{ loop.index }}, host: "{{hostvars[host].mongo_hostname }}:{{ mongod_port }}"},  {% endfor %}   ] } );
 sleep(3000);
+{% if groups ["mongod_arbiters"] is defined %}
 {% for host in groups["mongod_arbiters"] %}
 rs.addArb("{{ hostvars[host].mongo_hostname }}:{{ mongod_port }}");
 {% endfor %}
+{% endif %}
+{% if groups ["mongod_slaves"] is defined %}
 {% for host in groups["mongod_slaves"] %}
 rs.add("{{ hostvars[host].mongo_hostname }}:{{ mongod_port }}");
 {% endfor %}
+{% endif %}
 printjson(rs.status());


### PR DESCRIPTION
Mongo needs to have a replicaset configured in order to support sessions (needed for oidcng).  This was not yet implemented for standalone nodes. This commit fixes that