### PR TITLE
Feature/haproxy block http methods

### DIFF
--- a/roles/haproxy/defaults/main.yml
+++ b/roles/haproxy/defaults/main.yml
@@ -1,4 +1,6 @@
 tls_backend_ca: /etc/pki/haproxy/backend.{{ base_domain }}.pem
 haproxy_cookie_max_idle: 3600
 haproxy_metricbeat: False
+# The default http methods whitelist is meant to disable methods like TRACE or DEBUG.
+# OPTIONS is mainly used for CORS requests in OIDC-NG (like SPA apps)
 haproxy_supported_http_methods: "GET HEAD OPTIONS POST PUT DELETE"

--- a/roles/haproxy/defaults/main.yml
+++ b/roles/haproxy/defaults/main.yml
@@ -1,4 +1,3 @@
 tls_backend_ca: /etc/pki/haproxy/backend.{{ base_domain }}.pem
-haproxy_removal_applications: []
 haproxy_cookie_max_idle: 3600
 haproxy_metricbeat: False

--- a/roles/haproxy/defaults/main.yml
+++ b/roles/haproxy/defaults/main.yml
@@ -1,3 +1,4 @@
 tls_backend_ca: /etc/pki/haproxy/backend.{{ base_domain }}.pem
 haproxy_cookie_max_idle: 3600
 haproxy_metricbeat: False
+haproxy_supported_http_methods: "GET HEAD OPTIONS POST PUT DELETE"

--- a/roles/haproxy/templates/haproxy_frontend.cfg.j2
+++ b/roles/haproxy/templates/haproxy_frontend.cfg.j2
@@ -28,7 +28,7 @@ frontend internet_ip
     http-request set-var(txn.useragent) req.fhdr(User-Agent)
     # The ACL below makes sure only supported http methods are allowed
     acl valid_method method {{ haproxy_supported_http_methods }}
-    http-request deny if !valid_method
+    http-request deny deny_status 405 if !valid_method
     # Create ACLs to make samesite=origin execeptions for unsupported browsers
     # See https://www.chromium.org/updates/same-site/incompatible-clients
     acl no_same_site_uas var(txn.useragent) -m reg -f /etc/haproxy/maps/nosamesitebrowsers.lst
@@ -88,7 +88,7 @@ frontend internet_restricted_ip
     http-request set-var(txn.useragent) req.fhdr(User-Agent)
     # The ACL below makes sure only supported http methods are allowed
     acl valid_method method {{ haproxy_supported_http_methods }}
-    http-request deny if !valid_method
+    http-request deny deny_status 405 if !valid_method
     # Create ACLs to make samesite=origin execeptions for unsupported browsers
     # See https://www.chromium.org/updates/same-site/incompatible-clients
     acl no_same_site_uas var(txn.useragent) -m reg -f /etc/haproxy/maps/nosamesitebrowsers.lst

--- a/roles/haproxy/templates/haproxy_frontend.cfg.j2
+++ b/roles/haproxy/templates/haproxy_frontend.cfg.j2
@@ -26,6 +26,9 @@ frontend internet_ip
     capture request header User-agent len 256
     # Put the useragent header in a variable, shared between request and response. 
     http-request set-var(txn.useragent) req.fhdr(User-Agent)
+    # The ACL below makes sure only supported http methods are allowed
+    acl valid_method method {{ haproxy_supported_http_methods }}
+    http-request deny if !valid_method
     # Create ACLs to make samesite=origin execeptions for unsupported browsers
     # See https://www.chromium.org/updates/same-site/incompatible-clients
     acl no_same_site_uas var(txn.useragent) -m reg -f /etc/haproxy/maps/nosamesitebrowsers.lst
@@ -83,6 +86,9 @@ frontend internet_restricted_ip
     capture request header User-agent len 256 
     # Put the useragent header in a variable, shared between request and response. 
     http-request set-var(txn.useragent) req.fhdr(User-Agent)
+    # The ACL below makes sure only supported http methods are allowed
+    acl valid_method method {{ haproxy_supported_http_methods }}
+    http-request deny if !valid_method
     # Create ACLs to make samesite=origin execeptions for unsupported browsers
     # See https://www.chromium.org/updates/same-site/incompatible-clients
     acl no_same_site_uas var(txn.useragent) -m reg -f /etc/haproxy/maps/nosamesitebrowsers.lst


### PR DESCRIPTION
This adds the ability in Haproxy to whitelist only allowed http methods. 

The current list is:
GET HEAD OPTIONS POST PUT DELETE

Other methods are not needed by the OpenConext stack. 