### PR TITLE
Feature/haproxy add maps

### DIFF
--- a/roles/haproxy/tasks/main.yml
+++ b/roles/haproxy/tasks/main.yml
@@ -61,6 +61,17 @@
     group: lbops
     mode: 0775
 
+- name: Create haproxy config map and acl directories
+  file:
+    path: "/etc/haproxy/{{ item }}"
+    state: directory
+    owner: root
+    group: lbops
+    mode: 0755
+  with_items:
+    - acls
+    - maps
+
 - name: Enable haproxy
   service:
     name: haproxy
@@ -144,15 +155,41 @@
   notify:
     - "reload haproxy"
 
+- name: Copy haproxy acls
+  template:
+    src: "{{ item }}.j2"
+    dest: "/etc/haproxy/acls/{{ item }}"
+    owner: root
+    group: lbops
+    mode: 0664
+  with_items:
+    - validvhostsrestricted.acl
+    - validvhostsunrestricted.acl
+  notify:
+    - "reload haproxy"
+
+- name: Copy haproxy maps
+  template: 
+    src: "{{ item }}.j2"
+    dest: "/etc/haproxy/maps/{{ item }}"
+    owner: root
+    group: lbops
+    mode: 0664
+  with_items:
+    - backends.map
+    - redirects.map
+  notify:
+    - "reload haproxy"
+ 
 - name: Place file with list of browsers that do not accept samesite=none cookies
   copy:
     src: nosamesitebrowsers.lst
-    dest: /etc/haproxy/nosamesitebrowsers.lst
+    dest: /etc/haproxy/maps/nosamesitebrowsers.lst
     owner: root
-    group: root
-    mode: 0644
-  notify: 
-    - "reload haproxy" 
+    group: lbops
+    mode: 0664
+  notify:
+    - "reload haproxy"
 
 - name: Start haproxy
   service:  

--- a/roles/haproxy/templates/backends.map.j2
+++ b/roles/haproxy/templates/backends.map.j2
@@ -1,0 +1,3 @@
+{% for application in haproxy_applications %}
+{{ application.vhost_name }} {{ application.name }}_be
+{% endfor %}

--- a/roles/haproxy/templates/haproxy_frontend.cfg.j2
+++ b/roles/haproxy/templates/haproxy_frontend.cfg.j2
@@ -28,7 +28,7 @@ frontend internet_ip
     http-request set-var(txn.useragent) req.fhdr(User-Agent)
     # Create ACLs to make samesite=origin execeptions for unsupported browsers
     # See https://www.chromium.org/updates/same-site/incompatible-clients
-    acl no_same_site_uas var(txn.useragent) -m reg -f /etc/haproxy/nosamesitebrowsers.lst
+    acl no_same_site_uas var(txn.useragent) -m reg -f /etc/haproxy/maps/nosamesitebrowsers.lst
     acl has_same_site_flag res.fhdr(Set-Cookie) -m sub SameSite
     # Rewrite responses
     # Set HSTS on all outgoing responses
@@ -44,18 +44,8 @@ frontend internet_ip
 # -------------------------------------------------------------------
 frontend local_ip
     bind 127.0.0.1:81 accept-proxy
-    {% for application in haproxy_applications %}
-    {%if application.restricted is not defined %}
-    acl valid_vhost hdr(host) -i {{ application.vhost_name }}
-    acl {{ application.name }} hdr(host) -i {{ application.vhost_name }}
-    {% endif %}
-    {% endfor %}
-    {%if haproxy_redirects is defined %}
-    {% for application in haproxy_redirects %}    
-    acl valid_vhost hdr(host) -i {{ application.url }}
-    acl {{ application.name }} hdr(host) -i {{ application.url }}
-    {% endfor %}
-    {% endif %}
+    acl valid_vhost hdr(host) -f /etc/haproxy/acls/validvhostsunrestricted.acl
+    use_backend %[req.hdr(host),lower,map(/etc/haproxy/maps/backends.map)]
     option httplog
     capture request header User-agent len 256
     capture request header X-TLS-Client len 256
@@ -65,17 +55,7 @@ frontend local_ip
     http-request capture sc_http_req_rate(0) len 4
     # Deny the request when no valid host header is used
     http-request deny if ! valid_vhost
-
-    {% for application in haproxy_applications %}
-    {%if application.restricted is not defined %}
-    use_backend {{ application.name }}_be if {{ application.name }}
-    {% endif %}
-    {% endfor %}
-    {%if haproxy_redirects is defined %}
-    {% for application in haproxy_redirects %}
-    http-request redirect location {{ application.redirecturl }} if {{ application.name }}
-    {% endfor %}
-    {% endif %}
+    http-request redirect location %[req.hdr(host),lower,map(/etc/haproxy/maps/redirects.map)] if { req.hdr(host),lower,map_str(/etc/haproxy/maps/redirects.map) -m found }
 
 {% if haproxy_sni_ip_restricted is defined %}
 #--------------------------------------------------------------------
@@ -105,7 +85,7 @@ frontend internet_restricted_ip
     http-request set-var(txn.useragent) req.fhdr(User-Agent)
     # Create ACLs to make samesite=origin execeptions for unsupported browsers
     # See https://www.chromium.org/updates/same-site/incompatible-clients
-    acl no_same_site_uas var(txn.useragent) -m reg -f /etc/haproxy/nosamesitebrowsers.lst
+    acl no_same_site_uas var(txn.useragent) -m reg -f /etc/haproxy/maps/nosamesitebrowsers.lst
     acl has_same_site_flag res.fhdr(Set-Cookie) -m sub SameSite
     # Rewrite responses
     # Set HSTS on all outgoing responses
@@ -121,12 +101,8 @@ frontend internet_restricted_ip
 # -------------------------------------------------------------------
 frontend localhost_restricted    
     bind 127.0.0.1:82 accept-proxy
-    {% for application in haproxy_applications %}
-    {%if application.restricted is defined %}
-    acl valid_vhost hdr(host) -i {{ application.vhost_name }}
-    acl {{ application.name }} hdr(host) -i {{ application.vhost_name }}
-    {% endif %}
-    {% endfor %}
+    acl valid_vhost hdr(host) -f /etc/haproxy/acls/validvhostsrestricted.acl
+    use_backend %[req.hdr(host),lower,map(/etc/haproxy/maps/backends.map)]
     option httplog
     capture request header User-agent len 256
     capture request header X-TLS-Client len 256
@@ -137,9 +113,4 @@ frontend localhost_restricted
     # Deny the request when no valid host header is used
     http-request deny if ! valid_vhost
 
-    {% for application in haproxy_applications %}
-    {%if application.restricted is defined %}
-    use_backend {{ application.name }}_be if {{ application.name }}
-    {% endif %}
-    {% endfor %}
 {% endif %}

--- a/roles/haproxy/templates/redirects.map.j2
+++ b/roles/haproxy/templates/redirects.map.j2
@@ -1,0 +1,5 @@
+{%if haproxy_redirects is defined %}
+{% for application in haproxy_redirects %}
+{{ application.url }} {{ application.redirecturl }}
+{% endfor %}
+{% endif %}

--- a/roles/haproxy/templates/validvhostsrestricted.acl.j2
+++ b/roles/haproxy/templates/validvhostsrestricted.acl.j2
@@ -1,0 +1,5 @@
+{% for application in haproxy_applications %}
+{%if application.restricted is defined %}
+{{ application.vhost_name }}
+{% endif %}
+{% endfor %}

--- a/roles/haproxy/templates/validvhostsunrestricted.acl.j2
+++ b/roles/haproxy/templates/validvhostsunrestricted.acl.j2
@@ -1,0 +1,10 @@
+{% for application in haproxy_applications %}
+{%if application.restricted is not defined %}
+{{ application.vhost_name }}
+{% endif %}
+{% endfor %}
+{%if haproxy_redirects is defined %}
+{% for application in haproxy_redirects %}
+{{ application.url }}
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
Some logic has been moved from the configuration file into lists and maps.
* Allowed vhosts are in a seperate file
* The map host header / backend has been placed in a mapfile
* Redirects are placed in a mapfile

This simplifies the configuration, and also makes it possible to change the maps and acls on the fly.