### PR TITLE
PHP-FPM configs: Enable the status page

### DIFF
--- a/roles/diyidp/templates/diyidp-pool-72.conf.j2
+++ b/roles/diyidp/templates/diyidp-pool-72.conf.j2
@@ -117,7 +117,7 @@ pm.max_requests = 300
 ;       anything, but it may not be a good idea to use the .php extension or it
 ;       may conflict with a real PHP file.
 ; Default Value: not set
-;pm.status_path = /status
+pm.status_path = /status
 
 ; The ping URI to call the monitoring page of FPM. If this value is not set, no
 ; URI will be recognized as a ping page. This could be used to test from outside

--- a/roles/engineblock/templates/engine-pool-72.conf.j2
+++ b/roles/engineblock/templates/engine-pool-72.conf.j2
@@ -118,7 +118,7 @@ pm.max_spare_servers = 35
 ;       anything, but it may not be a good idea to use the .php extension or it
 ;       may conflict with a real PHP file.
 ; Default Value: not set
-;pm.status_path = /status
+pm.status_path = /status
 
 ; The ping URI to call the monitoring page of FPM. If this value is not set, no
 ; URI will be recognized as a ping page. This could be used to test from outside

--- a/roles/lifecycle/templates/lifecycle-pool-72.conf.j2
+++ b/roles/lifecycle/templates/lifecycle-pool-72.conf.j2
@@ -117,7 +117,7 @@ pm.max_requests = 300
 ;       anything, but it may not be a good idea to use the .php extension or it
 ;       may conflict with a real PHP file.
 ; Default Value: not set
-;pm.status_path = /status
+pm.status_path = /status
 
 ; The ping URI to call the monitoring page of FPM. If this value is not set, no
 ; URI will be recognized as a ping page. This could be used to test from outside

--- a/roles/profile/templates/profile-pool-72.conf.j2
+++ b/roles/profile/templates/profile-pool-72.conf.j2
@@ -117,7 +117,7 @@ pm.max_requests = 300
 ;       anything, but it may not be a good idea to use the .php extension or it
 ;       may conflict with a real PHP file.
 ; Default Value: not set
-;pm.status_path = /status
+pm.status_path = /status
 
 ; The ping URI to call the monitoring page of FPM. If this value is not set, no
 ; URI will be recognized as a ping page. This could be used to test from outside


### PR DESCRIPTION
This will allow monitoring agents to access the php fpm statistics page over the php fpm socket