### PR TITLE
Feature/elk timestamp enhancements

### DIFF
--- a/roles/elk/files/logstash/core/11-core-haproxy.conf
+++ b/roles/elk/files/logstash/core/11-core-haproxy.conf
@@ -7,6 +7,9 @@ filter {
       source => "captured_request_headers"
       target => "ua"
     }
+    date {
+       match => [ "accept_date", "dd/MMM/yyyy:HH:mm:ss.SSS" ]
+    }
     mutate {
       remove_field => [ "syslog_timestamp" ]
       remove_field => [ "source" ]
@@ -21,9 +24,6 @@ filter {
       remove_field => [ "haproxy_time" ]
       remove_field => [ "haproxy_year" ]
     }
-    date {
-       match => [ "accept_date", "dd/MMM/yyyy:HH:mm:ss.SSS" ]
-}
   }
 }
 

--- a/roles/elk/files/logstash/core/11-core-haproxy.conf
+++ b/roles/elk/files/logstash/core/11-core-haproxy.conf
@@ -11,7 +11,6 @@ filter {
        match => [ "accept_date", "dd/MMM/yyyy:HH:mm:ss.SSS" ]
     }
     mutate {
-      remove_field => [ "syslog_timestamp" ]
       remove_field => [ "source" ]
       remove_field => [ "captured_request_headers" ]
       remove_field => [ "accept_date" ]

--- a/roles/elk/files/logstash/sa/20-sa-mysqld.conf
+++ b/roles/elk/files/logstash/sa/20-sa-mysqld.conf
@@ -36,17 +36,7 @@ filter {
       overwrite => [ "message" ]
     }
 
-    # Because the mysql files are read from file, the syslog_timestamp is the time when this file was read, 
-    # not the time that the message was created. 
-    # Get the timestamp of the message from mysql and put it in generated_at
-    # 'if's with undefined variables can crash the logstash pipeline, leading to an unresponsive logstash.
     if "_grokparsefailure" not in [tags] {
-      # Parse mysql_timestamp into generated_at
-      date {
-        match => [ "mysql_timestamp", "YYMMdd H:mm:ss", "YYMMdd HH:mm:ss" ]
-        target => "generated_at"
-      }
-
       # Mysql syslog reports all messages at error, replace severity with severity from the actual mysql logline
       mutate {
         rename => [ "mysql_severity", "severity" ]

--- a/roles/elk/files/logstash/sa/20-sa-mysqld.conf
+++ b/roles/elk/files/logstash/sa/20-sa-mysqld.conf
@@ -19,15 +19,6 @@ filter {
       negate => true
     }
 
-    # Multline may turn timestap fields into an array
-    # Fix this by setting those fields to the first value
-    if "multiline" in [tags] {
-      mutate {
-        replace => [ "syslog_timestamp", "%{[syslog_timestamp][0]}" ]
-      }
-    }
-
-    
     # Get the (non-standard) "YYMMdd (H)H:mm:ss" formatted timestamp and severity and replace the message
     grok {
       match => { 

--- a/roles/elk/files/logstash/sa/20-sa-nginx.conf
+++ b/roles/elk/files/logstash/sa/20-sa-nginx.conf
@@ -3,16 +3,12 @@ filter {
   if [origin] == "stepup" and [program] =~ /^nginx_access*/ {
      grok {
           match => [ "message" , "%{COMBINEDAPACHELOG}"]
-          overwrite => [ "timestamp" ]
      }
      mutate {
        convert => ["response", "integer"]
        convert => ["bytes", "integer"]
        convert => ["responsetime", "float"]
 
-     }
-     date {
-       match => [ "timestamp" , "dd/MMM/YYYY:HH:mm:ss Z" ]
      }
      useragent {
        source => "agent"

--- a/roles/elk/files/logstash/sa/20-sa-stepup-authentication.conf
+++ b/roles/elk/files/logstash/sa/20-sa-stepup-authentication.conf
@@ -60,20 +60,11 @@ filter {
       if [json][_ctxt_institution] {
         mutate { replace => { "institution" => "%{[json][_ctxt_institution]}"  } }
       }
-
-      if [json][_ctxt_datetime] {
-        mutate { replace => { "stepup_authentication_timestamp" => "%{[json][_ctxt_datetime]}"  } }
-        date {
-          # Format: 2017-11-23T15:11:57+01:00
-          match => [ "stepup_authentication_timestamp", "ISO8601" ]
-        }
+      if [json][timestamp] {
+        date { match => [ "[json][timestamp]" , "UNIX" ] }
       }
-
       mutate { replace => { "severity" => "informational" } }
-
-      mutate {
-        remove_field => "json"
-      }
+      mutate { remove_field => "json" }
 
     }
 

--- a/roles/elk/files/logstash/sa/20-sa-stepup-authentication.conf
+++ b/roles/elk/files/logstash/sa/20-sa-stepup-authentication.conf
@@ -66,7 +66,6 @@ filter {
         date {
           # Format: 2017-11-23T15:11:57+01:00
           match => [ "stepup_authentication_timestamp", "ISO8601" ]
-          target => "generated_at"
         }
       }
 

--- a/roles/elk/tasks/logstash_stats.yml
+++ b/roles/elk/tasks/logstash_stats.yml
@@ -1,9 +1,7 @@
 - name: Install logstash plugins
   logstash_plugin: 
     state: present 
-    name: 
-      - logstash-filter-fingerprint
-      - logstash-output-influxdb
+    name: "logstash-filter-fingerprint logstash-output-influxdb"
 
 - name: Copy stats specific files
   template: 

--- a/roles/elk/templates/logstash/core/02-filebeat-input.conf.j2
+++ b/roles/elk/templates/logstash/core/02-filebeat-input.conf.j2
@@ -16,5 +16,9 @@ filter {
       match => { "message" =>  "%{SYSLOGBASE}?%{GREEDYDATA:message}" }
       overwrite => [ "message" ]
    }
+# We overwrite the @timestamp with the syslogtimestamp in stead of the timestamp when the log message arrives at Logstash 
+   date {
+      match => [ "timestamp" , "MMM d HH:mm:ss" ] 
+   }
 }
 

--- a/roles/elk/templates/logstash/core/13-core-ebauth.conf.j2
+++ b/roles/elk/templates/logstash/core/13-core-ebauth.conf.j2
@@ -10,7 +10,7 @@ filter {
     target => "ebauth"
 }
   date {
-     match => [ "[ebauth][context][login_stamp]", "yyyy-MM-dd'T'HH:mm:ssZZ" ]
+     match => [ "[ebauth][context][login_stamp]", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZZ" ]
 }
   de_dot {
 }   

--- a/roles/elk/templates/logstash/sa/02-sa-filebeat-input.conf.j2
+++ b/roles/elk/templates/logstash/sa/02-sa-filebeat-input.conf.j2
@@ -16,7 +16,12 @@ filter {
       match => { "message" =>  "%{SYSLOGBASE}?%{GREEDYDATA:message}" }
       overwrite => [ "message" ]
    }
+   date {
+       match => [ "timestamp" , "MMM d HH:mm:ss" ]
+   }
    mutate {
        remove_field => "agent" # Agent is added by filebeat, and clashes with the nginx agent field
+       remove_field => "timestamp" 
    }
+   
 }


### PR DESCRIPTION
This PR adds some enhancements to the timestamps in logstash: By default, at the beginning of the pipeline, the syslog timestamp is used for the default @timestamp of Elasticsearch. Where the application is logging it's timestamp as well it will overwrite the syslog generated timestamp.
