### PR TITLE
Add daemon-reload option to all Java systemd restart handlers

### DIFF
--- a/roles/attribute-aggregation-server/handlers/main.yml
+++ b/roles/attribute-aggregation-server/handlers/main.yml
@@ -1,9 +1,6 @@
 ---
-- name: systemctl daemon-reload
-  systemd:
-    daemon_reload: yes
-
 - name: restart attribute-aggregation
-  service:
+  systemd:
     name: attribute-aggregation
     state: restarted
+    daemon_reload: yes

--- a/roles/attribute-aggregation-server/tasks/main.yml
+++ b/roles/attribute-aggregation-server/tasks/main.yml
@@ -21,7 +21,6 @@
     src: "../../templates/spring-boot.service.j2"
     dest: "/etc/systemd/system/{{ springapp_service_name }}.service"
   notify:
-    - "systemctl daemon-reload"
     - "restart attribute-aggregation"
 
 - name: enable service

--- a/roles/attribute-mapper/handlers/main.yml
+++ b/roles/attribute-mapper/handlers/main.yml
@@ -1,9 +1,6 @@
 ---
-- name: systemctl daemon-reload
-  systemd:
-    daemon_reload: yes
-
 - name: restart attribute-mapper
-  service:
+  systemd:
     name: attribute-mapper
     state: restarted
+    daemon_reload: yes

--- a/roles/attribute-mapper/tasks/main.yml
+++ b/roles/attribute-mapper/tasks/main.yml
@@ -11,7 +11,6 @@
     src: templates/spring-boot.service.j2
     dest: "/etc/systemd/system/{{ springapp_service_name }}.service"
   notify:
-    - "systemctl daemon-reload"
     - "restart attribute-mapper"
 
 - name: Check presence of legacy init script

--- a/roles/authz-admin/handlers/main.yml
+++ b/roles/authz-admin/handlers/main.yml
@@ -1,9 +1,6 @@
 ---
-- name: systemctl daemon-reload
-  systemd:
-    daemon_reload: yes
-
 - name: restart authz-admin
-  service:
+  systemd:
     name: authz-admin
     state: restarted
+    daemon_reload: yes

--- a/roles/authz-admin/tasks/main.yml
+++ b/roles/authz-admin/tasks/main.yml
@@ -11,7 +11,6 @@
     src: "templates/spring-boot.service.j2"
     dest: "/etc/systemd/system/{{ springapp_service_name }}.service"
   notify:
-    - "systemctl daemon-reload"
     - "restart authz-admin"
 
 - name: Check presence of legacy init script

--- a/roles/authz-playground/handlers/main.yml
+++ b/roles/authz-playground/handlers/main.yml
@@ -1,9 +1,6 @@
 ---
-- name: systemctl daemon-reload
-  systemd:
-    daemon_reload: yes
-
 - name: restart authz-playground
-  service:
+  systemd:
     name: authz-playground
     state: restarted
+    daemon_reload: yes

--- a/roles/authz-playground/tasks/main.yml
+++ b/roles/authz-playground/tasks/main.yml
@@ -11,7 +11,6 @@
     src: "templates/spring-boot.service.j2"
     dest: "/etc/systemd/system/{{ springapp_service_name }}.service"
   notify:
-    - "systemctl daemon-reload"
     - "restart authz-playground"
 
 - name: Check presence of legacy init script

--- a/roles/authz-server/handlers/main.yml
+++ b/roles/authz-server/handlers/main.yml
@@ -1,9 +1,6 @@
 ---
-- name: systemctl daemon-reload
-  systemd:
-    daemon_reload: yes
-
 - name: restart authz-server
-  service:
+  systemd:
     name: authz-server
     state: restarted
+    daemon_reload: yes

--- a/roles/authz-server/tasks/main.yml
+++ b/roles/authz-server/tasks/main.yml
@@ -11,7 +11,6 @@
     src: "templates/spring-boot.service.j2"
     dest: "/etc/systemd/system/{{ springapp_service_name }}.service"
   notify:
-    - "systemctl daemon-reload"
     - "restart authz-server"
 
 - name: Check presence of legacy init script

--- a/roles/dashboard-server/handlers/main.yml
+++ b/roles/dashboard-server/handlers/main.yml
@@ -1,9 +1,6 @@
 ---
-- name: systemctl daemon-reload
-  systemd:
-    daemon_reload: yes
-
 - name: restart dashboard
-  service:
+  systemd:
     name: dashboard
+    daemon_reload: yes
     state: restarted

--- a/roles/dashboard-server/tasks/main.yml
+++ b/roles/dashboard-server/tasks/main.yml
@@ -11,7 +11,6 @@
     src: "../../templates/spring-boot.service.j2"
     dest: "/etc/systemd/system/{{ springapp_service_name }}.service"
   notify:
-    - "systemctl daemon-reload"
     - "restart dashboard"
 
 - name: enable service

--- a/roles/eduproxy/handlers/main.yml
+++ b/roles/eduproxy/handlers/main.yml
@@ -1,9 +1,6 @@
 ---
-- name: systemctl daemon-reload
-  systemd:
-    daemon_reload: yes
-
 - name: restart eduproxy
-  service:
+  systemd:
     name: eduproxy
     state: restarted
+    daemon_reload: yes

--- a/roles/eduproxy/tasks/main.yml
+++ b/roles/eduproxy/tasks/main.yml
@@ -11,7 +11,6 @@
     src: "templates/spring-boot.service.j2"
     dest: "/etc/systemd/system/{{ springapp_service_name }}.service"
   notify:
-    - "systemctl daemon-reload"
     - "restart eduproxy"
 
 - name: Check presence of legacy init script

--- a/roles/manage-server/handlers/main.yml
+++ b/roles/manage-server/handlers/main.yml
@@ -1,12 +1,9 @@
 ---
-- name: systemctl daemon-reload
-  systemd:
-    daemon_reload: yes
-
 - name: restart manage
-  service:
+  systemd:
     name: manage
     state: restarted
+    daemon_reload: yes
 
 - name: update_ca_trust
   command: update-ca-trust

--- a/roles/manage-server/tasks/main.yml
+++ b/roles/manage-server/tasks/main.yml
@@ -22,7 +22,6 @@
     src: "../../templates/spring-boot.service.j2"
     dest: "/etc/systemd/system/{{ springapp_service_name }}.service"
   notify:
-    - "systemctl daemon-reload"
     - "restart manage"
 
 - name: enable service

--- a/roles/monitoring-tests/handlers/main.yml
+++ b/roles/monitoring-tests/handlers/main.yml
@@ -1,19 +1,18 @@
 ---
-- name: systemctl daemon-reload
+- name: restart monitoring-tests
   systemd:
+    name: "{{ springapp_systemd_name }}"
+    state: restarted
     daemon_reload: yes
 
-- name: restart monitoring-tests
-  service:
-    name: "{{ springapp_service_name }}"
-    state: restarted
-
 - name: restart monitoring-tests-acc
-  service:
+  systemd:
     name: monitoring-tests-acc
     state: restarted
+    daemon_reload: yes
 
 - name: restart monitoring-tests-prd
-  service:
+  systemd:
     name: monitoring-tests-prd
     state: restarted
+    daemon_reload: yes

--- a/roles/monitoring-tests/tasks/main.yml
+++ b/roles/monitoring-tests/tasks/main.yml
@@ -11,7 +11,6 @@
     src: "../../templates/spring-boot.service.j2"
     dest: "/etc/systemd/system/{{ springapp_service_name }}.service"
   notify:
-    - "systemctl daemon-reload"
     - "restart monitoring-tests"
 
 - name: enable monitoring-tests service

--- a/roles/mujina-idp/handlers/main.yml
+++ b/roles/mujina-idp/handlers/main.yml
@@ -1,9 +1,6 @@
 ---
-- name: systemctl daemon-reload
-  systemd:
-    daemon_reload: yes
-
 - name: restart mujina-idp
   service:
     name: "{{ springapp_service_name }}"
     state: restarted
+    daemon_reload: yes

--- a/roles/mujina-idp/tasks/main.yml
+++ b/roles/mujina-idp/tasks/main.yml
@@ -5,7 +5,6 @@
 - name: Copy systemd service file
   template: src=../../templates/spring-boot.service.j2 dest=/etc/systemd/system/{{ springapp_service_name }}.service
   notify:
-    - "systemctl daemon-reload"
     - "restart mujina-idp"
 
 - name: Check presence of legacy init script

--- a/roles/mujina-sp/handlers/main.yml
+++ b/roles/mujina-sp/handlers/main.yml
@@ -1,9 +1,6 @@
 ---
-- name: systemctl daemon-reload
-  systemd:
-    daemon_reload: yes
-
 - name: restart mujina-sp
-  service:
+  systemd:
     name: "{{ springapp_service_name }}"
     state: restarted
+    daemon_reload: yes

--- a/roles/mujina-sp/tasks/main.yml
+++ b/roles/mujina-sp/tasks/main.yml
@@ -11,7 +11,6 @@
     src: "../../templates/spring-boot.service.j2"
     dest: "/etc/systemd/system/{{ springapp_service_name }}.service"
   notify:
-    - "systemctl daemon-reload"
     - "restart mujina-sp"
 
 - name: Check presence of legacy init script

--- a/roles/myconext-server/handlers/main.yml
+++ b/roles/myconext-server/handlers/main.yml
@@ -1,9 +1,6 @@
 ---
-- name: systemctl daemon-reload
-  systemd:
-    daemon_reload: yes
-
 - name: restart myconext
   service:
     name: myconext
     state: restarted
+    daemon_reload: yes

--- a/roles/myconext-server/tasks/main.yml
+++ b/roles/myconext-server/tasks/main.yml
@@ -11,7 +11,6 @@
     src: "../../templates/spring-boot.service.j2"
     dest: "/etc/systemd/system/{{ springapp_service_name }}.service"
   notify:
-    - "systemctl daemon-reload"
     - "restart myconext"
 
 - name: enable service

--- a/roles/oidc-playground-server/handlers/main.yml
+++ b/roles/oidc-playground-server/handlers/main.yml
@@ -1,9 +1,6 @@
 ---
-- name: systemctl daemon-reload
-  systemd:
-    daemon_reload: yes
-
 - name: restart oidc-playground
-  service:
+  systemd:
     name: oidc-playground
     state: restarted
+    daemon_reload: yes

--- a/roles/oidc-playground-server/tasks/main.yml
+++ b/roles/oidc-playground-server/tasks/main.yml
@@ -11,7 +11,6 @@
     src: "../../templates/spring-boot.service.j2"
     dest: "/etc/systemd/system/{{ springapp_service_name }}.service"
   notify:
-    - "systemctl daemon-reload"
     - "restart oidc-playground"
 
 - name: enable service

--- a/roles/oidcng/handlers/main.yml
+++ b/roles/oidcng/handlers/main.yml
@@ -1,9 +1,7 @@
 ---
-- name: systemctl daemon-reload
+- name: "restart oidcng"
   systemd:
-    daemon-reload: yes
-
-- name: restart oidcng
-  service:
     name: oidcng
     state: restarted
+    daemon-reload: yes
+

--- a/roles/oidcng/tasks/main.yml
+++ b/roles/oidcng/tasks/main.yml
@@ -11,7 +11,6 @@
     src: "../../templates/spring-boot.service.j2"
     dest: "/etc/systemd/system/{{ springapp_service_name }}.service"
   notify:
-    - "systemctl daemon-reload"
     - "restart oidcng"
 
 - name: enable service

--- a/roles/pdp-server/handlers/main.yml
+++ b/roles/pdp-server/handlers/main.yml
@@ -1,9 +1,6 @@
 ---
-- name: systemctl daemon-reload
-  systemd:
-      daemon_reload: yes
-
 - name: restart pdp
-  service:
+  systemd:
     name: pdp
     state: restarted
+    daemon_reload: yes

--- a/roles/pdp-server/tasks/main.yml
+++ b/roles/pdp-server/tasks/main.yml
@@ -11,7 +11,6 @@
       src: "templates/spring-boot.service.j2"
       dest: "/etc/systemd/system/{{ springapp_service_name }}.service"
   notify:
-    - "systemctl daemon-reload"
     - "restart pdp"
 
 - name: Check presence of legacy init script

--- a/roles/teams-server/handlers/main.yml
+++ b/roles/teams-server/handlers/main.yml
@@ -1,9 +1,6 @@
 ---
-- name: systemctl daemon-reload
-  systemd:
-    daemon-reload: yes
-
 - name: restart teams
-  service:
+  systemd:
     name: teams
     state: restarted
+    daemon-reload: yes

--- a/roles/teams-server/tasks/main.yml
+++ b/roles/teams-server/tasks/main.yml
@@ -11,7 +11,6 @@
     src: "../../templates/spring-boot.service.j2"
     dest: "/etc/systemd/system/{{ springapp_service_name }}.service"
   notify:
-    - "systemctl daemon-reload"
     - "restart teams"
 
 - name: enable service

--- a/roles/voot/handlers/main.yml
+++ b/roles/voot/handlers/main.yml
@@ -1,9 +1,6 @@
 ---
-- name: systemctl daemon-reload
-  systemd:
-    daemon_reload: yes
-
 - name: restart voot
-  service:
+  systemd:
     name: voot
     state: restarted
+    daemon_reload: yes

--- a/roles/voot/tasks/main.yml
+++ b/roles/voot/tasks/main.yml
@@ -11,7 +11,6 @@
     src: "templates/spring-boot.service.j2"
     dest: "/etc/systemd/system/{{ springapp_service_name }}.service"
   notify:
-    - "systemctl daemon-reload"
     - "restart voot"
 
 - name: Check presence of legacy init script


### PR DESCRIPTION
All Java apps had a seperate sytemd daemon reload handler when a systemd config file changed. However, handlers are global, and the last defined handler is executed after a notify. This is why the daemon reloads were executed _after_ the service restart. Adding the daemon reload option to the restart handler itself fixes that issue.