### PR TITLE
Bump manage to version 4.0.6

### DIFF
--- a/environments/template/group_vars/template.yml
+++ b/environments/template/group_vars/template.yml
@@ -27,8 +27,8 @@ oidc_playground_client_version: 0.0.1
 oidc_playground_server_version: 0.0.1
 authz_server_version: 1.3.13
 engine_version: "5.10.4"
-manage_gui_version: 4.0.5
-manage_server_version: 4.0.5
+manage_gui_version: 4.0.6
+manage_server_version: 4.0.6
 lifecycle_version: "0.0.5"
 monitoring_tests_version: 6.0.5
 mujina_version: 7.0.7

--- a/environments/vm/group_vars/vm.yml
+++ b/environments/vm/group_vars/vm.yml
@@ -20,8 +20,8 @@ authz_server_version: 1.3.13
 engine_version: "5.10.4"
 janus_ssp_version: 1.14.17
 janus_version: 1.23.1
-manage_gui_version: 4.0.5
-manage_server_version: 4.0.5
+manage_gui_version: 4.0.6
+manage_server_version: 4.0.6
 monitoring_tests_version: 6.0.5
 mujina_version: 7.0.7
 oidc_version: "1.3.4"


### PR DESCRIPTION
In order to enjoy the new step-up `coins` in EngineBlock, Manage needs a version bump to 4.0.6