### PR TITLE
Remove unused support urls from EB config

### DIFF
--- a/environments/template/group_vars/template.yml
+++ b/environments/template/group_vars/template.yml
@@ -24,7 +24,7 @@ authz_playground_version: 1.7
 oidc_playground_client_version: 1.0.4
 oidc_playground_server_version: 1.0.4
 authz_server_version: 1.3.16
-engine_version: "6.2.0"
+engine_version: "6.2.1"
 manage_gui_version: 4.0.20
 manage_server_version: 4.0.20
 lifecycle_version: "0.0.5"

--- a/environments/vm/group_vars/vm.yml
+++ b/environments/vm/group_vars/vm.yml
@@ -17,7 +17,7 @@ authz_playground_version: 1.7
 oidc_playground_client_version: 1.0.4
 oidc_playground_server_version: 1.0.4
 authz_server_version: 1.3.16
-engine_version: "6.2.0"
+engine_version: "6.2.1"
 manage_gui_version: 4.0.20
 manage_server_version: 4.0.20
 monitoring_tests_version: 6.0.5

--- a/roles/engineblock/templates/parameters.yml.j2
+++ b/roles/engineblock/templates/parameters.yml.j2
@@ -184,13 +184,6 @@ parameters:
     ## given again.
     consent_store_values: true
 
-    ## terms of use openconext
-    openconext_support_url: '{{ eb_support_url | replace("%","%%") }}'
-    openconext_terms_of_use_url: '{{ eb_tos_url | replace("%","%%") }}'
-
-    ## Consent view related settings
-    openconext_support_name_id_url: '{{ eb_support_url_nameid | replace("%","%%") }}'
-
     ## Email configuration
     email_idp_debugging:
         from:


### PR DESCRIPTION
The support urls are removed in favour of translatable urls
which are configurable through translations.

See: https://github.com/OpenConext/OpenConext-engineblock/pull/851