### PR TITLE
Teams - AA - PDP: Make authz config configurable

### DIFF
--- a/roles/attribute-aggregation-server/defaults/main.yml
+++ b/roles/attribute-aggregation-server/defaults/main.yml
@@ -10,4 +10,4 @@ attribute_aggregation_pseudo_emails_retention_days_period: 90
 aa_cronjobmaster: true
 attribute_aggregator_api_lifecycle_username: attribute_aggregator_api_lifecycle_user
 aa_flyway_schema_version_table_name: schema_version
-
+aa_oauth2_token_url: "https://authz.{{ base_domain }}/oauth/token"

--- a/roles/attribute-aggregation-server/templates/application.yml.j2
+++ b/roles/attribute-aggregation-server/templates/application.yml.j2
@@ -16,7 +16,7 @@ server:
 
 scim_server_environment: test.surfconext
 attribute_authorities_config_path: file:///opt/attribute-aggregation/attributeAuthorities.yml
-authorization_access_token_url: https://authz.{{ base_domain }}/oauth/token
+authorization_access_token_url: "{{ aa_oauth2_token_url }}"
 aggregate_cache_duration_milliseconds: -1
 
 orcid:

--- a/roles/pdp-server/defaults/main.yml
+++ b/roles/pdp-server/defaults/main.yml
@@ -7,3 +7,6 @@ pdp_jar: pdp.jar
 pdp_email_from: '{{ noreply_email }}'
 pdp_cronjobmaster: true
 pdp_invalid_policies_error_mail_to: '{{ error_mail_to }}'
+pdp_oauth2_clientid: pdp_client
+pdp_oauth2_token_url: "https://authz.{{ base_domain }}/oauth/token"
+pdp_oauth2_authorize_url: "https://authz.{{ base_domain }}/oauth/authorize"

--- a/roles/pdp-server/tasks/main.yml
+++ b/roles/pdp-server/tasks/main.yml
@@ -72,6 +72,7 @@
     mode: 0740
   notify:
     - "restart pdp"
+  tags: bartje
 
 - name: Copy xacml config
   template:

--- a/roles/pdp-server/templates/application.properties.j2
+++ b/roles/pdp-server/templates/application.properties.j2
@@ -62,11 +62,11 @@ policy.violation.retention.period.days=30
 
 # Voot client configuration for the teams PIP
 voot.serviceUrl=https://voot.{{ base_domain }}
-voot.accessTokenUri=https://authz.{{ base_domain }}/oauth/token
-voot.userAuthorizationUri=https://authz.{{ base_domain }}/oauth/authorize
+voot.accessTokenUri={{ pdp_oauth2_token_url }}
+voot.userAuthorizationUri={{ pdp_oauth2_authorize_url }}
 
-# The OAuth2 client defined in authz-admin
-voot.clientId=pdp_client
+# The OAuth2 client details
+voot.clientId={{ pdp_oauth2_clientid }}
 voot.clientSecret={{ pdp_client_secret }}
 voot.scopes = groups
 

--- a/roles/teams-server/defaults/main.yml
+++ b/roles/teams-server/defaults/main.yml
@@ -14,4 +14,5 @@ teams_main_link: https://www.openconext.org
 teams_organization: "{{ instance_name}}"
 teams_api_lifecycle_username: teams_api_lifecycle_user
 teams_cron_session_cleanup_expression: 0 * * * * *
-
+teams_oauth2_token_url: "https://authz.{{ base_domain }}/oauth/token"
+teams_authz_client_id: "surf-teams"

--- a/roles/teams-server/templates/application.yml.j2
+++ b/roles/teams-server/templates/application.yml.j2
@@ -55,9 +55,9 @@ teams:
 
 voot:
   serviceUrl: https://voot.{{ base_domain }}
-  accessTokenUri: https://authz.{{ base_domain }}/oauth/token
-  clientId: surf-teams
-  clientSecret: {{ teams_authz_client_secret }}
+  accessTokenUri: "{{ teams_oauth2_token_url }}"
+  clientId: "{{ teams_authz_client_id }}"
+  clientSecret: "{{ teams_authz_client_secret }}"
   scopes: groups
 
 spring:


### PR DESCRIPTION
You can now override the default authz server URLs and clientIDs. This enables you to migrate from authz to oidcng
It does yet change the default from authz to oidcng: This will come in a later stage. 