### PR TITLE
GitHub Actions: Build and publish the Docker image

### DIFF
--- a/.github/workflows/docker-build-image.yml
+++ b/.github/workflows/docker-build-image.yml
@@ -1,0 +1,52 @@
+# Github action to build and publish a Docker image
+
+name: build and publish docker
+on:
+  pull_request:
+    branches: 
+      - 'master'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Disable apparmor
+        run: |
+          sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
+          sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
+
+      - name: Build the docker image
+        run: docker build --rm -t surfnet/centos7-openconext-ga -f tests/Dockerfile.centos-7-ga .
+
+      - name: Run Ansible on the Docker container to install OpenConext
+        run: sh tests/githubactions-build.sh
+
+      - name: Check other issues
+        if: ${{ failure() }}
+        run: |
+          docker exec ansible-test-ga cat /var/log/messages
+          docker exec ansible-test-ga cat /var/log/manage/manage.log
+          docker exec systemctl status haproxy
+
+      - name: Commit and tag the Docker image
+        run: |
+          DOCKER_COMMIT_SHA=$(docker commit ansible-test-ga)
+          CONTAINER_TAG=$(echo $GITHUB_REF | sed -e 's,.*/\(.*\),\1,')
+          docker tag $DOCKER_COMMIT_SHA ghcr.io/openconext/openconext-deploy/openconext-core:$CONTAINER_TAG 
+          docker tag $DOCKER_COMMIT_SHA ghcr.io/openconext/openconext-deploy/openconext-core:latest
+
+      - name: Show the docker image
+        run: docker images
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GH_CONTAINER_REGISTRY_PAT }}
+
+      - name: Push the image
+        run: |
+          CONTAINER_TAG=$(echo $GITHUB_REF | sed -e 's,.*/\(.*\),\1,')
+          docker push ghcr.io/openconext/openconext-deploy/openconext-core:$CONTAINER_TAG

--- a/tests/Dockerfile.centos-7-ga
+++ b/tests/Dockerfile.centos-7-ga
@@ -1,0 +1,18 @@
+FROM centos:7
+
+MAINTAINER "Bart Geesink" <bart.geesink@surf.nl>
+
+ENV container docker
+
+RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+rm -f /lib/systemd/system/multi-user.target.wants/*;\
+rm -f /etc/systemd/system/*.wants/*;\
+rm -f /lib/systemd/system/local-fs.target.wants/*; \
+rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+rm -f /lib/systemd/system/basic.target.wants/*;\
+rm -f /lib/systemd/system/anaconda.target.wants/*;
+
+VOLUME [ "/sys/fs/cgroup" ]
+
+CMD ["/usr/sbin/init"]

--- a/tests/github.yml
+++ b/tests/github.yml
@@ -1,0 +1,12 @@
+haproxy_redirects:
+  - name: "redirecttest"
+    url: "redirect.vm.openconext.org"
+    redirecturl: "https://engine.vm.openconext.org"
+
+listen_address_ip4: 0.0.0.0
+postfix_interfaces: ipv4
+dashboard_install: False
+update_hosts_file: False
+manage_show_oidc_rp_tab: true
+manage_exclude_oidc_rp_imports_in_push: true
+

--- a/tests/githubactions-build.sh
+++ b/tests/githubactions-build.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+set -e
+
+# keep exit status
+status=0
+
+ANSIBLE_PLAYBOOK=./provision.yml
+ANSIBLE_INVENTORY=./environments-external/github/inventory
+ANSIBLE_SECRETS=./environments-external/github/secrets/vm.yml
+ANSIBLE_PLAYBOOK_WRAPPER=./provision
+ANSIBLE_USER=root
+
+# start docker container
+docker run --detach                                         \
+	-v /sys/fs/cgroup:/sys/fs/cgroup:ro                     \
+	-t                                                      \
+	--privileged                                            \
+	--publish 443:443                                       \
+	--name ansible-test-ga                                  \
+	--add-host static.vm.openconext.org:127.0.0.1           \
+	--add-host metadata.vm.openconext.org:127.0.0.1         \
+	--add-host engine.vm.openconext.org:127.0.0.1           \
+	--add-host profile.vm.openconext.org:127.0.0.1          \
+	--add-host mujina-sp.vm.openconext.org:127.0.0.1        \
+	--add-host mujina-idp.vm.openconext.org:127.0.0.1       \
+	--add-host teams.vm.openconext.org:127.0.0.1            \
+	--add-host voot.vm.openconext.org:127.0.0.1             \
+	--add-host db.vm.openconext.org:127.0.0.1               \
+	--add-host pdp.vm.openconext.org:127.0.0.1              \
+	--add-host engine-api.vm.openconext.org:127.0.0.1       \
+	--add-host aa.vm.openconext.org:127.0.0.1               \
+	--add-host link.vm.openconext.org:127.0.0.1             \
+	--add-host connect.vm.openconext.org:127.0.0.1          \
+	--add-host oidc-playground.vm.openconext.org:127.0.0.1  \
+	--add-host manage.vm.openconext.org:127.0.0.1           \
+	--add-host redirect.vm.openconext.org:127.0.0.1         \
+	--add-host localhost:127.0.0.1                          \
+	--hostname test.openconext.org                          \
+	-e TERM=xterm                                           \
+	surfnet/centos7-openconext-ga
+
+# initialize ansible.cfg
+cat <<-'EOF' > ansible.cfg
+	[defaults]
+	callback_whitelist=profile_tasks
+	[ssh_connection]
+	ssh_args=-o ControlMaster=auto -o ControlPersist=60m
+	pipelining=True
+EOF
+
+# Prepare the environment
+echo "Prepping the environment" 
+mkdir -p environments-external
+/bin/cp -r environments/vm/ environments-external/github
+/bin/mv environments-external/github/group_vars/vm.yml environments-external/github/group_vars/github.yml
+sed -i 's/192.168.66.98/0.0.0.0/g' environments-external/github/group_vars/github.yml
+sed -i 's/192.168.66.99/127.0.0.1/g' environments-external/github/group_vars/github.yml
+sed -i 's/oidc_push_enabled: true/oidc_push_enabled: false/g' environments-external/github/group_vars/github.yml
+# Change the hostname in the inventory
+/bin/cp environments/template/inventory environments-external/github/
+sed -i 's/%env%/github/g' environments-external/github/inventory
+sed -i 's/%target_host%/ansible-test-ga ansible_connection=docker/g' environments-external/github/inventory 
+
+# Create the proper host_vars file
+/bin/cp environments/template/host_vars/template.yml environments-external/github/host_vars/ansible-test-ga.yml
+
+echo
+echo "================================================================="
+echo "================================================================="
+echo "== STARTING MAIN PLAYBOOK RUN ==================================="
+echo "================================================================="
+echo "================================================================="
+echo
+
+./provision github $ANSIBLE_USER $ANSIBLE_SECRETS -e springboot_service_to_deploy=manage,mujina-sp,mujina-idp -e @tests/github.yml -t core
+
+# Make the image a bit smaller
+docker exec ansible-test-ga systemctl stop mysql mongod
+docker exec ansible-test-ga yum -y remove mongodb-org-mongos mongodb-org-tools
+docker exec ansible-test-ga rm -rf /var/lib/mongo/journal/*
+docker exec ansible-test-ga rm -rf /var/lib/mysql/ib_logfile*
+docker stop ansible-test-ga ansible-test-ga
+
+exit $status


### PR DESCRIPTION
We use GitHub actions to build and publish the OpenConext docker container. Some scripts have been added to perform the Ansible installation on a standard CentOS Docker image.

This container has the following components:
engineblock
profile
manage
mujina-sp
mujina-idp

This is a minimal OpenConext installation. The VM secrets have been used, which means all secrets are 'secret'. A default SAML signing key is used. This means that this container is not meant for anything else but development, testing or evaluation purposes.

