### PR TITLE
Minor change that helps speedup deployment

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,2 @@
+[ssh_connection]
+pipelining=True


### PR DESCRIPTION
This PR contains the following change:

* Added pipelining (Enabling pipelining reduces the number of SSH operations required to execute a module on the remote server, by executing many ansible modules without actual file transfer.)

An average `./provision vm` on my Mac went from 780 seconds to 670 seconds.