### PR TITLE
Haproxy: Add hitless reload options

### DIFF
--- a/roles/haproxy/templates/haproxy_global.cfg.j2
+++ b/roles/haproxy/templates/haproxy_global.cfg.j2
@@ -22,7 +22,7 @@ global
 {% if haproxy_metricbeat %}
   stats socket 127.0.0.1:14567
 {% endif %}
-  stats socket /var/lib/haproxy/haproxy.stats mode 660 level admin user root group lbops
+  stats socket /var/lib/haproxy/haproxy.stats mode 660 level admin user root group lbops expose-fd listeners
   server-state-file /var/lib/haproxy/state
 
 #---------------------------------------------------------------------


### PR DESCRIPTION
This will allow a reload of Haproxy without losing any connections,
under heavy loads. See: https://www.haproxy.com/blog/truly-seamless-reloads-with-haproxy-no-more-hacks/

This might be designed for very high loads, but it doesn't do any harm anyway. 