### PR TITLE
Feature/php use opcache

### DIFF
--- a/environments/vm/group_vars/dev.yml
+++ b/environments/vm/group_vars/dev.yml
@@ -1,2 +1,3 @@
+php_opcode_validate_timestamps: 1
 engine_apache_symfony_environment: dev
 develop: true

--- a/roles/php/defaults/main.yml
+++ b/roles/php/defaults/main.yml
@@ -1,0 +1,1 @@
+php_opcode_validate_timestamps: 0

--- a/roles/php/tasks/main.yml
+++ b/roles/php/tasks/main.yml
@@ -31,6 +31,7 @@
       - php72-php-soap
       - php72-php-xml
       - php72-php-gd
+      - php72-php-opcache
     state: present
   register: php_packages_php_installed
   until: php_packages_php_installed is succeeded
@@ -41,6 +42,7 @@
     dest: "/etc/opt/remi/php72/php.d/{{ item }}"
   with_items:
     - 40-apcu.ini
+    - 10-opcache.ini
     - openconext.ini
   notify:
     - "restart php72-php-fpm"
@@ -100,6 +102,7 @@
     state: absent
   register: php_packages_php_remove
   until: php_packages_php_remove is succeeded
+
 
 - name: Clean up old php-fpm 5.6 config
   file:

--- a/roles/php/tasks/main.yml
+++ b/roles/php/tasks/main.yml
@@ -66,13 +66,15 @@
 
 - name: Put 7.2 FPM configuration
   copy:
-    src: "{{ item.src }}"
-    dest: "/etc/opt/remi/php72/{{ item.dest }}f"
-  with_items:
-    - src: php72-fpm.conf
-      dest: php-fpm.con
-    - src: www.conf
-      dest: php-fpm.d/www.conf
+    src: php72-fpm.conf
+    dest: "/etc/opt/remi/php72/php-fpm.conf"
+  notify:
+    - "restart php72-php-fpm"
+
+- name: Create an empty default www pool file    
+  copy: 
+    content: ""
+    dest: /etc/opt/remi/php72/php-fpm.d/www.conf 
   notify:
     - "restart php72-php-fpm"
 

--- a/roles/php/templates/10-opcache.ini.j2
+++ b/roles/php/templates/10-opcache.ini.j2
@@ -1,0 +1,129 @@
+; Enable Zend OPcache extension module
+zend_extension=opcache
+
+; Determines if Zend OPCache is enabled
+opcache.enable=1
+
+; Determines if Zend OPCache is enabled for the CLI version of PHP
+;opcache.enable_cli=0
+
+; The OPcache shared memory storage size.
+opcache.memory_consumption=128
+
+; The amount of memory for interned strings in Mbytes.
+opcache.interned_strings_buffer=8
+
+; The maximum number of keys (scripts) in the OPcache hash table.
+; Only numbers between 200 and 1000000 are allowed.
+opcache.max_accelerated_files=10000
+
+; The maximum percentage of "wasted" memory until a restart is scheduled.
+;opcache.max_wasted_percentage=5
+
+; When this directive is enabled, the OPcache appends the current working
+; directory to the script key, thus eliminating possible collisions between
+; files with the same name (basename). Disabling the directive improves
+; performance, but may break existing applications.
+;opcache.use_cwd=1
+
+; When disabled, you must reset the OPcache manually or restart the
+; webserver for changes to the filesystem to take effect.
+opcache.validate_timestamps="{{ php_opcode_validate_timestamps }}"
+
+; How often (in seconds) to check file timestamps for changes to the shared
+; memory storage allocation. ("1" means validate once per second, but only
+; once per request. "0" means always validate)
+;opcache.revalidate_freq=2
+
+; Enables or disables file search in include_path optimization
+;opcache.revalidate_path=0
+
+; If disabled, all PHPDoc comments are dropped from the code to reduce the
+; size of the optimized code.
+;opcache.save_comments=1
+
+; If enabled, a fast shutdown sequence is used for the accelerated code
+; Depending on the used Memory Manager this may cause some incompatibilities.
+;opcache.fast_shutdown=0
+
+; Allow file existence override (file_exists, etc.) performance feature.
+;opcache.enable_file_override=0
+
+; A bitmask, where each bit enables or disables the appropriate OPcache
+; passes
+;opcache.optimization_level=0xffffffff
+
+;opcache.inherited_hack=1
+;opcache.dups_fix=0
+
+; The location of the OPcache blacklist file (wildcards allowed).
+; Each OPcache blacklist file is a text file that holds the names of files
+; that should not be accelerated.
+opcache.blacklist_filename=/etc/opt/remi/php72/php.d/opcache*.blacklist
+
+; Allows exclusion of large files from being cached. By default all files
+; are cached.
+;opcache.max_file_size=0
+
+; Check the cache checksum each N requests.
+; The default value of "0" means that the checks are disabled.
+;opcache.consistency_checks=0
+
+; How long to wait (in seconds) for a scheduled restart to begin if the cache
+; is not being accessed.
+;opcache.force_restart_timeout=180
+
+; OPcache error_log file name. Empty string assumes "stderr".
+;opcache.error_log=
+
+; All OPcache errors go to the Web server log.
+; By default, only fatal errors (level 0) or errors (level 1) are logged.
+; You can also enable warnings (level 2), info messages (level 3) or
+; debug messages (level 4).
+;opcache.log_verbosity_level=1
+
+; Preferred Shared Memory back-end. Leave empty and let the system decide.
+;opcache.preferred_memory_model=
+
+; Protect the shared memory from unexpected writing during script execution.
+; Useful for internal debugging only.
+;opcache.protect_memory=0
+
+; Allows calling OPcache API functions only from PHP scripts which path is
+; started from specified string. The default "" means no restriction
+;opcache.restrict_api=
+
+; Enables and sets the second level cache directory.
+; It should improve performance when SHM memory is full, at server restart or
+; SHM reset. The default "" disables file based caching.
+; RPM note : file cache directory must be owned by process owner
+;   for mod_php, see /etc/opt/remi/php72/httpd/conf.d/php.conf
+;   for php-fpm, see /etc/opt/remi/php72/php-fpm.d/*conf
+;opcache.file_cache=
+
+; Enables or disables opcode caching in shared memory.
+;opcache.file_cache_only=0
+
+; Enables or disables checksum validation when script loaded from file cache.
+;opcache.file_cache_consistency_checks=1
+
+; Implies opcache.file_cache_only=1 for a certain process that failed to
+; reattach to the shared memory (for Windows only). Explicitly enabled file
+; cache is required.
+;opcache.file_cache_fallback=1
+
+; Validate cached file permissions.
+; Leads OPcache to check file readability on each access to cached file.
+; This directive should be enabled in shared hosting environment, when few
+; users (PHP-FPM pools) reuse the common OPcache shared memory.
+;opcache.validate_permission=0
+
+; Prevent name collisions in chroot'ed environment.
+; This directive prevents file name collisions in different "chroot"
+; environments. It should be enabled for sites that may serve requests in
+; different "chroot" environments.
+;opcache.validate_root=0
+
+; Enables or disables copying of PHP code (text segment) into HUGE PAGES.
+; This should improve performance, but requires appropriate OS configuration.
+opcache.huge_code_pages=0


### PR DESCRIPTION
opcache needs to be explicitly installed in order to be available.
Initial tests show that this will make Engineblock and Profile an order of magnitude faster
