### PR TITLE
Ability to group services with an alias

### DIFF
--- a/roles/springboot/defaults/main.yml
+++ b/roles/springboot/defaults/main.yml
@@ -39,12 +39,15 @@ springboot_gui_services:
     role: oidc-playground-client
     artifactid: oidc-playground-client
   - name: myconext
+    alias: myconext
     enabled: "{{ springboot_services_state.myconext }}"
     version: "{{ myconext_gui_version }}"
   - name: account
+    alias: myconext
     enabled: "{{ springboot_services_state.account }}"
     version: "{{ account_gui_version }}"
   - name: eduid
+    alias: myconext
     enabled: "{{ springboot_services_state.eduid }}"
     version: "{{ eduid_gui_version }}"
 
@@ -109,6 +112,7 @@ springboot_server_services:
     config:
       "{{ oidc_playground }}"
   - name: myconext
+    alias: myconext
     enabled: "{{ springboot_services_state.myconext }}"
     version: "{{ myconext_server_version }}"
     type: server
@@ -116,6 +120,7 @@ springboot_server_services:
     config:
       "{{ myconext }}"
   - name: mujina-sp
+    alias: mujina
     enabled: "{{ springboot_services_state.mujina_sp }}"
     min_heapsize: '128m'
     max_heapsize: '128m'
@@ -127,6 +132,7 @@ springboot_server_services:
     config:
       "{{ mujina_sp }}"
   - name: mujina-idp
+    alias: mujina
     enabled: "{{ springboot_services_state.mujina_idp }}"
     min_heapsize: '128m'
     max_heapsize: '128m'

--- a/roles/springboot/tasks/main.yml
+++ b/roles/springboot/tasks/main.yml
@@ -32,7 +32,7 @@
     loop_var: springboot
   no_log: true
   when:
-    - springboot.name in _services_to_install
+    - springboot.name in _services_to_install or (springboot.alias is defined and springboot.alias in _services_to_install)
     - springboot.enabled
 
 - name: "Install Springboot Server services"
@@ -42,5 +42,5 @@
     loop_var: springboot
   no_log: true
   when:
-    - springboot.name in _services_to_install
+    - springboot.name in _services_to_install or (springboot.alias is defined and springboot.alias in _services_to_install)
     - springboot.enabled


### PR DESCRIPTION
With the introduction of springboot services the 'tag' functionality was lost. This reinstates this  functionality with an optional alias attribute to group services.