### PR TITLE
Haproxy: Log the request rate per ip per 10s

### DIFF
--- a/roles/elk/files/logstash/patterns/haproxy
+++ b/roles/elk/files/logstash/patterns/haproxy
@@ -1,1 +1,1 @@
-HAPROXYCAPTUREDREQUESTHEADERS %{DATA:request_header_user_agent}\|%{DATA:request_header_forwarded_for}\|%{DATA:request_header_tls_cipher},%{DATA:request_header_tls_version},%{DATA:request_header_http_version}
+HAPROXYCAPTUREDREQUESTHEADERS %{DATA:request_header_user_agent}\|%{DATA:request_header_forwarded_for}\|%{DATA:request_header_tls_cipher},%{DATA:request_header_tls_version},%{DATA:request_header_http_version}\|%{DATA:http_req_rate_10s}

--- a/roles/haproxy/templates/haproxy_frontend.cfg.j2
+++ b/roles/haproxy/templates/haproxy_frontend.cfg.j2
@@ -58,6 +58,11 @@ frontend local_ip
     capture request header User-agent len 256
     capture request header X-Forwarded-For len 128
     capture request header X-TLS-Client len 256
+    # The following lines are to log the request rate per 10s
+    stick-table type ip size 1m expire 10s store http_req_rate(10s)
+    http-request track-sc0 hdr(X-Forwarded-For)
+    http-request capture sc_http_req_rate(0) len 4
+    # Deny the request when no valid host header is used
     http-request deny if ! valid_vhost
 
     {% for application in haproxy_applications %}
@@ -123,6 +128,11 @@ frontend localhost_restricted
     capture request header User-agent len 256
     capture request header X-Forwarded-For len 128
     capture request header X-TLS-Client len 256
+    # The following lines are to log the request rate per 10s
+    stick-table type ip size 1m expire 10s store http_req_rate(10s)
+    http-request track-sc0 hdr(X-Forwarded-For)
+    http-request capture sc_http_req_rate(0) len 4
+    # Deny the request when no valid host header is used
     http-request deny if ! valid_vhost
 
     {% for application in haproxy_applications %}


### PR DESCRIPTION
This adds an extra field in the haproxy logging where the rate of
requests per ip address is logged. This information can later be used to
set limits