### PR TITLE
Make supported acr_values in OIDC playground match those configured for OIDCNG

### DIFF
--- a/roles/oidc-playground-server/templates/application.yml.j2
+++ b/roles/oidc-playground-server/templates/application.yml.j2
@@ -29,3 +29,9 @@ gui:
   disclaimer:
     background-color: "{{ oidc_playground.gui_disclaimer.background_color }}"
     content: "{{ oidc_playground.gui_disclaimer.content }}"
+
+acr:
+  values:
+  {% for loa in oidcng.acr_values_supported %}
+    - "{{ loa }}"
+  {% endfor %}


### PR DESCRIPTION
Instead of using the hardcoded list that ships with oidc-playground jar