### PR TITLE
Feature/haproxy samesite fix

### DIFF
--- a/roles/haproxy/files/nosamesitebrowsers.lst
+++ b/roles/haproxy/files/nosamesitebrowsers.lst
@@ -4,4 +4,4 @@ UCBrowser
 iPhone OS 12_
 iPad; CPU OS 12_
 Outlook-iOS
-(Macintosh; Intel Mac OS X 10_14_\d\) AppleWebKit\/[\.\d]+ \(KHTML, like Gecko\)$
+\(Macintosh; Intel Mac OS X 10_14_\d\) AppleWebKit\/[\.\d]+ \(KHTML, like Gecko\)$

--- a/roles/haproxy/files/nosamesitebrowsers.lst
+++ b/roles/haproxy/files/nosamesitebrowsers.lst
@@ -4,4 +4,4 @@ UCBrowser
 iPhone OS 12_
 iPad; CPU OS 12_
 Outlook-iOS
-Macintosh; Intel Mac OS X 10_14_
+(Macintosh; Intel Mac OS X 10_14_\d\) AppleWebKit\/[\.\d]+ \(KHTML, like Gecko\)$

--- a/roles/haproxy/templates/haproxy_frontend.cfg.j2
+++ b/roles/haproxy/templates/haproxy_frontend.cfg.j2
@@ -27,7 +27,7 @@ frontend internet_ip
     http-response set-header Strict-Transport-Security max-age=15768000
     # Create ACLs to make samesite=origin execeptions for unsupported browsers
     # See https://www.chromium.org/updates/same-site/incompatible-clients
-    acl no_same_site_uas hdr(agent_internal) -m reg -f /etc/haproxy/nosamesitebrowsers.lst
+    acl no_same_site_uas req.fhdr(agent_internal) -m reg -f /etc/haproxy/nosamesitebrowsers.lst
     # Add samesite=none to all outgoing cookies except for Safari, which is broken currently
     http-response replace-header Set-Cookie (.*) \1;\ SameSite=None if !no_same_site_uas
     # Remove the agent_interal header again
@@ -101,7 +101,7 @@ frontend internet_restricted_ip
     http-response set-header Strict-Transport-Security max-age=15768000
     # Create ACLs to make samesite=origin execeptions for unsupported browsers
     # See https://www.chromium.org/updates/same-site/incompatible-clients
-    acl no_same_site_uas hdr(agent_internal) -m reg -f /etc/haproxy/nosamesitebrowsers.lst
+    acl no_same_site_uas req.fhdr(agent_internal) -m reg -f /etc/haproxy/nosamesitebrowsers.lst
     # Add samesite=none to all outgoing cookies except for Safari, which is broken currently
     http-response replace-header Set-Cookie (.*) \1;\ SameSite=None if !no_same_site_uas
     # Remove the agent_interal header again


### PR DESCRIPTION
We don't send the samesite cookie parameter to MacOS 12 clients, because Safari and the embedded browser have a known bug on this platform when the samesite cookie attribute is set. However, this also leads to Chrome users on MacOS 12 not receiving the samesite cookie, and Chrome does need the attribute. 
This PR fixes that issue, and only withholds the SameSite cookie attribute from MacOS12 embedded browser (Safari was already excluded)