### PR TITLE
Springboot: Allow apps to be grouped

### DIFF
--- a/molecule/base/molecule.yml
+++ b/molecule/base/molecule.yml
@@ -24,6 +24,7 @@ provisioner:
   env:
     ANSIBLE_REMOTE_TMP: /tmp/
     ANSIBLE_ROLES_PATH: ../../roles
+    ANSIBLE_FILTER_PLUGINS: ../../filter_plugins
   inventory:
     links:
       group_vars: ../../group_vars

--- a/molecule/frontend/molecule.yml
+++ b/molecule/frontend/molecule.yml
@@ -24,6 +24,7 @@ provisioner:
   env:
     ANSIBLE_REMOTE_TMP: /tmp/
     ANSIBLE_ROLES_PATH: ../../roles
+    ANSIBLE_FILTER_PLUGINS: ../../filter_plugins
   inventory:
     links:
       group_vars: ../../group_vars

--- a/molecule/java/molecule.yml
+++ b/molecule/java/molecule.yml
@@ -25,6 +25,7 @@ provisioner:
   env:
     ANSIBLE_REMOTE_TMP: /tmp/
     ANSIBLE_ROLES_PATH: ../../roles
+    ANSIBLE_FILTER_PLUGINS: ../../filter_plugins
   inventory:
     links:
       group_vars: ../../group_vars

--- a/molecule/loadbalancer/molecule.yml
+++ b/molecule/loadbalancer/molecule.yml
@@ -26,6 +26,7 @@ provisioner:
   env:
     ANSIBLE_REMOTE_TMP: /tmp/
     ANSIBLE_ROLES_PATH: ../../roles
+    ANSIBLE_FILTER_PLUGINS: ../../filter_plugins
   inventory:
     links:
       group_vars: ../../group_vars

--- a/molecule/mongo/molecule.yml
+++ b/molecule/mongo/molecule.yml
@@ -24,6 +24,7 @@ provisioner:
   env:
     ANSIBLE_REMOTE_TMP: /tmp/
     ANSIBLE_ROLES_PATH: ../../roles
+    ANSIBLE_FILTER_PLUGINS: ../../filter_plugins
   inventory:
     links:
       group_vars: ../../group_vars

--- a/molecule/mysql/molecule.yml
+++ b/molecule/mysql/molecule.yml
@@ -40,6 +40,7 @@ provisioner:
   env:
     ANSIBLE_REMOTE_TMP: /tmp/
     ANSIBLE_ROLES_PATH: ../../roles
+    ANSIBLE_FILTER_PLUGINS: ../../filter_plugins
   inventory:
     links:
       group_vars: ../../group_vars

--- a/molecule/php/molecule.yml
+++ b/molecule/php/molecule.yml
@@ -24,6 +24,7 @@ provisioner:
   env:
     ANSIBLE_REMOTE_TMP: /tmp/
     ANSIBLE_ROLES_PATH: ../../roles
+    ANSIBLE_FILTER_PLUGINS: ../../filter_plugins
   inventory:
     links:
       group_vars: ../../group_vars

--- a/roles/springboot/defaults/main.yml
+++ b/roles/springboot/defaults/main.yml
@@ -49,11 +49,13 @@ springboot_gui_services:
     enabled: "{{ springboot_services_state.myconext }}"
     version: "{{ myconext_gui_version }}"
   - name: account
-    alias: myconext, account-gui
+    alias: account-gui
+    group: myconext
     enabled: "{{ springboot_services_state.account }}"
     version: "{{ account_gui_version }}"
   - name: eduid
-    alias: myconext, eduid-gui
+    alias: eduid-gui
+    group: myconext
     enabled: "{{ springboot_services_state.eduid }}"
     version: "{{ eduid_gui_version }}"
   - name: dashboard

--- a/roles/springboot/tasks/main.yml
+++ b/roles/springboot/tasks/main.yml
@@ -29,6 +29,7 @@
     loop_var: springboot
   when:
     - springboot.name in _services_to_install or (springboot.alias is defined and springboot.alias in _services_to_install)
+                                              or (springboot.group is defined and springboot.group in _services_to_install)
     - springboot.enabled
 
 - name: "Install Springboot Server services"
@@ -38,4 +39,5 @@
     loop_var: springboot
   when:
     - springboot.name in _services_to_install or (springboot.alias is defined and springboot.alias in _services_to_install)
+                                              or (springboot.group is defined and springboot.group in _services_to_install)
     - springboot.enabled


### PR DESCRIPTION
This allows you to group a set of apps into one allowing to use the group name as springboot_service_to_deploy
