### PR TITLE
Change log path to reflect dev vm path

### DIFF
--- a/roles/engineblock/defaults/main.yml
+++ b/roles/engineblock/defaults/main.yml
@@ -88,7 +88,7 @@ engine_syslog_priority: 7
 #engine_initial_sql: ''
 
 engineblock_symfony_cache_path: "/tmp/engineblock/cache"
-engineblock_symfony_log_path: "/tmp/engineblock/log"
+engineblock_symfony_log_path: "{{ engine_current_release_symlink }}/var/logs"
 
 engine_fpm_user: engine
 engine_fpm_port: 801


### PR DESCRIPTION
In production all is logged to syslog so this wouldn't prove an issue.

See https://github.com/OpenConext/OpenConext-engineblock/pull/857