### PR TITLE
iptables: Add specific drop rule at the end of the other rules

### DIFF
--- a/roles/iptables/templates/ip6tables.j2
+++ b/roles/iptables/templates/ip6tables.j2
@@ -61,5 +61,9 @@
 -A INPUT -d ff02::12 -p vrrp -j ACCEPT
 {% endif %}
 
+-A INPUT -j REJECT --reject-with icmp6-adm-prohibited
+-A FORWARD -j REJECT --reject-with icmp6-adm-prohibited
+
+
 COMMIT
 # A newline after COMMIT is required

--- a/roles/iptables/templates/iptables.j2
+++ b/roles/iptables/templates/iptables.j2
@@ -111,5 +111,8 @@
 -A INPUT -p tcp --dport 3306 -j ACCEPT
 {% endif %}
 
+-A INPUT -j REJECT --reject-with icmp-host-prohibited
+-A FORWARD -j REJECT --reject-with icmp-host-prohibited
+
 COMMIT
 # A newline after COMMIT is required


### PR DESCRIPTION
There are no drop rules present in the iptables and ip6tables rules.
