### PR TITLE
Use the PHP 7.2 xdebug extension

### DIFF
--- a/roles/php/tasks/main.yml
+++ b/roles/php/tasks/main.yml
@@ -99,7 +99,7 @@
 
 - name: Configure PHP Xdebug for 7.2
   template:
-    src: "xdebug.ini.j2"
+    src: "xdebug-php72.ini.j2"
     dest: "/etc/opt/remi/php72/php.d/15-xdebug.ini"
   when:
     - develop | bool

--- a/roles/php/templates/xdebug-php72.ini.j2
+++ b/roles/php/templates/xdebug-php72.ini.j2
@@ -1,0 +1,5 @@
+zend_extension = /opt/remi/php72/root/usr/lib64/php/modules/xdebug.so
+
+xdebug.remote_enable = 1
+xdebug.remote_host = 192.168.66.1
+xdebug.idekey = "PHPSTORM"


### PR DESCRIPTION
Currently we use the PHP 5.6 xdebug extension which does not work for PHP 7.2. By creating an additional xdebug ini file for the PHP 7.2 pool, with a link to the correct extension, the debug feature should now work as intended on both PHP 5.6 and 7.2 applications.

See: https://github.com/OpenConext/OpenConext-deploy/pull/233#issuecomment-532594993