### PR TITLE
Java: Remove the java 7 install, it's not used anymore

### DIFF
--- a/roles/java/tasks/main.yml
+++ b/roles/java/tasks/main.yml
@@ -11,7 +11,6 @@
   yum:
     name:
       - java-1.8.0-openjdk-devel.x86_64
-      - java-1.7.0-openjdk-devel
     state: present
   register: java_package_java_installed
   until: java_package_java_installed is succeeded


### PR DESCRIPTION
We still install Java 7, which is not used anymore. Removing them, it also saves a lot of space when using Docker