### PR TITLE
Feature/haproxy send samesite none cookie attribute

### DIFF
--- a/roles/elk/files/logstash/core/11-core-haproxy.conf
+++ b/roles/elk/files/logstash/core/11-core-haproxy.conf
@@ -1,18 +1,25 @@
 filter {
   if [program] == "haproxy" {
     grok {
+      patterns_dir => "/etc/logstash/patterns"
       match => { "message" => "%{HAPROXYHTTPBASE}" }
     }
     useragent {
-      source => "captured_request_headers"
+      source => "request_header_user_agent"
       target => "ua"
+    }
+    mutate {
+       replace => {
+          "client_ip" =>  "%{[request_header_forwarded_for]}"
+       }
     }
     date {
        match => [ "accept_date", "dd/MMM/yyyy:HH:mm:ss.SSS" ]
     }
     mutate {
       remove_field => [ "source" ]
-      remove_field => [ "captured_request_headers" ]
+      remove_field => [ "request_header_forwarded_for" ]
+      remove_field => [ "request_header_user_agent" ]
       remove_field => [ "accept_date" ]
       remove_field => [ "haproxy_hour" ]
       remove_field => [ "haproxy_milliseconds" ]
@@ -25,4 +32,3 @@ filter {
     }
   }
 }
-

--- a/roles/elk/files/logstash/patterns/haproxy
+++ b/roles/elk/files/logstash/patterns/haproxy
@@ -1,0 +1,1 @@
+HAPROXYCAPTUREDREQUESTHEADERS %{DATA:request_header_user_agent}\|%{DATA:request_header_forwarded_for}

--- a/roles/haproxy/files/nosamesitebrowsers.lst
+++ b/roles/haproxy/files/nosamesitebrowsers.lst
@@ -1,0 +1,3 @@
+Version\/.* Safari\/
+Chrom(e|ium)\/(5[1-9]|6[0-6])
+UCBrowser

--- a/roles/haproxy/tasks/main.yml
+++ b/roles/haproxy/tasks/main.yml
@@ -139,6 +139,14 @@
   notify:
     - "reload haproxy"
 
+- name: Place file with list of browsers that do not accept samesite=none cookies
+  copy:
+    src: nosamesitebrowsers.lst
+    dest: /etc/haproxy/nosamesitebrowsers.lst
+    owner: root
+    group: root
+    mode: 0744
+
 - name: Run hapos-upd for initial OCSP responses
   shell: /usr/local/sbin/hapos-upd --partial-chain --good-only --socket /var/lib/haproxy/haproxy.stats --VAfile /etc/pki/haproxy/{{ item.name }}_haproxy.pem --cert /etc/pki/haproxy/{{ item.name }}_haproxy.pem
   with_items:

--- a/roles/haproxy/tasks/main.yml
+++ b/roles/haproxy/tasks/main.yml
@@ -145,7 +145,7 @@
     dest: /etc/haproxy/nosamesitebrowsers.lst
     owner: root
     group: root
-    mode: 0744
+    mode: 0644
 
 - name: Run hapos-upd for initial OCSP responses
   shell: /usr/local/sbin/hapos-upd --partial-chain --good-only --socket /var/lib/haproxy/haproxy.stats --VAfile /etc/pki/haproxy/{{ item.name }}_haproxy.pem --cert /etc/pki/haproxy/{{ item.name }}_haproxy.pem

--- a/roles/haproxy/templates/haproxy_backend.cfg.j2
+++ b/roles/haproxy/templates/haproxy_backend.cfg.j2
@@ -1,4 +1,24 @@
 #jinja2: lstrip_blocks: True
+#---------------------------------------------------------------------
+# public ip dummy backend
+#---------------------------------------------------------------------
+  backend dummy_backend
+  mode http
+  option httpclose
+  # We add the header agent_interal so we can build an ACL
+  http-response set-header agent_internal %[capture.req.hdr(0)] 
+  server localhost 127.0.0.1:80
+
+#---------------------------------------------------------------------
+# restricted ip dummy backend
+#---------------------------------------------------------------------
+  backend dummy_backend_restricted
+  mode http
+  option httpclose
+  # We add the header agent_interal so we can build an ACL
+  http-response set-header agent_internal %[capture.req.hdr(0)] 
+  server localhost 127.0.0.1:81
+
 {% for application in haproxy_applications %}
 #---------------------------------------------------------------------
 # {{ application.name }} backend

--- a/roles/haproxy/templates/haproxy_backend.cfg.j2
+++ b/roles/haproxy/templates/haproxy_backend.cfg.j2
@@ -27,7 +27,6 @@
   backend {{ application.name }}_be
   option httpchk {{ application.ha_method }} {{ application.ha_url }} "HTTP/1.0\r\nHost: {{ application.vhost_name }}"
 
-  option forwardfor # This sets X-Forwarded-For
   {%if application.x_forwarded_port is defined %}
   http-request set-header X-Forwarded-Port {{ application.x_forwarded_port }}
   {% endif %}

--- a/roles/haproxy/templates/haproxy_frontend.cfg.j2
+++ b/roles/haproxy/templates/haproxy_frontend.cfg.j2
@@ -2,18 +2,40 @@
 ## Frontend configuration
 
 #--------------------------------------------------------------------
-#  frontend 
+#  frontend public ips
 # -------------------------------------------------------------------
-frontend ssl_ip
+frontend internet_ip
 
     bind {{ haproxy_sni_ip.ipv4 }}:443 ssl {% for certs in haproxy_sni_ip.certs %} crt /etc/pki/haproxy/{{ certs.name }}_haproxy.pem {% endfor %} no-sslv3 alpn h2,http/1.1 transparent 
     bind {{ haproxy_sni_ip.ipv6 }}:443 ssl {% for certs in haproxy_sni_ip.certs %} crt /etc/pki/haproxy/{{ certs.name }}_haproxy.pem {% endfor %} no-sslv3 alpn h2,http/1.1 transparent 
-    http-request del-header Proxy
-    rspadd  Strict-Transport-Security:\ max-age=15768000
-    capture request header User-agent len 256
     bind {{ haproxy_sni_ip.ipv4 }}:80 transparent
     bind {{ haproxy_sni_ip.ipv6 }}:80 transparent
+    # Rewrite requests
+    # First we strip any Proxy headers
+    http-request del-header Proxy
+    # We redirect all port 80 to port 443
+    http-request redirect scheme https code 301 if !{ ssl_fc }
+    # Log the user agent in the httplogs
+    capture request header User-agent len 256
+    # Store the user agent for use in the dummy backend 
+    declare capture request len 256
+    http-request capture req.hdr(User-Agent) id 0
+    # Rewrite responses
+    # Set HSTS on all outgoing responses
+    http-response set-header Strict-Transport-Security max-age=15768000
+    # Add samesite=none to all outgoing cookies except for Safari, which is broken currently
+    http-response replace-header Set-Cookie (.*) \1;\ SameSite=None if !{ req.hdr(agent_internal) -i -m sub safari }
+    # Remove the agent_interal header again
+    http-response del-header agent_internal 
+    # We need a dummy backend in order to be able to rewrite the loadbalancer cookies
+    use_backend dummy_backend
 
+#--------------------------------------------------------------------
+#  frontend public ips localhost
+#  traffic coming back from the dummy backend ends up here
+# -------------------------------------------------------------------
+frontend local_ip
+    bind 127.0.0.1:80
     {% for application in haproxy_applications %}
     {%if application.restricted is not defined %}
     acl valid_vhost hdr(host) -i {{ application.vhost_name }}
@@ -28,7 +50,6 @@ frontend ssl_ip
     {% endif %}
 
     http-request deny if ! valid_vhost
-    http-request redirect scheme https code 301 if !{ ssl_fc }
 
     {% for application in haproxy_applications %}
     {%if application.restricted is not defined %}
@@ -45,16 +66,40 @@ frontend ssl_ip
 #--------------------------------------------------------------------
 ##  frontend restricted applications
 ## -------------------------------------------------------------------
-frontend ssl_restricted_ip
+frontend internet_restricted_ip
 
     bind {{ haproxy_sni_ip_restricted.ipv4 }}:443 ssl {% for certs in haproxy_sni_ip_restricted.certs %} crt /etc/pki/haproxy/{{ certs.name }}_haproxy.pem {% endfor %} no-sslv3 no-tlsv10 no-tlsv11 alpn h2,http/1.1 transparent 
     bind {{ haproxy_sni_ip_restricted.ipv6 }}:443 ssl  {% for certs in haproxy_sni_ip_restricted.certs %} crt /etc/pki/haproxy/{{ certs.name }}_haproxy.pem {% endfor %} no-sslv3 no-tlsv10 no-tlsv11 alpn h2,http/1.1 transparent 
-    http-request del-header Proxy
-    rspadd  Strict-Transport-Security:\ max-age=15768000
-    capture request header User-agent len 256 
     bind {{ haproxy_sni_ip_restricted.ipv4 }}:80 transparent
     bind {{ haproxy_sni_ip_restricted.ipv6 }}:80 transparent
-
+    # Rewrite requests
+    # First we strip any Proxy headers
+    http-request del-header Proxy
+    # We redirect all port 80 to port 443
+    http-request redirect scheme https code 301 if !{ ssl_fc }
+    # Log the user agent in the httplogs
+    capture request header User-agent len 256 
+    # Store the user agent for use in the dummy backend 
+    declare capture request len 256 
+    http-request capture req.hdr(User-Agent) id 0
+    # ACL
+    # Safari doesn't support samesite=none, we need an ACL to fix that
+    acl safariout hdr(agent_internal) -m sub -i safari
+    # Rewrite responses
+    # Set HSTS on all outgoing responses
+    http-response set-header Strict-Transport-Security max-age=15768000
+    # Add samesite=none to all outgoing cookies
+    http-response replace-header Set-Cookie (.*) \1;\ SameSite=None
+    # Remove the agent_interal header again
+    http-response del-header agent_internal 
+    # We need a dummy backend in order to be able to rewrite the loadbalancer cookies
+    use_backend dummy_backend_restricted
+#--------------------------------------------------------------------
+#  frontend restricted ip addresses localhost
+#  traffic coming back from the dummy backend ends up here
+# -------------------------------------------------------------------
+frontend localhost_restricted    
+    bind 127.0.0.1:81
     {% for application in haproxy_applications %}
     {%if application.restricted is defined %}
     acl valid_vhost hdr(host) -i {{ application.vhost_name }}
@@ -62,7 +107,6 @@ frontend ssl_restricted_ip
     {% endif %}
     {% endfor %}
     http-request deny if ! valid_vhost
-    http-request redirect scheme https code 301 if !{ ssl_fc }
 
     {% for application in haproxy_applications %}
     {%if application.restricted is defined %}

--- a/roles/haproxy/templates/haproxy_frontend.cfg.j2
+++ b/roles/haproxy/templates/haproxy_frontend.cfg.j2
@@ -23,8 +23,14 @@ frontend internet_ip
     # Rewrite responses
     # Set HSTS on all outgoing responses
     http-response set-header Strict-Transport-Security max-age=15768000
+    # Create ACLs to make samesite=origin execeptions for unsupported browsers
+    # See https://www.chromium.org/updates/same-site/incompatible-clients
+    acl safari hdr(agent_internal) -m reg "Version\/.* Safari\/"
+    acl chrome51to66 hdr(agent_internal) -m reg "Chrom(e|ium)\/(5[1-9]|6[0-6])"
+    acl ucbrowser hdr(agent_internal) -m sub UCBrowser
+
     # Add samesite=none to all outgoing cookies except for Safari, which is broken currently
-    http-response replace-header Set-Cookie (.*) \1;\ SameSite=None if !{ req.hdr(agent_internal) -i -m sub safari }
+    http-response replace-header Set-Cookie (.*) \1;\ SameSite=None if !chrome51to66 !safari !ucbrowser
     # Remove the agent_interal header again
     http-response del-header agent_internal 
     # We need a dummy backend in order to be able to rewrite the loadbalancer cookies
@@ -82,14 +88,16 @@ frontend internet_restricted_ip
     # Store the user agent for use in the dummy backend 
     declare capture request len 256 
     http-request capture req.hdr(User-Agent) id 0
-    # ACL
-    # Safari doesn't support samesite=none, we need an ACL to fix that
-    acl safariout hdr(agent_internal) -m sub -i safari
     # Rewrite responses
     # Set HSTS on all outgoing responses
     http-response set-header Strict-Transport-Security max-age=15768000
-    # Add samesite=none to all outgoing cookies
-    http-response replace-header Set-Cookie (.*) \1;\ SameSite=None
+    # Create ACLs to make samesite=origin execeptions for unsupported browsers
+    # See https://www.chromium.org/updates/same-site/incompatible-clients
+    acl safari hdr(agent_internal) -m reg "Version\/.* Safari\/"
+    acl chrome51to66 hdr(agent_internal) -m reg "Chrom(e|ium)\/(5[1-9]|6[0-6])"
+    acl ucbrowser hdr(agent_internal) -m sub UCBrowser
+    # Add samesite=none to all outgoing cookies except for Safari, which is broken currently
+    http-response replace-header Set-Cookie (.*) \1;\ SameSite=None if !chrome51to66 !safari !ucbrowser
     # Remove the agent_interal header again
     http-response del-header agent_internal 
     # We need a dummy backend in order to be able to rewrite the loadbalancer cookies

--- a/roles/haproxy/templates/haproxy_frontend.cfg.j2
+++ b/roles/haproxy/templates/haproxy_frontend.cfg.j2
@@ -25,12 +25,9 @@ frontend internet_ip
     http-response set-header Strict-Transport-Security max-age=15768000
     # Create ACLs to make samesite=origin execeptions for unsupported browsers
     # See https://www.chromium.org/updates/same-site/incompatible-clients
-    acl safari hdr(agent_internal) -m reg "Version\/.* Safari\/"
-    acl chrome51to66 hdr(agent_internal) -m reg "Chrom(e|ium)\/(5[1-9]|6[0-6])"
-    acl ucbrowser hdr(agent_internal) -m sub UCBrowser
-
+    acl no_same_site_uas hdr(agent_internal) -m reg -f /etc/haproxy/nosamesitebrowsers.lst
     # Add samesite=none to all outgoing cookies except for Safari, which is broken currently
-    http-response replace-header Set-Cookie (.*) \1;\ SameSite=None if !chrome51to66 !safari !ucbrowser
+    http-response replace-header Set-Cookie (.*) \1;\ SameSite=None if !no_same_site_uas
     # Remove the agent_interal header again
     http-response del-header agent_internal 
     # We need a dummy backend in order to be able to rewrite the loadbalancer cookies
@@ -93,11 +90,9 @@ frontend internet_restricted_ip
     http-response set-header Strict-Transport-Security max-age=15768000
     # Create ACLs to make samesite=origin execeptions for unsupported browsers
     # See https://www.chromium.org/updates/same-site/incompatible-clients
-    acl safari hdr(agent_internal) -m reg "Version\/.* Safari\/"
-    acl chrome51to66 hdr(agent_internal) -m reg "Chrom(e|ium)\/(5[1-9]|6[0-6])"
-    acl ucbrowser hdr(agent_internal) -m sub UCBrowser
+    acl no_same_site_uas hdr(agent_internal) -m reg -f /etc/haproxy/nosamesitebrowsers.lst
     # Add samesite=none to all outgoing cookies except for Safari, which is broken currently
-    http-response replace-header Set-Cookie (.*) \1;\ SameSite=None if !chrome51to66 !safari !ucbrowser
+    http-response replace-header Set-Cookie (.*) \1;\ SameSite=None if !no_same_site_uas
     # Remove the agent_interal header again
     http-response del-header agent_internal 
     # We need a dummy backend in order to be able to rewrite the loadbalancer cookies

--- a/roles/haproxy/templates/haproxy_frontend.cfg.j2
+++ b/roles/haproxy/templates/haproxy_frontend.cfg.j2
@@ -10,13 +10,13 @@ frontend internet_ip
     bind {{ haproxy_sni_ip.ipv6 }}:443 ssl {% for certs in haproxy_sni_ip.certs %} crt /etc/pki/haproxy/{{ certs.name }}_haproxy.pem {% endfor %} no-sslv3 alpn h2,http/1.1 transparent 
     bind {{ haproxy_sni_ip.ipv4 }}:80 transparent
     bind {{ haproxy_sni_ip.ipv6 }}:80 transparent
+    # Logging is done in the local_ip backend, otherwise all requests are logged twice
+    no log
     # Rewrite requests
     # First we strip any Proxy headers
     http-request del-header Proxy
     # We redirect all port 80 to port 443
     http-request redirect scheme https code 301 if !{ ssl_fc }
-    # Log the user agent in the httplogs
-    capture request header User-agent len 256
     # Store the user agent for use in the dummy backend 
     declare capture request len 256
     http-request capture req.hdr(User-Agent) id 0
@@ -51,7 +51,10 @@ frontend local_ip
     acl {{ application.name }} hdr(host) -i {{ application.url }}
     {% endfor %}
     {% endif %}
-
+    option httplog
+    option forwardfor
+    capture request header User-agent len 256
+    capture request header X-Forwarded-For len 128
     http-request deny if ! valid_vhost
 
     {% for application in haproxy_applications %}
@@ -75,6 +78,9 @@ frontend internet_restricted_ip
     bind {{ haproxy_sni_ip_restricted.ipv6 }}:443 ssl  {% for certs in haproxy_sni_ip_restricted.certs %} crt /etc/pki/haproxy/{{ certs.name }}_haproxy.pem {% endfor %} no-sslv3 no-tlsv10 no-tlsv11 alpn h2,http/1.1 transparent 
     bind {{ haproxy_sni_ip_restricted.ipv4 }}:80 transparent
     bind {{ haproxy_sni_ip_restricted.ipv6 }}:80 transparent
+    # Logging is done in the local_ip_restriced backend, otherwise all requests are logged twice
+    no log
+ 
     # Rewrite requests
     # First we strip any Proxy headers
     http-request del-header Proxy
@@ -109,6 +115,11 @@ frontend localhost_restricted
     acl {{ application.name }} hdr(host) -i {{ application.vhost_name }}
     {% endif %}
     {% endfor %}
+    option httplog
+    option forwardfor
+    capture request header User-agent len 256
+    capture request header X-Forwarded-For len 128
+
     http-request deny if ! valid_vhost
 
     {% for application in haproxy_applications %}

--- a/roles/haproxy/templates/haproxy_global.cfg.j2
+++ b/roles/haproxy/templates/haproxy_global.cfg.j2
@@ -33,7 +33,6 @@ global
 defaults
     mode                        http
     log                         global
-    option                      httplog
     option                      http-ignore-probes
     option                      http-server-close
     option                      forwardfor       except 127.0.0.0/8


### PR DESCRIPTION
This PR tries to work around the new default setting of Chrome for the samesite cookie attribute. The new default (samesite=origin) makes that in cross site POSTS the cookie is no longer included in the POST. This creates issues for our loadbalancing and cookies for SAML sessions.  See https://www.chromium.org/updates/same-site for more info.

In this PR, Haproxy rewrites _all_ cookies including the loadbalancer cookies, adding "samesite=none". Since there are some browser incompabilities (https://www.chromium.org/updates/same-site/incompatible-clients) ACLs are in place to recognise those, and override the rewrite behaviour
