### PR TITLE
Feature/java logback less logfiles

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -38,3 +38,6 @@ influxdb_stats_user: stats
 
 # The supported_languages_codes is a comma-separated String with the language codes that need to be supported.
 supported_language_codes: "en,nl"
+
+# Default logback retention time in days
+logback_max_history: 7

--- a/roles/attribute-aggregation-server/templates/logback.xml.j2
+++ b/roles/attribute-aggregation-server/templates/logback.xml.j2
@@ -7,7 +7,7 @@
    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
      <!-- daily rollover -->
      <fileNamePattern>/var/log/attribute-aggregation/attribute-aggregation-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
-     <maxHistory>30</maxHistory>
+     <maxHistory>"{{ logback_max_history }}"</maxHistory>
    </rollingPolicy>
    <encoder>
      <pattern>%d{ISO8601} %5p [%t] %logger{40}:%L - %m%n</pattern>
@@ -19,7 +19,7 @@
    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
      <!-- daily rollover -->
      <fileNamePattern>/var/log/attribute-aggregation/analytics-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
-     <maxHistory>30</maxHistory>
+     <maxHistory>"{{ logback_max_history }}"</maxHistory>
    </rollingPolicy>
    <encoder>
      <pattern>%d{ISO8601} %5p [%t] %logger{40}:%L - %m%n</pattern>

--- a/roles/attribute-aggregation-server/templates/logback.xml.j2
+++ b/roles/attribute-aggregation-server/templates/logback.xml.j2
@@ -6,7 +6,7 @@
    <file>/var/log/attribute-aggregation/attribute-aggregation.log</file>
    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
      <!-- daily rollover -->
-     <fileNamePattern>/var/log/attribute-aggregation/attribute-aggregation-%d{yyyy-MM-dd}.log</fileNamePattern>
+     <fileNamePattern>/var/log/attribute-aggregation/attribute-aggregation-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
      <maxHistory>30</maxHistory>
    </rollingPolicy>
    <encoder>
@@ -18,7 +18,7 @@
    <file>/var/log/attribute-aggregation/analytics.log</file>
    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
      <!-- daily rollover -->
-     <fileNamePattern>/var/log/attribute-aggregation/analytics-%d{yyyy-MM-dd}.log</fileNamePattern>
+     <fileNamePattern>/var/log/attribute-aggregation/analytics-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
      <maxHistory>30</maxHistory>
    </rollingPolicy>
    <encoder>

--- a/roles/attribute-mapper/templates/logback.xml.j2
+++ b/roles/attribute-mapper/templates/logback.xml.j2
@@ -11,7 +11,7 @@
     <file>/var/log/attribute-mapper/attribute-mapper.log</file>
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
        <!-- daily rollover -->
-       <fileNamePattern>/var/log/attribute-mapper/attribute-mapper-%d{yyyy-MM-dd}.log</fileNamePattern>
+       <fileNamePattern>/var/log/attribute-mapper/attribute-mapper-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
        <maxHistory>30</maxHistory>
      </rollingPolicy>
      <encoder>

--- a/roles/attribute-mapper/templates/logback.xml.j2
+++ b/roles/attribute-mapper/templates/logback.xml.j2
@@ -12,7 +12,7 @@
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
        <!-- daily rollover -->
        <fileNamePattern>/var/log/attribute-mapper/attribute-mapper-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
-       <maxHistory>30</maxHistory>
+       <maxHistory>"{{ logback_max_history }}"</maxHistory>
      </rollingPolicy>
      <encoder>
        <pattern>%d{ISO8601} %5p [%t] %logger{40}:%L - %m%n</pattern>

--- a/roles/authz-admin/templates/logback.xml.j2
+++ b/roles/authz-admin/templates/logback.xml.j2
@@ -12,7 +12,7 @@
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
        <!-- daily rollover -->
        <fileNamePattern>/var/log/authz-admin/authz-admin-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
-       <maxHistory>30</maxHistory>
+       <maxHistory>"{{ logback_max_history }}"</maxHistory>
      </rollingPolicy>
      <encoder>
        <pattern>%d{ISO8601} %5p [%t] %logger{40}:%L - %m%n</pattern>

--- a/roles/authz-admin/templates/logback.xml.j2
+++ b/roles/authz-admin/templates/logback.xml.j2
@@ -11,7 +11,7 @@
     <file>/var/log/authz-admin/authz-admin.log</file>
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
        <!-- daily rollover -->
-       <fileNamePattern>/var/log/authz-admin/authz-admin-%d{yyyy-MM-dd}.log</fileNamePattern>
+       <fileNamePattern>/var/log/authz-admin/authz-admin-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
        <maxHistory>30</maxHistory>
      </rollingPolicy>
      <encoder>

--- a/roles/authz-playground/templates/logback.xml.j2
+++ b/roles/authz-playground/templates/logback.xml.j2
@@ -5,8 +5,7 @@
     <file>/var/log/authz-playground/authz-playground.log</file>
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
       <!-- daily rollover -->
-      <fileNamePattern>/var/log/authz-playground/authz-playground.%d{yyyy-MM-dd}.log</fileNamePattern>
-      <!-- keep 30 days' worth of history -->
+      <fileNamePattern>/var/log/authz-playground/authz-playground.%d{yyyy-MM-dd}.log.gz</fileNamePattern>
       <maxHistory>30</maxHistory>
     </rollingPolicy>
 

--- a/roles/authz-playground/templates/logback.xml.j2
+++ b/roles/authz-playground/templates/logback.xml.j2
@@ -6,7 +6,7 @@
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
       <!-- daily rollover -->
       <fileNamePattern>/var/log/authz-playground/authz-playground.%d{yyyy-MM-dd}.log.gz</fileNamePattern>
-      <maxHistory>30</maxHistory>
+      <maxHistory>"{{ logback_max_history }}"</maxHistory>
     </rollingPolicy>
 
     <encoder>

--- a/roles/authz-server/templates/logback.xml.j2
+++ b/roles/authz-server/templates/logback.xml.j2
@@ -11,8 +11,7 @@
     <file>/var/log/authz-server/authz-server.log</file>
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
       <!-- daily rollover -->
-      <fileNamePattern>/var/log/authz-server/authz-server.%d{yyyy-MM-dd}.log</fileNamePattern>
-      <!-- keep 30 days' worth of history -->
+      <fileNamePattern>/var/log/authz-server/authz-server.%d{yyyy-MM-dd}.log.gz</fileNamePattern>
       <maxHistory>30</maxHistory>
     </rollingPolicy>
     <encoder>

--- a/roles/authz-server/templates/logback.xml.j2
+++ b/roles/authz-server/templates/logback.xml.j2
@@ -12,7 +12,7 @@
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
       <!-- daily rollover -->
       <fileNamePattern>/var/log/authz-server/authz-server.%d{yyyy-MM-dd}.log.gz</fileNamePattern>
-      <maxHistory>30</maxHistory>
+      <maxHistory>"{{ logback_max_history }}"</maxHistory>
     </rollingPolicy>
     <encoder>
       <pattern>%date{HH:mm:ss.SSS} %-4relative [%thread] %-5level %logger{35} - %msg%n</pattern>

--- a/roles/dashboard-server/templates/logback.xml.j2
+++ b/roles/dashboard-server/templates/logback.xml.j2
@@ -7,7 +7,7 @@
    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
      <!-- daily rollover -->
      <fileNamePattern>/var/log/dashboard/dashboard-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
-     <maxHistory>30</maxHistory>
+     <maxHistory>"{{ logback_max_history }}"</maxHistory>
    </rollingPolicy>
    <encoder>
      <pattern>%d{ISO8601} %5p [%t] %logger{40}:%L - %m%n</pattern>

--- a/roles/dashboard-server/templates/logback.xml.j2
+++ b/roles/dashboard-server/templates/logback.xml.j2
@@ -6,7 +6,7 @@
    <file>/var/log/dashboard/dashboard.log</file>
    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
      <!-- daily rollover -->
-     <fileNamePattern>/var/log/dashboard/dashboard-%d{yyyy-MM-dd}.log</fileNamePattern>
+     <fileNamePattern>/var/log/dashboard/dashboard-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
      <maxHistory>30</maxHistory>
    </rollingPolicy>
    <encoder>

--- a/roles/eduproxy/templates/logback.xml.j2
+++ b/roles/eduproxy/templates/logback.xml.j2
@@ -11,8 +11,7 @@
     <file>/var/log/eduproxy/eduproxy.log</file>
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
       <!-- daily rollover -->
-      <fileNamePattern>/var/log/eduproxy/eduproxy-%d{yyyy-MM-dd}.log</fileNamePattern>
-      <!-- keep 30 days' worth of history -->
+      <fileNamePattern>/var/log/eduproxy/eduproxy-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
       <maxHistory>30</maxHistory>
     </rollingPolicy>
     <encoder>

--- a/roles/eduproxy/templates/logback.xml.j2
+++ b/roles/eduproxy/templates/logback.xml.j2
@@ -12,7 +12,7 @@
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
       <!-- daily rollover -->
       <fileNamePattern>/var/log/eduproxy/eduproxy-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
-      <maxHistory>30</maxHistory>
+      <maxHistory>"{{ logback_max_history }}"</maxHistory>
     </rollingPolicy>
     <encoder>
      <pattern>%d{ISO8601} %5p [%t] %logger{40}:%L - %m%n</pattern>

--- a/roles/manage-server/templates/logback.xml.j2
+++ b/roles/manage-server/templates/logback.xml.j2
@@ -6,7 +6,7 @@
    <file>/var/log/manage/manage.log</file>
    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
      <!-- daily rollover -->
-     <fileNamePattern>/var/log/manage/manage-%d{yyyy-MM-dd}.log</fileNamePattern>
+     <fileNamePattern>/var/log/manage/manage-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
      <maxHistory>30</maxHistory>
    </rollingPolicy>
    <encoder>

--- a/roles/manage-server/templates/logback.xml.j2
+++ b/roles/manage-server/templates/logback.xml.j2
@@ -7,7 +7,7 @@
    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
      <!-- daily rollover -->
      <fileNamePattern>/var/log/manage/manage-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
-     <maxHistory>30</maxHistory>
+     <maxHistory>"{{ logback_max_history }}"</maxHistory>
    </rollingPolicy>
    <encoder>
      <pattern>%d{ISO8601} %5p [%t] %logger{40}:%L - %m%n</pattern>

--- a/roles/monitoring-tests/templates/logback.xml.j2
+++ b/roles/monitoring-tests/templates/logback.xml.j2
@@ -5,7 +5,7 @@
 	  <file>/var/log/{{ springapp_service_name }}/monitoring-tests.log</file>
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
        <!-- daily rollover -->
-       <fileNamePattern>/var/log/{{ springapp_service_name }}/monitoring-tests-%d{yyyy-MM-dd}.log</fileNamePattern>
+       <fileNamePattern>/var/log/{{ springapp_service_name }}/monitoring-tests-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
        <maxHistory>30</maxHistory>
      </rollingPolicy>
      <encoder>

--- a/roles/monitoring-tests/templates/logback.xml.j2
+++ b/roles/monitoring-tests/templates/logback.xml.j2
@@ -6,7 +6,7 @@
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
        <!-- daily rollover -->
        <fileNamePattern>/var/log/{{ springapp_service_name }}/monitoring-tests-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
-       <maxHistory>30</maxHistory>
+       <maxHistory>"{{ logback_max_history }}"</maxHistory>
      </rollingPolicy>
      <encoder>
        <pattern>%d{ISO8601} %5p [%t] %logger{40}:%L - %m%n</pattern>

--- a/roles/mujina-idp/templates/logback.xml.j2
+++ b/roles/mujina-idp/templates/logback.xml.j2
@@ -5,7 +5,7 @@
 	  <file>/var/log/{{ springapp_service_name }}/{{ springapp_service_name }}.log</file>
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
        <!-- daily rollover -->
-       <fileNamePattern>/var/log/{{ springapp_service_name }}/{{ springapp_service_name }}-%d{yyyy-MM-dd}.log</fileNamePattern>
+       <fileNamePattern>/var/log/{{ springapp_service_name }}/{{ springapp_service_name }}-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
        <maxHistory>30</maxHistory>
      </rollingPolicy>
      <encoder>

--- a/roles/mujina-idp/templates/logback.xml.j2
+++ b/roles/mujina-idp/templates/logback.xml.j2
@@ -6,7 +6,7 @@
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
        <!-- daily rollover -->
        <fileNamePattern>/var/log/{{ springapp_service_name }}/{{ springapp_service_name }}-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
-       <maxHistory>30</maxHistory>
+       <maxHistory>"{{ logback_max_history }}"</maxHistory>
      </rollingPolicy>
      <encoder>
        <pattern>%d{ISO8601} %5p [%t] %logger{40}:%L - %m%n</pattern>

--- a/roles/mujina-sp/templates/logback.xml.j2
+++ b/roles/mujina-sp/templates/logback.xml.j2
@@ -5,7 +5,7 @@
 	  <file>/var/log/{{ springapp_service_name }}/{{ springapp_service_name }}.log</file>
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
        <!-- daily rollover -->
-       <fileNamePattern>/var/log/{{ springapp_service_name }}/{{ springapp_service_name }}-%d{yyyy-MM-dd}.log</fileNamePattern>
+       <fileNamePattern>/var/log/{{ springapp_service_name }}/{{ springapp_service_name }}-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
        <maxHistory>30</maxHistory>
      </rollingPolicy>
      <encoder>

--- a/roles/mujina-sp/templates/logback.xml.j2
+++ b/roles/mujina-sp/templates/logback.xml.j2
@@ -6,7 +6,7 @@
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
        <!-- daily rollover -->
        <fileNamePattern>/var/log/{{ springapp_service_name }}/{{ springapp_service_name }}-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
-       <maxHistory>30</maxHistory>
+       <maxHistory>"{{ logback_max_history }}"</maxHistory>
      </rollingPolicy>
      <encoder>
        <pattern>%d{ISO8601} %5p [%t] %logger{40}:%L - %m%n</pattern>

--- a/roles/myconext-server/templates/logback.xml.j2
+++ b/roles/myconext-server/templates/logback.xml.j2
@@ -6,7 +6,7 @@
    <file>/var/log/myconext/myconext.log</file>
    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
      <!-- daily rollover -->
-     <fileNamePattern>/var/log/myconext/myconext-%d{yyyy-MM-dd}.log</fileNamePattern>
+     <fileNamePattern>/var/log/myconext/myconext-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
      <maxHistory>30</maxHistory>
    </rollingPolicy>
    <encoder>

--- a/roles/myconext-server/templates/logback.xml.j2
+++ b/roles/myconext-server/templates/logback.xml.j2
@@ -7,7 +7,7 @@
    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
      <!-- daily rollover -->
      <fileNamePattern>/var/log/myconext/myconext-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
-     <maxHistory>30</maxHistory>
+     <maxHistory>"{{ logback_max_history }}"</maxHistory>
    </rollingPolicy>
    <encoder>
      <pattern>%d{ISO8601} %5p [%t] %logger{40}:%L - %m%n</pattern>

--- a/roles/oidc-playground-server/templates/logback.xml.j2
+++ b/roles/oidc-playground-server/templates/logback.xml.j2
@@ -7,7 +7,7 @@
    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
      <!-- daily rollover -->
      <fileNamePattern>/var/log/oidc-playground/oidc-playground-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
-     <maxHistory>30</maxHistory>
+     <maxHistory>"{{ logback_max_history }}"</maxHistory>
    </rollingPolicy>
    <encoder>
      <pattern>%d{ISO8601} %5p [%t] %logger{40}:%L - %m%n</pattern>

--- a/roles/oidc-playground-server/templates/logback.xml.j2
+++ b/roles/oidc-playground-server/templates/logback.xml.j2
@@ -6,7 +6,7 @@
    <file>/var/log/oidc-playground/oidc-playground.log</file>
    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
      <!-- daily rollover -->
-     <fileNamePattern>/var/log/oidc-playground/oidc-playground-%d{yyyy-MM-dd}.log</fileNamePattern>
+     <fileNamePattern>/var/log/oidc-playground/oidc-playground-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
      <maxHistory>30</maxHistory>
    </rollingPolicy>
    <encoder>

--- a/roles/oidc/templates/oidc-logback.xml.j2
+++ b/roles/oidc/templates/oidc-logback.xml.j2
@@ -12,7 +12,7 @@
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
       <!-- daily rollover -->
       <fileNamePattern>/var/log/oidc/oidc-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
-      <maxHistory>30</maxHistory>
+      <maxHistory>"{{ logback_max_history }}"</maxHistory>
     </rollingPolicy>
     <encoder>
       <pattern>%d{ISO8601} %5p [%t] %logger{40}:%L - %m%n</pattern>

--- a/roles/oidc/templates/oidc-logback.xml.j2
+++ b/roles/oidc/templates/oidc-logback.xml.j2
@@ -11,8 +11,7 @@
     <file>/var/log/oidc/oidc.log</file>
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
       <!-- daily rollover -->
-      <fileNamePattern>/var/log/oidc/oidc-%d{yyyy-MM-dd}.log</fileNamePattern>
-      <!-- keep 30 days' worth of history -->
+      <fileNamePattern>/var/log/oidc/oidc-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
       <maxHistory>30</maxHistory>
     </rollingPolicy>
     <encoder>

--- a/roles/oidcng/templates/logback.xml.j2
+++ b/roles/oidcng/templates/logback.xml.j2
@@ -7,7 +7,7 @@
    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
      <!-- daily rollover -->
      <fileNamePattern>/var/log/oidcng/oidcng-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
-     <maxHistory>30</maxHistory>
+     <maxHistory>"{{ logback_max_history }}"</maxHistory>
    </rollingPolicy>
    <encoder>
      <pattern>%d{ISO8601} %5p [%t] %logger{40}:%L - %m%n</pattern>

--- a/roles/oidcng/templates/logback.xml.j2
+++ b/roles/oidcng/templates/logback.xml.j2
@@ -6,7 +6,7 @@
    <file>/var/log/oidcng/oidcng.log</file>
    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
      <!-- daily rollover -->
-     <fileNamePattern>/var/log/oidcng/oidcng-%d{yyyy-MM-dd}.log</fileNamePattern>
+     <fileNamePattern>/var/log/oidcng/oidcng-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
      <maxHistory>30</maxHistory>
    </rollingPolicy>
    <encoder>

--- a/roles/pdp-server/templates/logback.xml.j2
+++ b/roles/pdp-server/templates/logback.xml.j2
@@ -15,7 +15,7 @@
       <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
          <!-- daily rollover -->
          <fileNamePattern>/var/log/pdp/pdp-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
-         <maxHistory>30</maxHistory>
+         <maxHistory>"{{ logback_max_history }}"</maxHistory>
       </rollingPolicy>
       <encoder>
          <pattern>%d{ISO8601} %5p [%t] %logger{40}:%L - %m%n</pattern>

--- a/roles/pdp-server/templates/logback.xml.j2
+++ b/roles/pdp-server/templates/logback.xml.j2
@@ -14,8 +14,7 @@
       <file>/var/log/pdp/pdp.log</file>
       <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
          <!-- daily rollover -->
-         <fileNamePattern>/var/log/pdp/pdp-%d{yyyy-MM-dd}.log</fileNamePattern>
-         <!-- keep 30 days' worth of history -->
+         <fileNamePattern>/var/log/pdp/pdp-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
          <maxHistory>30</maxHistory>
       </rollingPolicy>
       <encoder>

--- a/roles/teams-server/templates/logback.xml.j2
+++ b/roles/teams-server/templates/logback.xml.j2
@@ -7,7 +7,7 @@
    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
      <!-- daily rollover -->
      <fileNamePattern>/var/log/teams/teams-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
-     <maxHistory>30</maxHistory>
+     <maxHistory>"{{ logback_max_history }}"</maxHistory>
    </rollingPolicy>
    <encoder>
      <pattern>%d{ISO8601} %5p [%t] %logger{40}:%L - %m%n</pattern>

--- a/roles/teams-server/templates/logback.xml.j2
+++ b/roles/teams-server/templates/logback.xml.j2
@@ -6,7 +6,7 @@
    <file>/var/log/teams/teams.log</file>
    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
      <!-- daily rollover -->
-     <fileNamePattern>/var/log/teams/teams-%d{yyyy-MM-dd}.log</fileNamePattern>
+     <fileNamePattern>/var/log/teams/teams-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
      <maxHistory>30</maxHistory>
    </rollingPolicy>
    <encoder>

--- a/roles/voot/templates/logback.xml.j2
+++ b/roles/voot/templates/logback.xml.j2
@@ -11,8 +11,7 @@
     <file>/var/log/voot/voot.log</file>
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
       <!-- daily rollover -->
-      <fileNamePattern>/var/log/voot/voot-%d{yyyy-MM-dd}.log</fileNamePattern>
-      <!-- keep 30 days' worth of history -->
+      <fileNamePattern>/var/log/voot/voot-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
       <maxHistory>30</maxHistory>
     </rollingPolicy>
     <encoder>

--- a/roles/voot/templates/logback.xml.j2
+++ b/roles/voot/templates/logback.xml.j2
@@ -12,7 +12,7 @@
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
       <!-- daily rollover -->
       <fileNamePattern>/var/log/voot/voot-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
-      <maxHistory>30</maxHistory>
+      <maxHistory>"{{ logback_max_history }}"</maxHistory>
     </rollingPolicy>
     <encoder>
      <pattern>%d{ISO8601} %5p [%t] %logger{40}:%L - %m%n</pattern>


### PR DESCRIPTION
All logback configurations had a 30 days retention period for the Java logfiles. This is now configurable, using the configuration parameter "logback_max_history". The default is set to 7 days in stead of 30. 