### PR TITLE
Increase maximum syslog logsize for Apache from 1k to 32k

### DIFF
--- a/roles/account-gui/templates/account.conf.j2
+++ b/roles/account-gui/templates/account.conf.j2
@@ -7,8 +7,8 @@ Listen {{ apache_app_listen_address.account }}:{{ loadbalancing.account.port }}
     # General setup for the virtual host, inherited from global configuration
     ServerName https://login.{{ myconext_base_domain }}
 
-    ErrorLog "|/usr/bin/logger -p local3.err  -t 'Apache-account'"
-    CustomLog "|/usr/bin/logger -p local3.info  -t 'Apache-account'" combined
+    ErrorLog "|/usr/bin/logger -S 32k -p local3.err  -t 'Apache-account'"
+    CustomLog "|/usr/bin/logger -S 32k -p local3.info  -t 'Apache-account'" combined
 
     RewriteEngine on
 

--- a/roles/attribute-aggregation-gui/templates/attribute_aggregation.conf.j2
+++ b/roles/attribute-aggregation-gui/templates/attribute_aggregation.conf.j2
@@ -8,8 +8,8 @@ Listen {{ apache_app_listen_address.aa }}:{{ loadbalancing.aa.port }}
     # General setup for the virtual host, inherited from global configuration
     ServerName https://aa.{{ base_domain }}
 
-    ErrorLog "|/usr/bin/logger -p local3.err  -t 'Apache-AA'"
-    CustomLog "|/usr/bin/logger -p local3.info  -t 'Apache-AA'" combined
+    ErrorLog "|/usr/bin/logger -S 32k -p local3.err  -t 'Apache-AA'"
+    CustomLog "|/usr/bin/logger -S 32k -p local3.info  -t 'Apache-AA'" combined
 
     RewriteEngine on
 
@@ -99,8 +99,8 @@ Listen {{ apache_app_listen_address.aa }}:{{ loadbalancing.aa.port }}
     # General setup for the virtual host, inherited from global configuration
     ServerName https://link.{{ base_domain }}
 
-    ErrorLog "|/usr/bin/logger -p local3.err  -t 'Apache-AAlink'"
-    CustomLog "|/usr/bin/logger -p local3.info  -t 'Apache-AAlink'" combined
+    ErrorLog "|/usr/bin/logger -S 32k -p local3.err  -t 'Apache-AAlink'"
+    CustomLog "|/usr/bin/logger -S 32k -p local3.info  -t 'Apache-AAlink'" combined
 
     RewriteEngine on
 

--- a/roles/dashboard-gui/templates/dashboard.conf.j2
+++ b/roles/dashboard-gui/templates/dashboard.conf.j2
@@ -7,8 +7,8 @@ Listen {{ apache_app_listen_address.dashboard }}:{{ loadbalancing.dashboard.port
     # General setup for the virtual host, inherited from global configuration
     ServerName https://dashboard.{{ base_domain }}
 
-    ErrorLog "|/usr/bin/logger -p local3.err  -t 'Apache-dashboard'"
-    CustomLog "|/usr/bin/logger -p local3.info  -t 'Apache-dashboard'" combined
+    ErrorLog "|/usr/bin/logger -S 32k -p local3.err  -t 'Apache-dashboard'"
+    CustomLog "|/usr/bin/logger -S 32k -p local3.info  -t 'Apache-dashboard'" combined
 
     RewriteEngine on
 

--- a/roles/diyidp/templates/diyidp.conf.j2
+++ b/roles/diyidp/templates/diyidp.conf.j2
@@ -25,6 +25,6 @@ Listen {{ apache_app_listen_address.diyidp }}:{{ loadbalancing.diyidp.port }}
     Include ssl_backend.conf
     {% endif %}
 
-    ErrorLog "|/usr/bin/logger -p local3.err  -t 'Apache-DIYIDP'"
-    CustomLog "|/usr/bin/logger -p local3.info  -t 'Apache-DIYIDP'" combined
+    ErrorLog "|/usr/bin/logger -S 32k -p local3.err  -t 'Apache-DIYIDP'"
+    CustomLog "|/usr/bin/logger -S 32k -p local3.info  -t 'Apache-DIYIDP'" combined
 </VirtualHost>

--- a/roles/eduid-gui/templates/eduid.conf.j2
+++ b/roles/eduid-gui/templates/eduid.conf.j2
@@ -7,8 +7,8 @@ Listen {{ apache_app_listen_address.eduid }}:{{ loadbalancing.eduid.port }}
     # General setup for the virtual host, inherited from global configuration
     ServerName https://{{ myconext_base_domain }}
 
-    ErrorLog "|/usr/bin/logger -p local3.err  -t 'Apache-eduid'"
-    CustomLog "|/usr/bin/logger -p local3.info  -t 'Apache-eduid'" combined
+    ErrorLog "|/usr/bin/logger -S 32k -p local3.err  -t 'Apache-eduid'"
+    CustomLog "|/usr/bin/logger -S 32k -p local3.info  -t 'Apache-eduid'" combined
 
     RewriteEngine on
 

--- a/roles/elk/templates/kibana.conf.j2
+++ b/roles/elk/templates/kibana.conf.j2
@@ -41,6 +41,6 @@ Listen {{ apache_app_listen_address.kibana }}:{{ loadbalancing.kibana.port }}
         Header always set X-Xss-Protection "1; mode=block"
         Header set Referrer-Policy "same-origin"
 
-        ErrorLog "|/usr/bin/logger -p local3.err  -t 'Apache-Kibana'"
-        CustomLog "|/usr/bin/logger -p local3.info  -t 'Apache-Kibana'" combined
+        ErrorLog "|/usr/bin/logger -S 32k -p local3.err  -t 'Apache-Kibana'"
+        CustomLog "|/usr/bin/logger -S 32k -p local3.info  -t 'Apache-Kibana'" combined
 </VirtualHost>

--- a/roles/engineblock/templates/engine-api.conf.j2
+++ b/roles/engineblock/templates/engine-api.conf.j2
@@ -41,8 +41,8 @@ Listen {{ apache_app_listen_address.engine_api }}:{{ loadbalancing.engine_api.po
     #Proxy the requests to FPM
     ProxyPassMatch ^/(.*\.php(/.*)?)$ unix:/var/run/php-fpm/engine-pool-72.sock|fcgi://localhost/{{ engine_current_release_symlink }}/web/$1
      
-    ErrorLog "|/usr/bin/logger -p local3.err  -t 'Apache-EBAPI'"
-    CustomLog "|/usr/bin/logger -p local3.info  -t 'Apache-EBAPI'" combined
+    ErrorLog "|/usr/bin/logger -S 32k -p local3.err  -t 'Apache-EBAPI'"
+    CustomLog "|/usr/bin/logger -S 32k -p local3.info  -t 'Apache-EBAPI'" combined
     
     {% if haproxy_backend_tls %}
     SSLEngine on

--- a/roles/engineblock/templates/engine.conf.j2
+++ b/roles/engineblock/templates/engine.conf.j2
@@ -32,8 +32,8 @@ Listen {{ apache_app_listen_address.engine }}:{{ loadbalancing.engine.port }}
     #Proxy the requests to FPM
     ProxyPassMatch ^/(.*\.php(/.*)?)$ unix:/var/run/php-fpm/engine-pool-72.sock|fcgi://localhost/{{ engine_current_release_symlink }}/web/$1
 
-    ErrorLog "|/usr/bin/logger -p local3.err  -t 'Apache-EB'"
-    CustomLog "|/usr/bin/logger -p local3.info  -t 'Apache-EB'" combined
+    ErrorLog "|/usr/bin/logger -S 32k -p local3.err  -t 'Apache-EB'"
+    CustomLog "|/usr/bin/logger -S 32k -p local3.info  -t 'Apache-EB'" combined
     {% if haproxy_backend_tls %}
     SSLEngine on
     SSLCertificateFile      {{ tls.cert_path }}/backend.{{ base_domain }}.pem

--- a/roles/lifecycle/templates/lifecycle.conf.j2
+++ b/roles/lifecycle/templates/lifecycle.conf.j2
@@ -16,8 +16,8 @@ Listen {{ apache_app_listen_address.lifecycle }}:{{ loadbalancing.lifecycle.port
 	RewriteRule ^(.*)$ app.php [QSA,L]
     </Directory>
     ProxyPassMatch ^/(.*\.php(/.*)?)$ unix:/var/run/php-fpm/lifecycle-pool-72.sock|fcgi://localhost{{ lifecycle_current_release_symlink }}/web/$1
-    ErrorLog "|/usr/bin/logger -p local3.err  -t 'Apache-LIFECYCLE'"
-    CustomLog "|/usr/bin/logger -p local3.info  -t 'Apache-LIFECYCLE'" combined
+    ErrorLog "|/usr/bin/logger -S 32k -p local3.err  -t 'Apache-LIFECYCLE'"
+    CustomLog "|/usr/bin/logger -S 32k -p local3.info  -t 'Apache-LIFECYCLE'" combined
     
     {% if haproxy_backend_tls %}
     SSLEngine on

--- a/roles/manage-gui/templates/manage.conf.backdoor.j2
+++ b/roles/manage-gui/templates/manage.conf.backdoor.j2
@@ -7,8 +7,8 @@ Listen {{ apache_app_listen_address.manage }}:{{ loadbalancing.manage.port }}
     # General setup for the virtual host, inherited from global configuration
     ServerName https://manage.{{ base_domain }}
 
-    ErrorLog "|/usr/bin/logger -p local3.err  -t 'Apache-Manage'"
-    CustomLog "|/usr/bin/logger -p local3.info  -t 'Apache-Manage'" combined
+    ErrorLog "|/usr/bin/logger -S 32k -p local3.err  -t 'Apache-Manage'"
+    CustomLog "|/usr/bin/logger -S 32k -p local3.info  -t 'Apache-Manage'" combined
 
     RewriteEngine on
 

--- a/roles/manage-gui/templates/manage.conf.j2
+++ b/roles/manage-gui/templates/manage.conf.j2
@@ -7,8 +7,8 @@ Listen {{ apache_app_listen_address.manage }}:{{ loadbalancing.manage.port }}
     # General setup for the virtual host, inherited from global configuration
     ServerName https://manage.{{ base_domain }}
 
-    ErrorLog "|/usr/bin/logger -p local3.err  -t 'Apache-Manage'"
-    CustomLog "|/usr/bin/logger -p local3.info  -t 'Apache-Manage'" combined
+    ErrorLog "|/usr/bin/logger -S 32k -p local3.err  -t 'Apache-Manage'"
+    CustomLog "|/usr/bin/logger -S 32k -p local3.info  -t 'Apache-Manage'" combined
 
     RewriteEngine on
 

--- a/roles/metadata/templates/metadata.conf.j2
+++ b/roles/metadata/templates/metadata.conf.j2
@@ -22,8 +22,8 @@ Listen {{ apache_app_listen_address.metadata }}:{{ loadbalancing.metadata.port }
         ForceType text/xml
     </Location>
 
-    ErrorLog "|/usr/bin/logger -p local3.err  -t 'Apache-METADATA'"
-    CustomLog "|/usr/bin/logger -p local3.info  -t 'Apache-METADATA'" combined
+    ErrorLog "|/usr/bin/logger -S 32k -p local3.err  -t 'Apache-METADATA'"
+    CustomLog "|/usr/bin/logger -S 32k -p local3.info  -t 'Apache-METADATA'" combined
     
     {% if haproxy_backend_tls %}
     SSLEngine on

--- a/roles/mujina-idp/templates/mujina_idp.conf.j2
+++ b/roles/mujina-idp/templates/mujina_idp.conf.j2
@@ -8,8 +8,8 @@ Listen {{ apache_app_listen_address.mujina_idp }}:{{ loadbalancing.mujina_idp.po
 
     UseCanonicalName On
 
-    ErrorLog "|/usr/bin/logger -p local3.err  -t 'Apache-mujina-idp'"
-    CustomLog "|/usr/bin/logger -p local3.info  -t 'Apache-mujina-idp'" combined
+    ErrorLog "|/usr/bin/logger -S 32k -p local3.err  -t 'Apache-mujina-idp'"
+    CustomLog "|/usr/bin/logger -S 32k -p local3.info  -t 'Apache-mujina-idp'" combined
 
     ProxyPass / http://localhost:{{ springapp_tcpport }}/ retry=0
     ProxyPassReverse / http://localhost:{{ springapp_tcpport }}/ retry=0

--- a/roles/mujina-sp/templates/mujina_sp.conf.j2
+++ b/roles/mujina-sp/templates/mujina_sp.conf.j2
@@ -10,8 +10,8 @@ Listen {{ apache_app_listen_address.mujina_sp }}:{{ loadbalancing.mujina_sp.port
 
     UseCanonicalName On
 
-    ErrorLog "|/usr/bin/logger -p local3.err  -t 'Apache-mujina-sp'"
-    CustomLog "|/usr/bin/logger -p local3.info  -t 'Apache-mujina-sp'" combined
+    ErrorLog "|/usr/bin/logger -S 32k -p local3.err  -t 'Apache-mujina-sp'"
+    CustomLog "|/usr/bin/logger -S 32k -p local3.info  -t 'Apache-mujina-sp'" combined
 
     ProxyPass / http://localhost:{{ springapp_tcpport }}/ retry=0
     ProxyPassReverse / http://localhost:{{ springapp_tcpport }}/ retry=0

--- a/roles/myconext-gui/templates/myconext.conf.j2
+++ b/roles/myconext-gui/templates/myconext.conf.j2
@@ -7,8 +7,8 @@ Listen {{ apache_app_listen_address.myconext }}:{{ loadbalancing.myconext.port }
     # General setup for the virtual host, inherited from global configuration
     ServerName https://mijn.{{ myconext_base_domain }}
 
-    ErrorLog "|/usr/bin/logger -p local3.err  -t 'Apache-myconext'"
-    CustomLog "|/usr/bin/logger -p local3.info  -t 'Apache-myconext'" combined
+    ErrorLog "|/usr/bin/logger -S 32k -p local3.err  -t 'Apache-myconext'"
+    CustomLog "|/usr/bin/logger -S 32k -p local3.info  -t 'Apache-myconext'" combined
 
     RewriteEngine on
 

--- a/roles/oidc-playground-client/templates/oidc-playground.conf.j2
+++ b/roles/oidc-playground-client/templates/oidc-playground.conf.j2
@@ -7,8 +7,8 @@ Listen {{ apache_app_listen_address.oidc_playground }}:{{ loadbalancing.oidc_pla
     # General setup for the virtual host, inherited from global configuration
     ServerName https://oidc-playground.{{ base_domain }}
 
-    ErrorLog "|/usr/bin/logger -p local3.err  -t 'Apache-Oidc-Playground'"
-    CustomLog "|/usr/bin/logger -p local3.info  -t 'Apache-Oidc-Playground'" combined
+    ErrorLog "|/usr/bin/logger -S 32k -p local3.err  -t 'Apache-Oidc-Playground'"
+    CustomLog "|/usr/bin/logger -S 32k -p local3.info  -t 'Apache-Oidc-Playground'" combined
 
     RewriteEngine on
 

--- a/roles/oidcng/templates/oidcng.conf.j2
+++ b/roles/oidcng/templates/oidcng.conf.j2
@@ -7,8 +7,8 @@ Listen {{ apache_app_listen_address.oidcng }}:{{ loadbalancing.oidcng.port }}
 
     ServerName https://{{ oidcng_base_hostname }}
 
-    ErrorLog "|/usr/bin/logger -p local3.err  -t 'Apache-oidcng'"
-    CustomLog "|/usr/bin/logger -p local3.info  -t 'Apache-oidcng'" combined
+    ErrorLog "|/usr/bin/logger -S 32k -p local3.err  -t 'Apache-oidcng'"
+    CustomLog "|/usr/bin/logger -S 32k -p local3.info  -t 'Apache-oidcng'" combined
 
     ProxyPass /.well-known/openid-configuration http://localhost:{{ springapp_tcpport}}/oidc/.well-known/openid-configuration retry=0
     ProxyPass / http://localhost:{{ springapp_tcpport }}/ retry=0

--- a/roles/pdp-gui/templates/pdp.conf.j2
+++ b/roles/pdp-gui/templates/pdp.conf.j2
@@ -8,8 +8,8 @@ Listen {{ apache_app_listen_address.pdp }}:{{ loadbalancing.pdp.port }}
     # General setup for the virtual host, inherited from global configuration
     ServerName https://pdp.{{ base_domain }}
 
-    ErrorLog "|/usr/bin/logger -p local3.err  -t 'Apache-PDP'"
-    CustomLog "|/usr/bin/logger -p local3.info  -t 'Apache-PDP'" combined
+    ErrorLog "|/usr/bin/logger -S 32k -p local3.err  -t 'Apache-PDP'"
+    CustomLog "|/usr/bin/logger -S 32k -p local3.info  -t 'Apache-PDP'" combined
 
     RewriteEngine on
 

--- a/roles/profile/templates/profile.conf.j2
+++ b/roles/profile/templates/profile.conf.j2
@@ -26,8 +26,8 @@ Listen {{ apache_app_listen_address.profile }}:{{ loadbalancing.profile.port }}
     # Proxy the requests to FPM
     ProxyPassMatch ^/(.*\.php(/.*)?)$ unix:/var/run/php-fpm/profile-pool-72.sock|fcgi://localhost/{{ profile_current_release_symlink }}/web/$1
 
-    ErrorLog "|/usr/bin/logger -p local3.err  -t 'Apache-PROFILE'"
-    CustomLog "|/usr/bin/logger -p local3.info  -t 'Apache-PROFILE'" combined
+    ErrorLog "|/usr/bin/logger -S 32k -p local3.err  -t 'Apache-PROFILE'"
+    CustomLog "|/usr/bin/logger -S 32k -p local3.info  -t 'Apache-PROFILE'" combined
     {% if haproxy_backend_tls %}
     SSLEngine on
     SSLCertificateFile      {{ tls.cert_path }}/backend.{{ base_domain }}.pem

--- a/roles/static/templates/static.conf.j2
+++ b/roles/static/templates/static.conf.j2
@@ -12,8 +12,8 @@ Listen {{ apache_app_listen_address.static }}:{{ loadbalancing.static.port }}
     Header set X-Content-Type-Options "nosniff"
     Header set X-XSS-Protection "1; mode=block"
 
-    ErrorLog "|/usr/bin/logger -p local3.err  -t 'Apache-STATIC'"
-    CustomLog "|/usr/bin/logger -p local3.info  -t 'Apache-STATIC'" combined
+    ErrorLog "|/usr/bin/logger -S 32k -p local3.err  -t 'Apache-STATIC'"
+    CustomLog "|/usr/bin/logger -S 32k -p local3.info  -t 'Apache-STATIC'" combined
     
     {% if haproxy_backend_tls %}
     SSLEngine on

--- a/roles/stats/templates/stats.conf.j2
+++ b/roles/stats/templates/stats.conf.j2
@@ -9,8 +9,8 @@ Listen {{ apache_app_listen_address.stats }}:{{ loadbalancing.stats.port }}
     ServerAdmin {{ apache_server_admin }}
 
     DocumentRoot {{ stats_api_env_dir }}/www/
-    ErrorLog "|/usr/bin/logger -p local3.err  -t 'Apache-STATS'"
-    CustomLog "|/usr/bin/logger -p local3.info  -t 'Apache-STATS'" combined
+    ErrorLog "|/usr/bin/logger -S 32k -p local3.err  -t 'Apache-STATS'"
+    CustomLog "|/usr/bin/logger -S 32k -p local3.info  -t 'Apache-STATS'" combined
 
     RewriteEngine on
 

--- a/roles/teams-gui/templates/teams.conf.j2
+++ b/roles/teams-gui/templates/teams.conf.j2
@@ -8,8 +8,8 @@ Listen {{ apache_app_listen_address.teams }}:{{ loadbalancing.teams.port }}
     # General setup for the virtual host, inherited from global configuration
     ServerName https://teams.{{ base_domain }}
 
-    ErrorLog "|/usr/bin/logger -p local3.err  -t 'Apache-teams'"
-    CustomLog "|/usr/bin/logger -p local3.info  -t 'Apache-teams'" combined
+    ErrorLog "|/usr/bin/logger -S 32k -p local3.err  -t 'Apache-teams'"
+    CustomLog "|/usr/bin/logger -S 32k -p local3.info  -t 'Apache-teams'" combined
 
     RewriteEngine on
 

--- a/roles/voot/templates/voot.conf.j2
+++ b/roles/voot/templates/voot.conf.j2
@@ -7,8 +7,8 @@ Listen {{ apache_app_listen_address.voot }}:{{ loadbalancing.voot.port }}
     # General setup for the virtual host, inherited from global configuration
     ServerName https://voot.{{ base_domain }}
 
-    ErrorLog "|/usr/bin/logger -p local3.err  -t 'Apache-VOOT'" 
-    CustomLog "|/usr/bin/logger -p local3.info  -t 'Apache-VOOT'" combined
+    ErrorLog "|/usr/bin/logger -S 32k -p local3.err  -t 'Apache-VOOT'" 
+    CustomLog "|/usr/bin/logger -S 32k -p local3.info  -t 'Apache-VOOT'" combined
 
     ProxyPass / http://localhost:{{ springapp_tcpport }}/ retry=0
 

--- a/roles/welcome/templates/welcome-vm.conf.j2
+++ b/roles/welcome/templates/welcome-vm.conf.j2
@@ -9,8 +9,8 @@ Listen {{ apache_app_listen_address.welcome }}:{{ loadbalancing.welcome.port }}
 
     DocumentRoot /var/www/welcome
 
-    ErrorLog "|/usr/bin/logger -p local3.err  -t 'Apache-Welcome'"
-    CustomLog "|/usr/bin/logger -p local3.info  -t 'Apache-Welcome'" combined
+    ErrorLog "|/usr/bin/logger -S 32k -p local3.err  -t 'Apache-Welcome'"
+    CustomLog "|/usr/bin/logger -S 32k -p local3.info  -t 'Apache-Welcome'" combined
     
     {% if haproxy_backend_tls %}
     SSLEngine on


### PR DESCRIPTION
This prevents large messages (like engineblock authn requests) from splitting up over several lines in syslog