### PR TITLE
removed and changed legacy brew commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,12 @@ You will need at least Vagrant 1.7. Do not use Vagrant 1.8.5, which contains a b
 
 To install both with Homebrew:
 
-    brew tap caskroom/cask
-    brew install brew-cask
     brew cask install vagrant
     brew cask install virtualbox
 
 With the above commands you get the latest versions. There might be incompatibilities. Vagrant will tell you and if you need a different version install cask versions and install the correct version of virtualbox and / or vagrant:
 
-    brew tap caskroom/versions
+    brew tap homebrew/cask-versions
     brew cask install virtualbox4330101610
 
 ## Install Ansible


### PR DESCRIPTION
In newer versions of brew it's not needed to install cask, this is already included in brew.
"brew tap caskroom/versions" will give the following error:
caskroom/versions was moved. Tap homebrew/cask-versions instead.
So I changed that to "brew tap homebrew/cask-versions"