### PR TITLE
New role: Remove Java app

### DIFF
--- a/roles/remove-java-app/defaults/main.yml
+++ b/roles/remove-java-app/defaults/main.yml
@@ -1,0 +1,1 @@
+java_apps_to_remove: [] 

--- a/roles/remove-java-app/handlers/main.yml
+++ b/roles/remove-java-app/handlers/main.yml
@@ -1,0 +1,9 @@
+---
+- name: daemon_reload
+  systemd:
+    daemon_reload: yes
+
+- name: restart httpd
+  systemd:
+    name: httpd
+    state: restarted

--- a/roles/remove-java-app/tasks/main.yml
+++ b/roles/remove-java-app/tasks/main.yml
@@ -1,0 +1,50 @@
+---
+- name: Remove the httpd configuration
+  file: 
+    path: /etc/httpd/conf.d/{{ item}}.conf
+    state: absent
+  notify:
+    - restart httpd
+  with_items:
+    - "{{ java_apps_to_remove }}"
+
+- name: Remove the systemd service file
+  file: 
+    path: "/etc/systemd/system/{{ item }}.service"
+    state: absent
+  notify: 
+    - daemon_reload
+  with_items:
+    - "{{ java_apps_to_remove }}"
+  register: systemd_removed
+
+- name: Disable and stop the app
+  service: 
+    name: "{{ item }}"
+    enabled: no
+    state: stopped
+  with_items:
+    - "{{ java_apps_to_remove }}"
+  when:
+    - systemd_removed.changed | bool
+
+- name: Remove the app dir and its contents
+  file:
+    path: /opt/{{ item }}/
+    state: absent
+  with_items:
+    - "{{ java_apps_to_remove }}"
+
+- name: Remove the www dir
+  file:
+    path: /var/www/{{ item }}/
+    state: absent
+  with_items:
+    - "{{ java_apps_to_remove }}"
+
+- name: Remove the logs
+  file:
+    path: /var/log/{{ item }}/
+    state: absent
+  with_items:
+    - "{{ java_apps_to_remove }}"


### PR DESCRIPTION
This role helps to remove obsolete Java apps from an application server.
It's just meant as a helper for when you have multiple application servers. 