### PR TITLE
PHP: disable unused functions in Profile and EB

### DIFF
--- a/roles/engineblock/templates/engine-pool-72.conf.j2
+++ b/roles/engineblock/templates/engine-pool-72.conf.j2
@@ -223,3 +223,4 @@ php_admin_value[memory_limit] = {{ engine_fpm_memory }}
 ; Set session path to a directory owned by process user
 php_value[session.save_handler] = files
 php_value[session.save_path] = {{ php_session_dir}}/engine
+php_value[disable_functions] = exec,passthru,shell_exec,system,proc_open,popen,curl_multi_exec,show_source,pcntl_alarm,pcntl_fork,pcntl_waitpid,pcntl_wait,pcntl_wifexited,pcntl_wifstopped,pcntl_wifsignaled,pcntl_wifcontinued,pcntl_wexitstatus,pcntl_wtermsig,pcntl_wstopsig,pcntl_signal,pcntl_signal_dispatch,pcntl_get_last_error,pcntl_strerror,pcntl_sigprocmask,pcntl_sigwaitinfo,pcntl_sigtimedwait,pcntl_exec,pcntl_getpriority,pcntl_setpriority,

--- a/roles/profile/templates/profile-pool-72.conf.j2
+++ b/roles/profile/templates/profile-pool-72.conf.j2
@@ -222,3 +222,4 @@ php_admin_flag[log_errors] = on
 ; Set session path to a directory owned by process user
 php_value[session.save_handler] = files
 php_value[session.save_path] = {{ php_session_dir }}/profile
+php_value[disable_functions] = exec,passthru,shell_exec,system,proc_open,popen,curl_multi_exec,show_source,pcntl_alarm,pcntl_fork,pcntl_waitpid,pcntl_wait,pcntl_wifexited,pcntl_wifstopped,pcntl_wifsignaled,pcntl_wifcontinued,pcntl_wexitstatus,pcntl_wtermsig,pcntl_wstopsig,pcntl_signal,pcntl_signal_dispatch,pcntl_get_last_error,pcntl_strerror,pcntl_sigprocmask,pcntl_sigwaitinfo,pcntl_sigtimedwait,pcntl_exec,pcntl_getpriority,pcntl_setpriority,


### PR DESCRIPTION
This PR replaces this one:
https://github.com/OpenConext/OpenConext-deploy/pull/188

This will disable unused PHP functions to harden the applications
Profile and EngineBlock. Only the php-fpm configuration is changed.

Credits go to @Timdebruijn for initiating this change. 
