### PR TITLE
Use the "hosts" key if there is one to configure the hosts information in MySQL

### DIFF
--- a/roles/mysql/tasks/main.yml
+++ b/roles/mysql/tasks/main.yml
@@ -103,7 +103,7 @@
 - name: Create database user
   mysql_user:
     name: "{{ item[0].name }}"
-    host: "{{ item[1] }}"
+    host: "{{ item[0].hosts | join(',') if item[0].hosts is defined and (item[0].hosts | length>0) else item[1] }}"
     password: "{{ item[0].password }}"
     priv: "{{ item[0].db_name }}.*:ALL"
     state: present


### PR DESCRIPTION
This PR contains the following change:

* If an entry in the `databases.users` property has an `hosts` key configured and at least 1 entry in the list, it will be used instead of the `database_clients` property;

fixes #93 