### PR TITLE
Feature/haproxy use proxy protocol internally

### DIFF
--- a/roles/elk/files/logstash/core/11-core-haproxy.conf
+++ b/roles/elk/files/logstash/core/11-core-haproxy.conf
@@ -8,17 +8,12 @@ filter {
       source => "request_header_user_agent"
       target => "ua"
     }
-    mutate {
-       replace => {
-          "client_ip" =>  "%{[request_header_forwarded_for]}"
-       }
     }
     date {
        match => [ "accept_date", "dd/MMM/yyyy:HH:mm:ss.SSS" ]
     }
     mutate {
       remove_field => [ "source" ]
-      remove_field => [ "request_header_forwarded_for" ]
       remove_field => [ "request_header_user_agent" ]
       remove_field => [ "accept_date" ]
       remove_field => [ "haproxy_hour" ]

--- a/roles/elk/files/logstash/patterns/haproxy
+++ b/roles/elk/files/logstash/patterns/haproxy
@@ -1,1 +1,1 @@
-HAPROXYCAPTUREDREQUESTHEADERS %{DATA:request_header_user_agent}\|%{DATA:request_header_forwarded_for}\|%{DATA:request_header_tls_cipher},%{DATA:request_header_tls_version},%{DATA:request_header_http_version}\|%{DATA:http_req_rate_10s}
+HAPROXYCAPTUREDREQUESTHEADERS %{DATA:request_header_user_agent}\|%{DATA:request_header_tls_cipher},%{DATA:request_header_tls_version},%{DATA:request_header_http_version}\|%{DATA:http_req_rate_10s}

--- a/roles/haproxy/templates/haproxy_backend.cfg.j2
+++ b/roles/haproxy/templates/haproxy_backend.cfg.j2
@@ -5,7 +5,7 @@
   backend dummy_backend
   mode http
   option httpclose
-  server localhost 127.0.0.1:81
+  server localhost 127.0.0.1:81 send-proxy
 
 #---------------------------------------------------------------------
 # restricted ip dummy backend
@@ -13,7 +13,7 @@
   backend dummy_backend_restricted
   mode http
   option httpclose
-  server localhost 127.0.0.1:82
+  server localhost 127.0.0.1:82 send-proxy
 
 {% for application in haproxy_applications %}
 #---------------------------------------------------------------------

--- a/roles/haproxy/templates/haproxy_frontend.cfg.j2
+++ b/roles/haproxy/templates/haproxy_frontend.cfg.j2
@@ -15,8 +15,9 @@ frontend internet_ip
     # Rewrite requests
     # We want to log the tls cipher, tls protocol and the http version
     http-request add-header X-TLS-Client %[ssl_fc_cipher],%[ssl_fc_protocol],%[ssl_fc_alpn]
-    # First we strip any Proxy headers
+    # First we strip any Proxy or X-Forwarded-for headers
     http-request del-header Proxy
+    http-request del-header X-Forwarded-For
     # We redirect all port 80 to port 443
     http-request redirect scheme https code 301 if !{ ssl_fc }
     # Log the user agent in the httplogs
@@ -91,8 +92,9 @@ frontend internet_restricted_ip
     # Rewrite requests
     # We want to log the tls cipher, tls protocol and the http version
     http-request add-header X-TLS-Client %[ssl_fc_cipher],%[ssl_fc_protocol],%[ssl_fc_alpn]
-    # First we strip any Proxy headers
+    # First we strip any Proxy or X-Forwarded-for headers
     http-request del-header Proxy
+    http-request del-header X-Forwarded-For
     # We redirect all port 80 to port 443
     http-request redirect scheme https code 301 if !{ ssl_fc }
     # Log the user agent in the httplogs

--- a/roles/haproxy/templates/haproxy_frontend.cfg.j2
+++ b/roles/haproxy/templates/haproxy_frontend.cfg.j2
@@ -12,6 +12,8 @@ frontend internet_ip
     bind {{ haproxy_sni_ip.ipv6 }}:80 transparent
     # Logging is done in the local_ip backend, otherwise all requests are logged twice
     no log
+    # We add the X-Forward-For header here
+    option forwardfor except 127.0.0.0/8
     # Rewrite requests
     # We want to log the tls cipher, tls protocol and the http version
     http-request add-header X-TLS-Client %[ssl_fc_cipher],%[ssl_fc_protocol],%[ssl_fc_alpn]
@@ -41,7 +43,7 @@ frontend internet_ip
 #  traffic coming back from the dummy backend ends up here
 # -------------------------------------------------------------------
 frontend local_ip
-    bind 127.0.0.1:81
+    bind 127.0.0.1:81 accept-proxy
     {% for application in haproxy_applications %}
     {%if application.restricted is not defined %}
     acl valid_vhost hdr(host) -i {{ application.vhost_name }}
@@ -55,13 +57,11 @@ frontend local_ip
     {% endfor %}
     {% endif %}
     option httplog
-    option forwardfor
     capture request header User-agent len 256
-    capture request header X-Forwarded-For len 128
     capture request header X-TLS-Client len 256
     # The following lines are to log the request rate per 10s
     stick-table type ip size 1m expire 10s store http_req_rate(10s)
-    http-request track-sc0 hdr(X-Forwarded-For)
+    http-request track-sc0 src
     http-request capture sc_http_req_rate(0) len 4
     # Deny the request when no valid host header is used
     http-request deny if ! valid_vhost
@@ -89,6 +89,8 @@ frontend internet_restricted_ip
     bind {{ haproxy_sni_ip_restricted.ipv6 }}:80 transparent
     # Logging is done in the local_ip_restriced backend, otherwise all requests are logged twice
     no log
+    # We add the X-Forward-For header here
+    option forwardfor except 127.0.0.0/8
     # Rewrite requests
     # We want to log the tls cipher, tls protocol and the http version
     http-request add-header X-TLS-Client %[ssl_fc_cipher],%[ssl_fc_protocol],%[ssl_fc_alpn]
@@ -118,7 +120,7 @@ frontend internet_restricted_ip
 #  traffic coming back from the dummy backend ends up here
 # -------------------------------------------------------------------
 frontend localhost_restricted    
-    bind 127.0.0.1:82
+    bind 127.0.0.1:82 accept-proxy
     {% for application in haproxy_applications %}
     {%if application.restricted is defined %}
     acl valid_vhost hdr(host) -i {{ application.vhost_name }}
@@ -126,13 +128,11 @@ frontend localhost_restricted
     {% endif %}
     {% endfor %}
     option httplog
-    option forwardfor
     capture request header User-agent len 256
-    capture request header X-Forwarded-For len 128
     capture request header X-TLS-Client len 256
     # The following lines are to log the request rate per 10s
     stick-table type ip size 1m expire 10s store http_req_rate(10s)
-    http-request track-sc0 hdr(X-Forwarded-For)
+    http-request track-sc0 src
     http-request capture sc_http_req_rate(0) len 4
     # Deny the request when no valid host header is used
     http-request deny if ! valid_vhost

--- a/roles/haproxy/templates/haproxy_global.cfg.j2
+++ b/roles/haproxy/templates/haproxy_global.cfg.j2
@@ -35,7 +35,6 @@ defaults
     log                         global
     option                      http-ignore-probes
     option                      http-server-close
-    option                      forwardfor       except 127.0.0.0/8
     option                      redispatch
     retries                     3
     timeout http-request        10s


### PR DESCRIPTION
This will use the [Haproxy proxy](https://www.haproxy.com/fr/blog/haproxy/proxy-protocol/) protocol internally and replaces the internal use of the X-Forwarded-For header, which eliminates so configuration to use that header. Added advantage is that the client's port is preserved as well.

We do keep setting the X-Forwarded-For for backend servers to use. That config option has been relocated to the frontend sections. It was located in the global section, which caused the X-Forwarded-For header to be added twice. Another config option was added to remove any pre existing  X-forwarded-For headers

ELK configs have been changed to reflect this change as well. 