### PR TITLE
Set httponly flag on lang cookie

### DIFF
--- a/roles/engineblock/templates/parameters.yml.j2
+++ b/roles/engineblock/templates/parameters.yml.j2
@@ -150,7 +150,7 @@ parameters:
     cookie.secure: true
     cookie.locale.domain: .{{ base_domain }}
     cookie.locale.expiry: 5184000
-    cookie.locale.http_only: false
+    cookie.locale.http_only: true
     cookie.locale.secure: true
 
     ## UI settings


### PR DESCRIPTION
The cookie is used exclusively by the PHP application, so a http_only flag set to true is in order here. This change is also applied in parameters distfile in EB

See: https://www.pivotaltracker.com/story/show/176287495
See: https://github.com/OpenConext/OpenConext-engineblock/pull/1056