### PR TITLE
Fix Java memory settings.

### DIFF
--- a/roles/attribute-aggregation-server/defaults/main.yml
+++ b/roles/attribute-aggregation-server/defaults/main.yml
@@ -10,3 +10,5 @@ aa_cronjobmaster: true
 attribute_aggregator_api_lifecycle_username: attribute_aggregator_api_lifecycle_user
 aa_flyway_schema_version_table_name: schema_version
 aa_oauth2_token_url: "https://authz.{{ base_domain }}/oauth/token"
+aa_min_heapsize: "256m"
+aa_max_heapsize: "256m"

--- a/roles/attribute-aggregation-server/vars/main.yml
+++ b/roles/attribute-aggregation-server/vars/main.yml
@@ -7,5 +7,6 @@ springapp_user: attribute-aggregation
 springapp_service_name: attribute-aggregation
 springapp_jar: "{{ attribute_aggregation_jar }}"
 springapp_tcpport: 9198
-springapp_heapsize: "256m"
+springapp_min_heapsize: "{{ aa_min_heapsize }}"
+springapp_max_heapsize: "{{ aa_max_heapsize }}"
 springapp_random_source: "file:///dev/urandom"

--- a/roles/attribute-mapper/defaults/main.yml
+++ b/roles/attribute-mapper/defaults/main.yml
@@ -3,3 +3,5 @@ attribute_mapper_dir: /opt/attribute-mapper
 attribute_mapper_version: ''
 attribute_mapper_snapshot_timestamp: ''
 attribute_mapper_jar: attribute-mapper-current.jar
+attribute_mapper_min_heapsize: "128m"
+attribute_mapper_max_heapsize: "128m"

--- a/roles/attribute-mapper/vars/main.yml
+++ b/roles/attribute-mapper/vars/main.yml
@@ -7,5 +7,6 @@ springapp_user: attribute-mapper
 springapp_service_name: attribute-mapper
 springapp_jar: "{{ attribute_mapper_jar }}"
 springapp_tcpport: 9292
-springapp_heapsize: "128m"
+springapp_min_heapsize: "{{ attribute_mapper_min_heapsize }}"
+springapp_max_heapsize: "{{ attribute_mapper_max_heapsize }}"
 springapp_random_source: "file:///dev/urandom"

--- a/roles/authz-admin/defaults/main.yml
+++ b/roles/authz-admin/defaults/main.yml
@@ -3,3 +3,5 @@ authz_admin_dir: /opt/authz-admin
 authz_admin_version: ''
 authz_admin_snapshot_timestamp: ''
 authz_admin_jar: authz-admin-current.jar
+authz_admin_min_heapsize: "128m"
+authz_admin_max_heapsize: "128m"

--- a/roles/authz-admin/vars/main.yml
+++ b/roles/authz-admin/vars/main.yml
@@ -7,5 +7,6 @@ springapp_user: authz-admin
 springapp_service_name: authz-admin
 springapp_jar: "{{ authz_admin_jar }}"
 springapp_tcpport: 9290
-springapp_heapsize: "128m"
+springapp_min_heapsize: "{{ authz_admin_min_heapsize }}"
+springapp_max_heapsize: "{{ authz_admin_max_heapsize }}"
 springapp_random_source: "file:///dev/urandom"

--- a/roles/authz-playground/defaults/main.yml
+++ b/roles/authz-playground/defaults/main.yml
@@ -1,3 +1,5 @@
 ---
 authz_playground_dir: /opt/authz-playground
 authz_playground_jar: authz-playground-current.jar
+authz_playground_min_heapsize: "64m"
+authz_playground_max_heapsize: "64m"

--- a/roles/authz-playground/vars/main.yml
+++ b/roles/authz-playground/vars/main.yml
@@ -7,5 +7,6 @@ springapp_user: authz-playground
 springapp_service_name: authz-playground
 springapp_jar: "{{ authz_playground_jar }}"
 springapp_tcpport: 9291
-springapp_heapsize: "64m"
+springapp_min_heapsize: "{{ authz_playground_min_heapsize }}"
+springapp_max_heapsize: "{{ authz_playground_max_heapsize }}"
 springapp_random_source: "file:///dev/urandom"

--- a/roles/authz-server/defaults/main.yml
+++ b/roles/authz-server/defaults/main.yml
@@ -5,3 +5,5 @@ authz_server_snapshot_timestamp: ''
 authz_server_jar: authz-server-current.jar
 authz_server_api_lifecycle_username: authz_server_api_lifecycle_user
 authz_server_cronjobmaster: true
+authz_min_heapsize: "64m"
+authz_max_heapsize: "64m"

--- a/roles/authz-server/vars/main.yml
+++ b/roles/authz-server/vars/main.yml
@@ -7,5 +7,6 @@ springapp_user: authz-server
 springapp_service_name: authz-server
 springapp_jar: "{{ authz_server_jar }}"
 springapp_tcpport: 9190
-springapp_heapsize: "64m"
+springapp_min_heapsize: "{{ authz_min_heapsize }}"
+springapp_max_heapsize: "{{ authz_max_heapsize }}"
 springapp_random_source: "file:///dev/urandom"

--- a/roles/dashboard-server/defaults/main.yml
+++ b/roles/dashboard-server/defaults/main.yml
@@ -6,3 +6,5 @@ dashboard_random_source: 'file:///dev/urandom'
 dashboard_hide_tabs: none
 dashboard_organization: SURFconext
 dashboard_install: true
+dashboard_min_heapsize: "512m"
+dashboard_max_heapsize: "512m"

--- a/roles/dashboard-server/vars/main.yml
+++ b/roles/dashboard-server/vars/main.yml
@@ -7,5 +7,6 @@ springapp_user: dashboard
 springapp_service_name: dashboard
 springapp_jar: "{{ dashboard_jar }}"
 springapp_tcpport: 9394
-springapp_heapsize: "512m"
+springapp_min_heapsize: "{{ dashboard_min_heapsize }}"
+springapp_max_heapsize: "{{ dashboard_max_heapsize }}"
 springapp_random_source: "file:///dev/urandom"

--- a/roles/eduproxy/defaults/main.yml
+++ b/roles/eduproxy/defaults/main.yml
@@ -3,3 +3,5 @@ eduproxy_dir: /opt/eduproxy
 eduproxy_version: ''
 eduproxy_snapshot_timestamp: ''
 eduproxy_jar: eduproxy-current.jar
+eduproxy_min_heapsize: "512m"
+eduproxy_max_heapsize: "512m"

--- a/roles/eduproxy/vars/main.yml
+++ b/roles/eduproxy/vars/main.yml
@@ -7,5 +7,6 @@ springapp_user: eduproxy
 springapp_service_name: eduproxy
 springapp_jar: "{{ eduproxy_jar }}"
 springapp_tcpport: 9299
-springapp_heapsize: 512m
+springapp_min_heapsize: "{{ eduproxy_min_heapsize }}"
+springapp_max_heapsize: "{{ eduproxy_max_heapsize }}"
 springapp_random_source: "file:///dev/urandom"

--- a/roles/manage-server/defaults/main.yml
+++ b/roles/manage-server/defaults/main.yml
@@ -10,3 +10,5 @@ manage_service_provider_feed_url: "http://mds.edugain.org/"
 manage_exclude_edugain_imports_in_push: true
 manage_show_oidc_rp_tab: false
 manage_exclude_oidc_rp_imports_in_push: false
+manage_min_heapsize: "512m"
+manage_max_heapsize: "512m"

--- a/roles/manage-server/vars/main.yml
+++ b/roles/manage-server/vars/main.yml
@@ -7,5 +7,6 @@ springapp_user: manage
 springapp_service_name: manage
 springapp_jar: "{{ manage_jar }}"
 springapp_tcpport: 9393
-springapp_heapsize: "512m"
+springapp_min_heapsize: "{{ manage_min_heapsize }}"
+springapp_max_heapsize: "{{ manage_max_heapsize }}"
 springapp_random_source: "file:///dev/urandom"

--- a/roles/monitoring-tests/defaults/main.yml
+++ b/roles/monitoring-tests/defaults/main.yml
@@ -5,4 +5,6 @@ monitoring_tests_snapshot_timestamp: ''
 monitoring_tests_jar: monitoring-tests-current.jar
 monitoring_tests_metadata_sp_url: https://engine.{{ base_domain }}/sp-metadata.xml
 monitoring_tests_metadata_idp_url: https://engine.{{ base_domain }}/idp-metadata.xml
+monitoring_tests_min_heapsize: "128m"
+monitoring_tests_max_heapsize: "128m"
 

--- a/roles/monitoring-tests/vars/main.yml
+++ b/roles/monitoring-tests/vars/main.yml
@@ -7,5 +7,6 @@ springapp_user: monitoring-tests
 springapp_service_name: monitoring-tests
 springapp_jar: "{{ monitoring_tests_jar }}"
 springapp_tcpport: 9392
-springapp_heapsize: "128m"
+springapp_min_heapsize: "{{ monitoring_tests_min_heapsize }}"
+springapp_max_heapsize: "{{ monitoring_tests_max_heapsize }}"
 springapp_random_source: "file:///dev/urandom"

--- a/roles/mujina-idp/defaults/main.yml
+++ b/roles/mujina-idp/defaults/main.yml
@@ -3,5 +3,5 @@ mujina_idp_dir: /opt/mujina-idp
 mujina_idp_version: ''
 mujina_idp_snapshot_timestamp: ''
 mujina_idp_jar: mujina-idp-current.jar
-
-
+mujina_idp_min_heapsize: "128m"
+mujina_idp_max_heapsize: "128m"

--- a/roles/mujina-idp/vars/main.yml
+++ b/roles/mujina-idp/vars/main.yml
@@ -7,5 +7,6 @@ springapp_user: mujina-idp
 springapp_service_name: mujina-idp
 springapp_jar: "{{ mujina_idp_jar }}"
 springapp_tcpport: 9390
-springapp_heapsize: "128m"
+springapp_min_heapsize: "{{ mujina_idp_min_heapsize }}"
+springapp_max_heapsize: "{{ mujina_idp_max_heapsize }}"
 springapp_random_source: "file:///dev/urandom"

--- a/roles/mujina-sp/defaults/main.yml
+++ b/roles/mujina-sp/defaults/main.yml
@@ -1,3 +1,5 @@
 ---
 mujina_sp_dir: /opt/mujina-sp
 mujina_sp_jar: mujina-sp-current.jar
+mujina_sp_min_heapsize: "128m"
+mujina_sp_max_heapsize: "128m"

--- a/roles/mujina-sp/vars/main.yml
+++ b/roles/mujina-sp/vars/main.yml
@@ -7,5 +7,6 @@ springapp_user: mujina-sp
 springapp_service_name: mujina-sp
 springapp_jar: "{{ mujina_sp_jar }}"
 springapp_tcpport: 9391
-springapp_heapsize: "128m"
+springapp_min_heapsize: "{{ mujina_sp_min_heapsize }}"
+springapp_max_heapsize: "{{ mujina_sp_max_heapsize }}"
 springapp_random_source: "file:///dev/urandom"

--- a/roles/myconext-server/defaults/main.yml
+++ b/roles/myconext-server/defaults/main.yml
@@ -6,3 +6,5 @@ myconext_random_source: 'file:///dev/urandom'
 myconext_install: true
 myconext_cronjobmaster: true
 myconext_onegini_entity_id: "https://www.onegini.me"
+myconext_min_heapsize: "512m"
+myconext_max_heapsize: "512m"

--- a/roles/myconext-server/vars/main.yml
+++ b/roles/myconext-server/vars/main.yml
@@ -7,5 +7,6 @@ springapp_user: myconext
 springapp_service_name: myconext
 springapp_jar: "{{ myconext_jar }}"
 springapp_tcpport: 9189
-springapp_heapsize: "512m"
+springapp_min_heapsize: "{{ myconext_min_heapsize }}"
+springapp_max_heapsize: "{{ myconext_max_heapsize }}"
 springapp_random_source: "file:///dev/urandom"

--- a/roles/oidc-playground-server/defaults/main.yml
+++ b/roles/oidc-playground-server/defaults/main.yml
@@ -2,3 +2,5 @@
 oidc_playground_dir: /opt/oidc-playground
 oidc_playground_jar: oidc-playground-current.jar
 oidc_playground_random_source: 'file:///dev/urandom'
+oidc_playground_min_heapsize: "256m"
+oidc_playground_max_heapsize: "256m"

--- a/roles/oidc-playground-server/vars/main.yml
+++ b/roles/oidc-playground-server/vars/main.yml
@@ -7,5 +7,6 @@ springapp_user: oidc-playground
 springapp_service_name: oidc-playground
 springapp_jar: "{{ oidc_playground_jar }}"
 springapp_tcpport: 9399
-springapp_heapsize: "512m"
+springapp_min_heapsize: "{{ oidc_playground_min_heapsize }}"
+springapp_max_heapsize: "{{ oidc_playground_max_heapsize }}"
 springapp_random_source: "file:///dev/urandom"

--- a/roles/pdp-server/defaults/main.yml
+++ b/roles/pdp-server/defaults/main.yml
@@ -9,3 +9,5 @@ pdp_invalid_policies_error_mail_to: '{{ error_mail_to }}'
 pdp_oauth2_clientid: pdp_client
 pdp_oauth2_token_url: "https://authz.{{ base_domain }}/oauth/token"
 pdp_oauth2_authorize_url: "https://authz.{{ base_domain }}/oauth/authorize"
+pdp_min_heapsize: "512m"
+pdp_max_heapsize: "512m"

--- a/roles/pdp-server/vars/main.yml
+++ b/roles/pdp-server/vars/main.yml
@@ -7,5 +7,6 @@ springapp_user: pdp
 springapp_service_name: pdp
 springapp_jar: "{{ pdp_jar }}"
 springapp_tcpport: 9196
-springapp_heapsize: "512m"
+springapp_min_heapsize: "{{ pdp_min_heapsize }}"
+springapp_max_heapsize: "{{ pdp_max_heapsize }}"
 springapp_random_source: "file:///dev/urandom"

--- a/roles/teams-server/defaults/main.yml
+++ b/roles/teams-server/defaults/main.yml
@@ -15,3 +15,5 @@ teams_api_lifecycle_username: teams_api_lifecycle_user
 teams_cron_session_cleanup_expression: 0 * * * * *
 teams_oauth2_token_url: "https://authz.{{ base_domain }}/oauth/token"
 teams_authz_client_id: "surf-teams"
+teams_min_heapsize: "256m"
+teams_max_heapsize: "256m"

--- a/roles/teams-server/vars/main.yml
+++ b/roles/teams-server/vars/main.yml
@@ -7,5 +7,6 @@ springapp_user: teams
 springapp_service_name: teams
 springapp_jar: "{{ teams_jar }}"
 springapp_tcpport: 9197
-springapp_heapsize: "256m"
+springapp_min_heapsize: "{{ teams_min_heapsize }}"
+springapp_max_heapsize: "{{ teams_max_heapsize }}"
 springapp_random_source: "file:///dev/urandom"

--- a/roles/voot/defaults/main.yml
+++ b/roles/voot/defaults/main.yml
@@ -3,3 +3,5 @@ voot_dir: /opt/voot/
 voot_version: ''
 voot_snapshot_timestamp: ''
 voot_service_jar: voot-service.jar
+voot_min_heapsize: "128m"
+voot_max_heapsize: "128m"

--- a/roles/voot/vars/main.yml
+++ b/roles/voot/vars/main.yml
@@ -7,5 +7,6 @@ springapp_user: voot
 springapp_service_name: voot
 springapp_jar: "{{ voot_service_jar }}"
 springapp_tcpport: 9191
-springapp_heapsize: "128m"
+springapp_min_heapsize: "{{ voot_min_heapsize }}"
+springapp_max_heapsize: "{{ voot_max_heapsize }}"
 springapp_random_source: "file:///dev/urandom"

--- a/templates/spring-boot.service.j2
+++ b/templates/spring-boot.service.j2
@@ -3,7 +3,7 @@ Description={{ springapp_service_name }}
 
 [Service]
 WorkingDirectory={{ springapp_dir }}
-ExecStart=/usr/lib/jvm/java-1.8.0/bin/java -Xms{{ springapp_min_heapsize if springapp_min_heapsize is defined else springapp_heapsize }} -Xmx{{ springapp_max_heapsize if springapp_max_heapsize is defined else springapp_heapsize }} -Djava.security.egd={{ springapp_random_source }} -jar {{ springapp_jar }} {{ springapp_opts | default('') }}
+ExecStart=/usr/lib/jvm/java-1.8.0/bin/java -Xms{{ springapp_min_heapsize }} -Xmx{{ springapp_max_heapsize }} -Djava.security.egd={{ springapp_random_source }} -jar {{ springapp_jar }} {{ springapp_opts | default('') }}
 User={{ springapp_user }}
 PrivateTmp=yes
 


### PR DESCRIPTION
The change in b7f9960a8a12bbc0e54683387e27722901a8eff5 made that all Java apps were configured with 512MB heap space. 
The problem was that role vars are global. 
This change allows all apps to set their own min and max heap spaces.