### PR TITLE
Feature/php 72 fixes

### DIFF
--- a/roles/php/files/createrundir.conf
+++ b/roles/php/files/createrundir.conf
@@ -1,0 +1,2 @@
+[Service]
+RuntimeDirectory=php-fpm

--- a/roles/php/handlers/main.yml
+++ b/roles/php/handlers/main.yml
@@ -1,5 +1,6 @@
 ---
 - name: restart php72-php-fpm
-  service:
+  systemd:
     name: php72-php-fpm
+    daemon_reload: yes
     state: restarted

--- a/roles/php/tasks/main.yml
+++ b/roles/php/tasks/main.yml
@@ -74,6 +74,13 @@
   notify:
     - "restart php72-php-fpm"
 
+- name: Put 72 php-fpm systemd override file to create the socket dir
+  copy:
+    src: "createrundir.conf"
+    dest: "/etc/systemd/system/php72-php-fpm.service.d/createrundir.conf"
+  notify:
+    - "restart php72-php-fpm"
+
 - name: Enable php72-php-fpm
   service:
     name: php72-php-fpm
@@ -96,13 +103,6 @@
       - php-mysql
       - php-soap
     state: absent
-
-# Could move sockets to a different place but that's a bit more cumbersome
-- name: Do keep php-fpm directory because sockets still live there.
-  file:
-    path: "/var/run/php-fpm/"
-    state: directory
-    mode: 0755
 
 - name: Clean up old php-fpm 5.6 config
   file:


### PR DESCRIPTION
The php72 socket dir is in tmpfs, and doesn't survive reboots. This change leaves the creation of the socket dir to systemd