### PR TITLE
Install EB build tools for EB

### DIFF
--- a/roles/engineblock/tasks/build.yml
+++ b/roles/engineblock/tasks/build.yml
@@ -1,0 +1,33 @@
+- name: Get Composer installer signature.
+  uri:
+    url: https://composer.github.io/installer.sig
+    return_content: true
+  register: composer_installer_signature
+
+- name: Download Composer installer
+  get_url:
+    url: https://getcomposer.org/installer
+    dest: /tmp/composer-installer.php
+    mode: 0755
+    checksum: "sha384:{{ composer_installer_signature.content }}"
+
+- name: Run Composer installer
+  command: >
+    php72 composer-installer.php
+    chdir=/tmp
+
+- name: Move Composer into globally-accessible location.
+  command: >
+    mv /tmp/composer.phar {{ composer_path }}
+    creates={{ composer_path }}
+
+- name: Add Nodesource repositories for Node.js
+  yum:
+    name: "https://rpm.nodesource.com/pub_12.x/el/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/nodesource-release-el{{ ansible_distribution_major_version }}-1.noarch.rpm"
+    state: present
+
+- name: Ensure Node.js and npm are installed
+  yum:
+    name: "nodejs-12*"
+    state: present
+    enablerepo: nodesource

--- a/roles/engineblock/tasks/install-branch.yml
+++ b/roles/engineblock/tasks/install-branch.yml
@@ -12,40 +12,6 @@
     force: yes
   register: eb_gitclone
 
-- name: Get Composer installer signature.
-  uri:
-    url: https://composer.github.io/installer.sig
-    return_content: true
-  register: composer_installer_signature
-
-- name: Download Composer installer
-  get_url:
-    url: https://getcomposer.org/installer
-    dest: /tmp/composer-installer.php
-    mode: 0755
-    checksum: "sha384:{{ composer_installer_signature.content }}"
-
-- name: Run Composer installer
-  command: >
-    php72 composer-installer.php
-    chdir=/tmp
-
-- name: Move Composer into globally-accessible location.
-  command: >
-    mv /tmp/composer.phar {{ composer_path }}
-    creates={{ composer_path }}
-
-- name: Add Nodesource repositories for Node.js
-  yum:
-    name: "https://rpm.nodesource.com/pub_12.x/el/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/nodesource-release-el{{ ansible_distribution_major_version }}-1.noarch.rpm"
-    state: present
-
-- name: Ensure Node.js and npm are installed
-  yum:
-    name: "nodejs-12*"
-    state: present
-    enablerepo: nodesource
-
 - name: Make release
   command: "./bin/makeRelease.sh {{ engine_branch }}"
   environment:

--- a/roles/engineblock/tasks/main.yml
+++ b/roles/engineblock/tasks/main.yml
@@ -19,6 +19,11 @@
     group: root
     mode: 0770
 
+- name: Install build tools (npm, composer)
+  include: build.yml
+  when:
+    - "(engine_branch is defined and engine_branch != '') or develop"
+
 - name: Include install-release.yml
   include: install-release.yml
   when:


### PR DESCRIPTION
Composer and NPM were not installed in dev mode. This
is because they were initially always installed. But by
removing them from prod they were also missing in dev.