### PR TITLE
Pass correct env var to vagrant provisioning

### DIFF
--- a/provision
+++ b/provision
@@ -88,7 +88,7 @@ then
 fi
 if [ "$env" = "devvm" ]
 then
-  env=DEV vagrant up
+  ENV=dev vagrant up
 fi
 
 


### PR DESCRIPTION
Fix a typo which prevented mounting the Enginblock source files
in the dev vm.