### PR TITLE
Only add SameSite attribute when not already present.

### DIFF
--- a/roles/haproxy/templates/haproxy_frontend.cfg.j2
+++ b/roles/haproxy/templates/haproxy_frontend.cfg.j2
@@ -26,11 +26,12 @@ frontend internet_ip
     # Create ACLs to make samesite=origin execeptions for unsupported browsers
     # See https://www.chromium.org/updates/same-site/incompatible-clients
     acl no_same_site_uas var(txn.useragent) -m reg -f /etc/haproxy/nosamesitebrowsers.lst
+    acl has_same_site_flag res.hdr(Set-Cookie) -m sub SameSite
     # Rewrite responses
     # Set HSTS on all outgoing responses
     http-response set-header Strict-Transport-Security max-age=15768000
     # Add samesite=none to all outgoing cookies except unsupported browsers
-    http-response replace-header Set-Cookie (.*) \1;\ SameSite=None if !no_same_site_uas
+    http-response replace-header Set-Cookie (.*) \1;\ SameSite=None if !no_same_site_uas !has_same_site_flag
     # We need a dummy backend in order to be able to rewrite the loadbalancer cookies
     use_backend dummy_backend
 


### PR DESCRIPTION
Several apps already publish a SameSite= attribute. Before this change this resulted in headers like
`set-cookie: _opensaml_req_https%3A%2F%2Fteams.example.org%2F=; expires=Mon, 01 Jan 2001 00:00:00 GMT; path=/; secure; HttpOnly; SameSite=None; SameSite=None`
(e.g. teams, oidcng...)