### PR TITLE
Feature/java cleanup old releases

### DIFF
--- a/roles/account-gui/tasks/main.yml
+++ b/roles/account-gui/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: create apache folder
-  file: path=/var/www/account owner=root group=root mode=2755 state=directory
+  file: path={{ account_html_dir }} owner=root group=root mode=2755 state=directory
 
 - name: copy virtual host config
   template: src=account.conf.j2 dest=/etc/httpd/conf.d/account.conf
@@ -14,14 +14,14 @@
     extension: zip
     version: "{{ account_gui_version }}"
     repository_url: "{{ maven_snapshot_repo if 'SNAPSHOT' in account_gui_version else maven_repo }}"
-    dest: /var/www/account
+    dest: "{{ account_html_dir }}"
   register: maven_result
   tags: deploy
 
 - name: extract html archive
   unarchive:
     src: "{{ maven_result.dest }}"
-    dest: /var/www/account
+    dest: "{{ account_html_dir }}"
     copy: no
     owner: root
     group: apache
@@ -37,3 +37,17 @@
     force: yes
   tags: deploy
   when: unarchive_result.changed
+
+- name: Remove old zipfiles
+  shell: 'ls -t *.zip | tail -n +3|  xargs --no-run-if-empty rm -v'
+  args:
+    chdir: "{{ account_html_dir }}" 
+  register: clean_account_zips
+  changed_when: '"removed" in clean_account_zips'
+
+- name: Remove old www directories
+  shell: 'find . ! -name $(basename $(readlink current)) -name "account-gui*" -type d  -printf "%T@  %p\n"  | sort -rn | awk ''{print $2}'' | tail -n +2 | xargs --no-run-if-empty rm -vr'
+  args:
+    chdir: "{{ account_html_dir }}" 
+  register: clean_account_wwwdirs
+  changed_when: '"removed" in clean_account_wwwdirs'

--- a/roles/account-gui/vars/main.yml
+++ b/roles/account-gui/vars/main.yml
@@ -1,3 +1,4 @@
 ---
 account_current: /var/www/account/current
 springapp_tcpport: 9189
+account_html_dir: /var/www/account/

--- a/roles/attribute-aggregation-gui/tasks/main.yml
+++ b/roles/attribute-aggregation-gui/tasks/main.yml
@@ -6,7 +6,7 @@
 
 - name: create apache folder
   file:
-    path: "/var/www/attribute-aggregation"
+    path: "{{ attribute_aggregation_html_dir }}"
     owner: root
     group: root
     mode: 02755
@@ -33,14 +33,14 @@
     extension: zip
     version: "{{ attribute_aggregation_gui_version }}"
     repository_url: "{{ maven_snapshot_repo if 'SNAPSHOT' in attribute_aggregation_gui_version else maven_repo }}"
-    dest: /var/www/attribute-aggregation
+    dest: "{{ attribute_aggregation_html_dir }}"
   register: maven_result
   tags: deploy
 
 - name: extract html archive
   unarchive:
     src: "{{ maven_result.dest }}"
-    dest: "/var/www/attribute-aggregation"
+    dest: "{{ attribute_aggregation_html_dir }}"
     copy: no
     owner: root
     group: apache
@@ -60,3 +60,18 @@
     - deploy
   when:
     - unarchive_result.changed
+
+- name: Remove old zipfiles
+  shell: 'ls -t *.zip | tail -n +3|  xargs --no-run-if-empty rm -v'
+  args:
+    chdir: "{{ attribute_aggregation_html_dir }}"
+  register: clean_attribute_aggregation_zips
+  changed_when: '"removed" in clean_attribute_aggregation_zips'
+
+- name: Remove old www directories
+  shell: 'find . ! -name $(basename $(readlink current)) -name "attribute-aggregation-gui*" -type d  -printf "%T@  %p\n"  | sort -rn | awk ''{print $2}'' | tail -n +2 | xargs --no-run-if-empty rm -vr'
+  args:
+    chdir: "{{ attribute_aggregation_html_dir }}"
+  register: clean_attribute_aggregation_wwwdirs
+  changed_when: '"removed" in clean_attribute_aggregation_wwwdirs'
+

--- a/roles/attribute-aggregation-gui/vars/main.yml
+++ b/roles/attribute-aggregation-gui/vars/main.yml
@@ -2,3 +2,4 @@
 attribute_aggregation_current: /var/www/attribute-aggregation/current
 #TODO - make this into a variable, see also attribute-aggregation-server/var/main.yml
 springapp_tcpport: 9198
+attribute_aggregation_html_dir: /var/www/attribute-aggregation/

--- a/roles/attribute-aggregation-server/tasks/main.yml
+++ b/roles/attribute-aggregation-server/tasks/main.yml
@@ -98,6 +98,10 @@
     enabled: yes
     state: started
 
-#- name: cleanup old jars
-#  shell: find . ! -name $(basename $(readlink attribute-aggregation-current.jar)) -name '*.jar' -type f -exec rm {} \; chdir={{ attribute_aggregation_dir }}
-#  when: maven_result.changed
+- name: cleanup old jars
+  shell: 'find . ! -name $(basename $(readlink attribute-aggregation-current.jar)) -name "*.jar" -type f -printf "%T@  %p\n"  | sort -rn | awk ''{print $2}'' | tail -n +2 | xargs --no-run-if-empty rm -v'
+  args:
+    chdir: "{{ attribute_aggregation_dir }}"
+  register: clean_attribute_aggregation_jars
+  changed_when: '"removed" in clean_attribute_aggregation_jars'
+

--- a/roles/authz-admin/tasks/main.yml
+++ b/roles/authz-admin/tasks/main.yml
@@ -100,3 +100,11 @@
     name: authz-admin
     enabled: yes
     state: started
+
+- name: cleanup old jars
+  shell: 'find . ! -name $(basename $(readlink authz-admin-current.jar)) -name "*.jar" -type f -printf "%T@  %p\n"  | sort -rn | awk ''{print $2}'' | tail -n +2 | xargs --no-run-if-empty rm -v'
+  args:
+    chdir: "{{ authz_admin_dir }}"
+  register: clean_authz_admin_jars
+  changed_when: '"removed" in clean_authz_admin_jars'
+

--- a/roles/authz-playground/tasks/main.yml
+++ b/roles/authz-playground/tasks/main.yml
@@ -89,3 +89,12 @@
     enabled: yes
     state: started
   ignore_errors: true
+
+- name: cleanup old jars
+  shell: 'find . ! -name $(basename $(readlink authz-playground-current.jar)) -name "*.jar" -type f -printf "%T@  %p\n"  | sort -rn | awk ''{print $2}'' | tail -n +2 | xargs --no-run-if-empty rm -v'
+  args:
+    chdir: "{{ authz_playground_dir }}" 
+  register: clean_authz_playground_jars
+  changed_when: '"removed" in clean_authz_playground_jars'
+
+

--- a/roles/authz-server/tasks/main.yml
+++ b/roles/authz-server/tasks/main.yml
@@ -84,3 +84,12 @@
     name: authz-server
     enabled: yes
     state: started
+
+- name: cleanup old jars
+  shell: 'find . ! -name $(basename $(readlink authz-server-current.jar)) -name "*.jar" -type f -printf "%T@  %p\n"  | sort -rn | awk ''{print $2}'' | tail -n +2 | xargs --no-run-if-empty rm -v'
+  args:
+    chdir: "{{ authz_server_dir }}"
+  register: clean_authz_server_jars
+  changed_when: '"removed" in clean_authz_server_jars'
+
+

--- a/roles/dashboard-gui/tasks/main.yml
+++ b/roles/dashboard-gui/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: create apache folder
-  file: path=/var/www/dashboard owner=root group=root mode=2755 state=directory
+  file: path={{ dashboard_html_dir }} owner=root group=root mode=2755 state=directory
 
 - name: copy virtual host config
   template: src=dashboard.conf.j2 dest=/etc/httpd/conf.d/dashboard.conf
@@ -14,14 +14,14 @@
     extension: zip
     version: "{{ dashboard_gui_version }}"
     repository_url: "{{ maven_snapshot_repo if 'SNAPSHOT' in dashboard_gui_version else maven_repo }}"
-    dest: /var/www/dashboard
+    dest: "{{ dashboard_html_dir }}"
   register: maven_result
   tags: deploy
 
 - name: extract html archive
   unarchive:
     src: "{{ maven_result.dest }}"
-    dest: /var/www/dashboard
+    dest: "{{ dashboard_html_dir }}"
     copy: no
     owner: root
     group: apache
@@ -37,3 +37,18 @@
     force: yes
   tags: deploy
   when: unarchive_result.changed
+
+- name: Remove old zipfiles
+  shell: 'ls -t *.zip | tail -n +3|  xargs --no-run-if-empty rm -v'
+  args:
+    chdir: "{{ dashboard_html_dir }}" 
+  register: clean_dashboard_zips
+  changed_when: '"removed" in clean_dashboard_zips'
+
+- name: Remove old www directories
+  shell: 'find . ! -name $(basename $(readlink current)) -name "dashboard-gui*" -type d  -printf "%T@  %p\n"  | sort -rn | awk ''{print $2}'' | tail -n +2 | xargs --no-run-if-empty rm -vr'
+  args:
+    chdir: "{{ dashboard_html_dir }}" 
+  register: clean_dashboard_wwwdirs
+  changed_when: '"removed" in clean_dashboard_wwwdirs'
+

--- a/roles/dashboard-gui/vars/main.yml
+++ b/roles/dashboard-gui/vars/main.yml
@@ -2,3 +2,4 @@
 dashboard_current: /var/www/dashboard/current
 #TODO - make this into a variable, see also manage-server/var/main.yml
 springapp_tcpport: 9394
+dashboard_html_dir: /var/www/dashboard/

--- a/roles/dashboard-server/tasks/main.yml
+++ b/roles/dashboard-server/tasks/main.yml
@@ -79,5 +79,8 @@
     state: started
 
 - name: cleanup old jars
-  shell: find . ! -name $(basename $(readlink dashboard-current.jar)) -name '*.jar' -type f -exec rm {} \; chdir={{ dashboard_dir }}
-  when: maven_result.changed
+  shell: 'find . ! -name $(basename $(readlink dashboard-current.jar)) -name "*.jar" -type f -printf "%T@  %p\n"  | sort -rn | awk ''{print $2}'' | tail -n +2 | xargs --no-run-if-empty rm -v'
+  args:
+    chdir: "{{ dashboard_dir }}" 
+  register: clean_dashboard_jars
+  changed_when: '"removed" in clean_dashboard_jars'

--- a/roles/eduid-gui/tasks/main.yml
+++ b/roles/eduid-gui/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: create apache folder
-  file: path=/var/www/eduid owner=root group=root mode=2755 state=directory
+  file: path={{ eduid_html_dir }} owner=root group=root mode=2755 state=directory
 
 - name: copy virtual host config
   template: src=eduid.conf.j2 dest=/etc/httpd/conf.d/eduid.conf
@@ -14,14 +14,14 @@
     extension: zip
     version: "{{ eduid_gui_version }}"
     repository_url: "{{ maven_snapshot_repo if 'SNAPSHOT' in eduid_gui_version else maven_repo }}"
-    dest: /var/www/eduid
+    dest: "{{ eduid_html_dir }}"
   register: maven_result
   tags: deploy
 
 - name: extract html archive
   unarchive:
     src: "{{ maven_result.dest }}"
-    dest: /var/www/eduid
+    dest: "{{ eduid_html_dir }}"
     copy: no
     owner: root
     group: apache
@@ -37,3 +37,17 @@
     force: yes
   tags: deploy
   when: unarchive_result.changed
+
+- name: Remove old zipfiles
+  shell: 'ls -t *.zip | tail -n +3|  xargs --no-run-if-empty rm -v'
+  args:
+    chdir: "{{ eduid_html_dir }}" 
+  register: clean_eduid_zips
+  changed_when: '"removed" in clean_eduid_zips'
+
+- name: Remove old www directories
+  shell: 'find . ! -name $(basename $(readlink current)) -name "eduid-gui*" -type d  -printf "%T@  %p\n"  | sort -rn | awk ''{print $2}'' | tail -n +2 | xargs --no-run-if-empty rm -vr'
+  args:
+    chdir: "{{ eduid_html_dir }}" 
+  register: clean_eduid_wwwdirs
+  changed_when: '"removed" in clean_eduid_wwwdirs'

--- a/roles/eduid-gui/vars/main.yml
+++ b/roles/eduid-gui/vars/main.yml
@@ -1,3 +1,4 @@
 ---
 eduid_current: /var/www/eduid/current
 springapp_tcpport: 9189
+eduid_html_dir: /var/www/eduid/

--- a/roles/manage-gui/tasks/main.yml
+++ b/roles/manage-gui/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: create apache folder
   file:
-    path: "/var/www/manage"
+    path: "{{ manage_html_dir }}"
     owner: root
     group: root
     mode: 02755
@@ -32,7 +32,7 @@
     extension: zip
     version: "{{ manage_gui_version }}"
     repository_url: "{{ maven_snapshot_repo if 'SNAPSHOT' in manage_gui_version else maven_repo }}"
-    dest: /var/www/manage
+    dest: "{{ manage_html_dir }}"
   register: maven_result
   tags:
     - deploy
@@ -40,7 +40,7 @@
 - name: extract html archive
   unarchive:
     src: "{{ maven_result.dest }}"
-    dest: "/var/www/manage"
+    dest: "{{ manage_html_dir }}"
     copy: no
     owner: root
     group: apache
@@ -60,3 +60,17 @@
     - deploy
   when:
     - unarchive_result.changed
+
+- name: Remove old zipfiles
+  shell: 'ls -t *.zip | tail -n +3|  xargs --no-run-if-empty rm -v'
+  args:
+    chdir: "{{ manage_html_dir }}" 
+  register: clean_manage_zips
+  changed_when: '"removed" in clean_manage_zips'
+
+- name: Remove old www directories
+  shell: 'find . ! -name $(basename $(readlink current)) -name "manage-gui*" -type d  -printf "%T@  %p\n"  | sort -rn | awk ''{print $2}'' | tail -n +2 | xargs --no-run-if-empty rm -vr'
+  args:
+    chdir: "{{ manage_html_dir }}" 
+  register: clean_manage_wwwdirs
+  changed_when: '"removed" in clean_manage_wwwdirs'

--- a/roles/manage-gui/vars/main.yml
+++ b/roles/manage-gui/vars/main.yml
@@ -2,3 +2,4 @@
 manage_current: /var/www/manage/current
 #TODO - make this into a variable, see also manage-server/var/main.yml
 springapp_tcpport: 9393
+manage_html_dir: /var/www/manage/

--- a/roles/manage-server/tasks/main.yml
+++ b/roles/manage-server/tasks/main.yml
@@ -160,5 +160,8 @@
     state: started
 
 - name: cleanup old jars
-  shell: find . ! -name $(basename $(readlink manage-current.jar)) -name '*.jar' -type f -exec rm {} \; chdir={{ manage_dir }}
-  when: maven_result.changed
+  shell: 'find . ! -name $(basename $(readlink manage-current.jar)) -name "*.jar" -type f -printf "%T@  %p\n"  | sort -rn | awk ''{print $2}'' | tail -n +2 | xargs --no-run-if-empty rm -v'
+  args:
+    chdir: "{{ manage_dir }}" 
+  register: clean_manage_jars
+  changed_when: '"removed" in clean_manage_jars'

--- a/roles/mujina-idp/tasks/main.yml
+++ b/roles/mujina-idp/tasks/main.yml
@@ -50,3 +50,10 @@
 
 - name: ensure the service is started
   service: name={{ springapp_service_name }} enabled=yes state=started
+
+- name: cleanup old jars
+  shell: 'find . ! -name $(basename $(readlink mujina-idp-current.jar)) -name "*.jar" -type f -printf "%T@  %p\n"  | sort -rn | awk ''{print $2}'' | tail -n +2 | xargs --no-run-if-empty rm -v'
+  args:
+    chdir: "{{ mujina_idp_dir }}" 
+  register: clean_mujina_idp_jars
+  changed_when: '"removed" in clean_mujina_idp_jars'

--- a/roles/mujina-sp/tasks/main.yml
+++ b/roles/mujina-sp/tasks/main.yml
@@ -95,3 +95,11 @@
     name: "{{ springapp_service_name }}"
     enabled: yes
     state: started
+
+- name: cleanup old jars
+  shell: 'find . ! -name $(basename $(readlink mujina-sp-current.jar)) -name "*.jar" -type f -printf "%T@  %p\n"  | sort -rn | awk ''{print $2}'' | tail -n +2 | xargs --no-run-if-empty rm -v'
+  args:
+    chdir: "{{ mujina_sp_dir }}" 
+  register: clean_mujina_sp_jars
+  changed_when: '"removed" in clean_mujina_sp_jars'
+

--- a/roles/myconext-gui/tasks/main.yml
+++ b/roles/myconext-gui/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: create apache folder
-  file: path=/var/www/myconext owner=root group=root mode=2755 state=directory
+  file: path={{ myconext_html_dir }} owner=root group=root mode=2755 state=directory
 
 - name: copy virtual host config
   template: src=myconext.conf.j2 dest=/etc/httpd/conf.d/myconext.conf
@@ -14,14 +14,14 @@
     extension: zip
     version: "{{ myconext_gui_version }}"
     repository_url: "{{ maven_snapshot_repo if 'SNAPSHOT' in myconext_gui_version else maven_repo }}"
-    dest: /var/www/myconext
+    dest: "{{ myconext_html_dir }}"
   register: maven_result
   tags: deploy
 
 - name: extract html archive
   unarchive:
     src: "{{ maven_result.dest }}"
-    dest: /var/www/myconext
+    dest: "{{ myconext_html_dir }}"
     copy: no
     owner: root
     group: apache
@@ -37,3 +37,18 @@
     force: yes
   tags: deploy
   when: unarchive_result.changed
+
+- name: Remove old zipfiles
+  shell: 'ls -t *.zip | tail -n +3|  xargs --no-run-if-empty rm -v'
+  args:
+    chdir: "{{ myconext_html_dir }}" 
+  register: clean_myconext_zips
+  changed_when: '"removed" in clean_myconext_zips'
+
+- name: Remove old www directories
+  shell: 'find . ! -name $(basename $(readlink current)) -name "myconext-gui*" -type d  -printf "%T@  %p\n"  | sort -rn | awk ''{print $2}'' | tail -n +2 | xargs --no-run-if-empty rm -vr'
+  args:
+    chdir: "{{ myconext_html_dir }}" 
+  register: clean_myconext_wwwdirs
+  changed_when: '"removed" in clean_myconext_wwwdirs'
+

--- a/roles/myconext-gui/vars/main.yml
+++ b/roles/myconext-gui/vars/main.yml
@@ -1,3 +1,4 @@
 ---
 myconext_current: /var/www/myconext/current
 springapp_tcpport: 9189
+myconext_html_dir: /var/www/myconext/

--- a/roles/myconext-server/tasks/main.yml
+++ b/roles/myconext-server/tasks/main.yml
@@ -96,7 +96,10 @@
     state: started
 
 - name: cleanup old jars
-  shell: find . ! -name $(basename $(readlink myconext-current.jar)) -name '*.jar' -type f -exec rm {} \; chdir={{ myconext_dir }}
-  when: maven_result.changed
+  shell: 'find . ! -name $(basename $(readlink myconext-current.jar)) -name "*.jar" -type f -printf "%T@  %p\n"  | sort -rn | awk ''{print $2}'' | tail -n +2 | xargs --no-run-if-empty rm -v'
+  args:
+    chdir: "{{ myconext_dir }}" 
+  register: clean_myconext_jars
+  changed_when: '"removed" in clean_myconext_jars'
 
 - meta: flush_handlers

--- a/roles/oidc-playground-client/tasks/main.yml
+++ b/roles/oidc-playground-client/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: create apache folder
   file:
-    path: "/var/www/oidc-playground"
+    path: "{{ oidc_playground_html_dir }}"
     owner: root
     group: root
     mode: 0755
@@ -23,7 +23,7 @@
     extension: zip
     version: "{{ oidc_playground_client_version }}"
     repository_url: "{{ maven_snapshot_repo if 'SNAPSHOT' in oidc_playground_client_version else maven_repo }}"
-    dest: /var/www/oidc-playground
+    dest: "{{ oidc_playground_html_dir }}"
   register: maven_result
   tags:
     - deploy
@@ -31,7 +31,7 @@
 - name: extract html archive
   unarchive:
     src: "{{ maven_result.dest }}"
-    dest: "/var/www/oidc-playground"
+    dest: "{{ oidc_playground_html_dir }}"
     copy: no
     owner: root
     group: apache
@@ -51,3 +51,18 @@
     - deploy
   when:
     - unarchive_result.changed
+
+- name: Remove old zipfiles
+  shell: 'ls -t *.zip | tail -n +3|  xargs --no-run-if-empty rm -v'
+  args:
+    chdir: "{{ oidc_playground_html_dir }}" 
+  register: clean_oidc_playground_zips
+  changed_when: '"removed" in clean_oidc_playground_zips'
+
+- name: Remove old www directories
+  shell: 'find . ! -name $(basename $(readlink current)) -name "oidc-playground-gui*" -type d  -printf "%T@  %p\n"  | sort -rn | awk ''{print $2}'' | tail -n +2 | xargs --no-run-if-empty rm -vr'
+  args:
+    chdir: "{{ oidc_playground_html_dir }}" 
+  register: clean_oidc_playground_wwwdirs
+  changed_when: '"removed" in clean_oidc_playground_wwwdirs'
+

--- a/roles/oidc-playground-client/vars/main.yml
+++ b/roles/oidc-playground-client/vars/main.yml
@@ -2,3 +2,4 @@
 oidc_playground_current: /var/www/oidc-playground/current
 #TODO - make this into a variable, see also oidc-playground-server/var/main.yml
 springapp_tcpport: 9399
+oidc_playground_html_dir: /var/www/oidc-playground/

--- a/roles/oidc-playground-server/tasks/main.yml
+++ b/roles/oidc-playground-server/tasks/main.yml
@@ -76,5 +76,8 @@
     state: started
 
 - name: cleanup old jars
-  shell: find . ! -name $(basename $(readlink oidc-playground-current.jar)) -name '*.jar' -type f -exec rm {} \; chdir={{ oidc_playground_dir }}
-  when: maven_result.changed
+  shell: 'find . ! -name $(basename $(readlink oidc-playground-current.jar)) -name "*.jar" -type f -printf "%T@  %p\n"  | sort -rn | awk ''{print $2}'' | tail -n +2 | xargs --no-run-if-empty rm -v'
+  args:
+    chdir: "{{ oidc_playground_dir }}" 
+  register: clean_oidc_playground_jars
+  changed_when: '"removed" in clean_oidc_playground_jars'

--- a/roles/oidcng/tasks/main.yml
+++ b/roles/oidcng/tasks/main.yml
@@ -129,7 +129,10 @@
     state: started
 
 - name: cleanup old jars
-  shell: find . ! -name $(basename $(readlink oidcng-current.jar)) -name '*.jar' -type f -exec rm {} \; chdir={{ oidcng_dir }}
-  when: maven_result.changed
+  shell: 'find . ! -name $(basename $(readlink oidcng-current.jar)) -name "*.jar" -type f -printf "%T@  %p\n"  | sort -rn | awk ''{print $2}'' | tail -n +2 | xargs --no-run-if-empty rm -v'
+  args:
+    chdir: "{{ oidcng_dir }}" 
+  register: clean_oidcng_jars
+  changed_when: '"removed" in clean_oidcng_jars'
 
 - meta: flush_handlers

--- a/roles/pdp-gui/tasks/main.yml
+++ b/roles/pdp-gui/tasks/main.yml
@@ -8,7 +8,7 @@
 
 - name: create apache folder
   file:
-    path: "/var/www/pdp"
+    path: "{{ pdp_html_dir }}"
     owner: root
     group: root
     mode: 02755
@@ -28,7 +28,7 @@
     extension: zip
     version: "{{ pdp_gui_version }}"
     repository_url: "{{ maven_snapshot_repo if 'SNAPSHOT' in pdp_gui_version else maven_repo }}"
-    dest: /var/www/pdp
+    dest: "{{ pdp_html_dir }}"
   register: maven_result
   tags:
     - deploy
@@ -36,7 +36,7 @@
 - name: extract html archive
   unarchive:
     src: "{{ maven_result.dest }}"
-    dest: "/var/www/pdp"
+    dest: "{{ pdp_html_dir }}"
     copy: no
     owner: root
     group: apache
@@ -56,3 +56,17 @@
     - deploy
   when:
     - unarchive_result.changed
+
+- name: Remove old zipfiles
+  shell: 'ls -t *.zip | tail -n +3|  xargs --no-run-if-empty rm -v'
+  args:
+    chdir: "{{ pdp_html_dir }}"
+  register: clean_pdp_zips
+  changed_when: '"removed" in clean_pdp_zips'
+
+- name: Remove old www directories
+  shell: 'find . ! -name $(basename $(readlink current)) -name "pdp-gui*" -type d  -printf "%T@  %p\n"  | sort -rn | awk ''{print $2}'' | tail -n +2 | xargs --no-run-if-empty rm -vr'
+  args:
+    chdir: "{{ pdp_html_dir }}"
+  register: clean_pdp_wwwdirs
+  changed_when: '"removed" in clean_pdp_wwwdirs'

--- a/roles/pdp-gui/vars/main.yml
+++ b/roles/pdp-gui/vars/main.yml
@@ -1,3 +1,4 @@
 ---
 pdp_current: /var/www/pdp/current
 springapp_tcpport: 9196
+pdp_html_dir: "/var/www/pdp/"

--- a/roles/pdp-server/tasks/main.yml
+++ b/roles/pdp-server/tasks/main.yml
@@ -101,3 +101,11 @@
     name: pdp
     enabled: yes
     state: started
+
+- name: cleanup old jars
+  shell: 'find . ! -name $(basename $(readlink pdp-current.jar)) -name "*.jar" -type f -printf "%T@  %p\n"  | sort -rn | awk ''{print $2}'' | tail -n +2 | xargs --no-run-if-empty rm -v'
+  args:
+    chdir: "{{ pdp_dir }}" 
+  register: clean_pdp_jars
+  changed_when: '"removed" in clean_pdp_jars'
+

--- a/roles/teams-gui/tasks/main.yml
+++ b/roles/teams-gui/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: create apache folder
   file:
-    path: "/var/www/teams"
+    path: "{{ teams_html_dir }}"
     owner: root
     group: root
     mode: 02755
@@ -23,7 +23,7 @@
     extension: zip
     version: "{{ teams_gui_version }}"
     repository_url: "{{ maven_snapshot_repo if 'SNAPSHOT' in teams_gui_version else maven_repo }}"
-    dest: "/var/www/teams"
+    dest: "{{ teams_html_dir }}"
   register: maven_result
   tags:
     - deploy
@@ -31,7 +31,7 @@
 - name: extract html archive
   unarchive:
     src: "{{ maven_result.dest }}"
-    dest: "/var/www/teams"
+    dest: "{{ teams_html_dir }}"
     copy: no
     owner: root
     group: apache
@@ -51,3 +51,18 @@
     - deploy
   when:
     - unarchive_result.changed
+
+- name: Remove old zipfiles
+  shell: 'ls -t *.zip | tail -n +3|  xargs --no-run-if-empty rm -v'
+  args:
+    chdir: "{{ teams_html_dir }}" 
+  register: clean_teams_zips
+  changed_when: '"removed" in clean_teams_zips'
+
+- name: Remove old www directories
+  shell: 'find . ! -name $(basename $(readlink current)) -name "teams-gui*" -type d  -printf "%T@  %p\n"  | sort -rn | awk ''{print $2}'' | tail -n +2 | xargs --no-run-if-empty rm -vr'
+  args:
+    chdir: "{{ teams_html_dir }}" 
+  register: clean_teams_wwwdirs
+  changed_when: '"removed" in clean_teams_wwwdirs'
+

--- a/roles/teams-gui/vars/main.yml
+++ b/roles/teams-gui/vars/main.yml
@@ -2,3 +2,4 @@
 teams_current: /var/www/teams/current
 #TODO - make this into a variable, see also teams-server/var/main.yml
 springapp_tcpport: 9197
+teams_html_dir: /var/www/teams/

--- a/roles/teams-server/tasks/main.yml
+++ b/roles/teams-server/tasks/main.yml
@@ -78,5 +78,9 @@
     state: started
 
 - name: cleanup old jars
-  shell: find . ! -name $(basename $(readlink teams-current.jar)) -name '*.jar' -type f -exec rm {} \; chdir={{ teams_dir }}
-  when: maven_result.changed
+  shell: 'find . ! -name $(basename $(readlink teams-current.jar)) -name "*.jar" -type f -printf "%T@  %p\n"  | sort -rn | awk ''{print $2}'' | tail -n +2 | xargs --no-run-if-empty rm -v'
+  args:
+    chdir: "{{ teams_dir }}" 
+  register: clean_teams_jars
+  changed_when: '"removed" in clean_teams_jars'
+

--- a/roles/voot/tasks/main.yml
+++ b/roles/voot/tasks/main.yml
@@ -101,4 +101,11 @@
     enabled: yes
     state: started
 
+- name: cleanup old jars
+  shell: 'find . ! -name $(basename $(readlink voot-current.jar)) -name "*.jar" -type f -printf "%T@  %p\n"  | sort -rn | awk ''{print $2}'' | tail -n +2 | xargs --no-run-if-empty rm -v'
+  args:
+    chdir: "{{ voot_dir }}" 
+  register: clean_voot_jars
+  changed_when: '"removed" in clean_voot_jars'
+
 - meta: flush_handlers


### PR DESCRIPTION
This will clean up all but the last two versions (the one currently installed, and the previous one) of all Java apps. 
It will keep the filesystems of the Java appservers clean, and make it possible to manually roll back a version by changing the symlink 