### PR TITLE
Feature/haproxy block excessive requests

### DIFF
--- a/roles/elk/files/logstash/patterns/haproxy
+++ b/roles/elk/files/logstash/patterns/haproxy
@@ -1,1 +1,1 @@
-HAPROXYCAPTUREDREQUESTHEADERS %{DATA:request_header_user_agent}\|%{DATA:request_header_tls_cipher},%{DATA:request_header_tls_version},%{DATA:request_header_http_version}\|%{DATA:http_req_rate_10s}
+HAPROXYCAPTUREDREQUESTHEADERS %{DATA:request_header_user_agent}\|%{DATA:request_header_tls_cipher},%{DATA:request_header_tls_version},%{DATA:request_header_http_version}\|%{DATA:http_req_rate_10s}\|%{DATA:http_req_rate_ip_path_1m}

--- a/roles/haproxy/README.md
+++ b/roles/haproxy/README.md
@@ -85,6 +85,25 @@ certs: A list of certificates that you use for https. That list contains these p
  key_content: You can add your https key in this parameter, and add it to your secrets. See environments/vm/secrets/vm.yml for an example
  crt_name: The certificate is placed in your environments directory: In files/certs/. The filename should match "crt_name"
 
+## Rate limiting
+The frontend has a limit that is configurable for the amount of requests per 10s. The rationale is that you want to stop sudden bursts of requests fired by clients, and you want to be quick enough to block it, before your backends are saturated. The default is 1000 requests per 10s. In our logs, we observed some NAT gateways of larger instutitions that were able to generate more than 500 legitimate requests per 10s. All rates above 1000 per 10s seemed to be coming from bots, scrapers, or misbehaving clients.
+If you want to exclude ip's (either in cidr notation, or single ip addresses) from the limit, you can add them to your configuration under ```haproxy_allowlistips```. Suppose you want to put the ip address 1.1.1.1 and the ip addres 2.2.2.2 to the allowlist, you can do so by putting the following in your environment:
+```
+haproxy_allowlistips:
+  - 1.1.1.1
+  - 2.2.2.2
+```
+
+You can also do this on a running loadbalancer by using entering this command:
+```
+echo "add acl /etc/haproxy/acls/allowedips 1.1.1.1" | socat unix-connect:/var/lib/haproxy/haproxy.stats stdio
+echo "add acl /etc/haproxy/acls/allowedips 2.2.2.2" | socat unix-connect:/var/lib/haproxy/haproxy.stats stdio
+```
+Please note that such a change does not survive a restart of haproxy. Adding them to the acl and deploying haproxy makes it permanent. 
+
+
+
+
 
 
 

--- a/roles/haproxy/defaults/main.yml
+++ b/roles/haproxy/defaults/main.yml
@@ -3,3 +3,6 @@ haproxy_cookie_max_idle: 3600
 haproxy_metricbeat: False
 haproxy_supported_http_methods: "GET HEAD OPTIONS POST PUT DELETE"
 haproxy_max_request_rate: 1000
+# You can create an allowlist of ips that are allowed to go over the configured ratelimit
+haproxy_allowlistips:
+  - ''

--- a/roles/haproxy/defaults/main.yml
+++ b/roles/haproxy/defaults/main.yml
@@ -2,3 +2,4 @@ tls_backend_ca: /etc/pki/haproxy/backend.{{ base_domain }}.pem
 haproxy_cookie_max_idle: 3600
 haproxy_metricbeat: False
 haproxy_supported_http_methods: "GET HEAD OPTIONS POST PUT DELETE"
+haproxy_max_request_rate: 1000

--- a/roles/haproxy/files/sysconfig_haproxy
+++ b/roles/haproxy/files/sysconfig_haproxy
@@ -2,4 +2,4 @@
 # specifying multiple configuration files with multiple -f options.
 # See haproxy(1) for a complete list of options.
 # This overrides the default haproxy.cfg config file
-CONFIG="/etc/haproxy/haproxy_global.cfg -f /etc/haproxy/haproxy_frontend.cfg -f /etc/haproxy/haproxy_backend.cfg"
+CONFIG="/etc/haproxy/haproxy_global.cfg -f /etc/haproxy/haproxy_frontend.cfg -f /etc/haproxy/haproxy_backend.cfg -f /etc/haproxy/haproxy_stick_table_backend.cfg"

--- a/roles/haproxy/tasks/main.yml
+++ b/roles/haproxy/tasks/main.yml
@@ -46,6 +46,8 @@
   copy:
     src: sysconfig_haproxy 
     dest: /etc/sysconfig/haproxy
+  notify:
+    - "restart haproxy"
 
 - name: install OCSP update tool
   copy:
@@ -152,6 +154,7 @@
     - haproxy_global.cfg
     - haproxy_frontend.cfg
     - haproxy_backend.cfg
+    - haproxy_stick_table_backend.cfg
   notify:
     - "reload haproxy"
 

--- a/roles/haproxy/tasks/main.yml
+++ b/roles/haproxy/tasks/main.yml
@@ -168,6 +168,7 @@
   with_items:
     - validvhostsrestricted.acl
     - validvhostsunrestricted.acl
+    - allowedips.acl
   notify:
     - "reload haproxy"
 

--- a/roles/haproxy/templates/allowedips.acl.j2
+++ b/roles/haproxy/templates/allowedips.acl.j2
@@ -1,0 +1,3 @@
+{% for ip in haproxy_allowlistips %}
+{{ ip }}
+{% endfor %}

--- a/roles/haproxy/templates/haproxy_frontend.cfg.j2
+++ b/roles/haproxy/templates/haproxy_frontend.cfg.j2
@@ -52,17 +52,21 @@ frontend local_ip
     option httplog
     capture request header User-agent len 256
     capture request header X-TLS-Client len 256
+    # Allowlist ACL
+    acl allowlist src -f /etc/haproxy/acls/allowedips.acl
     # Measure and log the request rate per 10s
     http-request track-sc0 src table st_httpreqs_per_ip
     http-request capture sc_http_req_rate(0) len 4
-    # Create an ACL when the request rate exceeds {{ haproxy_max_request_rate }} per 10s and deny them
+    # Create an ACL when the request rate exceeds {{ haproxy_max_request_rate }} per 10s
     acl exceeds_max_request_rate_per_ip sc_http_req_rate(0) gt {{ haproxy_max_request_rate }}
-    http-request deny deny_status 429 if exceeds_max_request_rate_per_ip
     # Measure and log the request rate per path and ip 
     http-request track-sc1 base32+src table st_httpreqs_per_ip_and_path
     http-request capture sc_http_req_rate(1) len 4
     # Deny the request when no valid host header is used
     http-request deny if ! valid_vhost
+    # Deny the request when the request rate exceeds {{ haproxy_max_request_rate }} per 10s
+    http-request deny deny_status 429 if exceeds_max_request_rate_per_ip !allowlist
+    # Create some http redirects
     http-request redirect location %[req.hdr(host),lower,map(/etc/haproxy/maps/redirects.map)] if { req.hdr(host),lower,map_str(/etc/haproxy/maps/redirects.map) -m found }
 
 {% if haproxy_sni_ip_restricted is defined %}
@@ -117,16 +121,20 @@ frontend localhost_restricted
     option httplog
     capture request header User-agent len 256
     capture request header X-TLS-Client len 256
+    # Allowlist ACL
+    acl allowlist src -f /etc/haproxy/acls/allowedips.acl
     # Measure and log the request rate per 10s
     http-request track-sc0 src table st_httpreqs_per_ip
     http-request capture sc_http_req_rate(0) len 4
-    # Create an ACL when the request rate exceeds {{ haproxy_max_request_rate }} per 10s and deny them
+    # Create an ACL when the request rate exceeds {{ haproxy_max_request_rate }} per 10s
     acl exceeds_max_request_rate_per_ip sc_http_req_rate(0) gt {{ haproxy_max_request_rate }}
-    http-request deny deny_status 429 if exceeds_max_request_rate_per_ip
+    http-request deny deny_status 429 if exceeds_max_request_rate_per_ip !allowlist
     # Measure and log the request rate per path and ip 
     http-request track-sc1 base32+src table st_httpreqs_per_ip_and_path
     http-request capture sc_http_req_rate(1) len 4
     # Deny the request when no valid host header is used
     http-request deny if ! valid_vhost
+    # Deny the request when the request rate exceeds {{ haproxy_max_request_rate }} per 10s
+    http-request deny deny_status 429 if exceeds_max_request_rate_per_ip !allowlist
 
 {% endif %}

--- a/roles/haproxy/templates/haproxy_frontend.cfg.j2
+++ b/roles/haproxy/templates/haproxy_frontend.cfg.j2
@@ -52,10 +52,12 @@ frontend local_ip
     option httplog
     capture request header User-agent len 256
     capture request header X-TLS-Client len 256
-    # The following lines are to log the request rate per 10s
-    stick-table type ip size 1m expire 10s store http_req_rate(10s)
-    http-request track-sc0 src
+    # Measure and log the request rate per 10s
+    http-request track-sc0 src table st_httpreqs_per_ip
     http-request capture sc_http_req_rate(0) len 4
+    # Create an ACL when the request rate exceeds {{ haproxy_max_request_rate }} per 10s and deny them
+    acl exceeds_max_request_rate_per_ip sc_http_req_rate(0) gt {{ haproxy_max_request_rate }}
+    http-request deny deny_status 429 if exceeds_max_request_rate_per_ip
     # Deny the request when no valid host header is used
     http-request deny if ! valid_vhost
     http-request redirect location %[req.hdr(host),lower,map(/etc/haproxy/maps/redirects.map)] if { req.hdr(host),lower,map_str(/etc/haproxy/maps/redirects.map) -m found }
@@ -112,10 +114,12 @@ frontend localhost_restricted
     option httplog
     capture request header User-agent len 256
     capture request header X-TLS-Client len 256
-    # The following lines are to log the request rate per 10s
-    stick-table type ip size 1m expire 10s store http_req_rate(10s)
-    http-request track-sc0 src
+    # Measure and log the request rate per 10s
+    http-request track-sc0 src table st_httpreqs_per_ip
     http-request capture sc_http_req_rate(0) len 4
+    # Create an ACL when the request rate exceeds {{ haproxy_max_request_rate }} per 10s and deny them
+    acl exceeds_max_request_rate_per_ip sc_http_req_rate(0) gt {{ haproxy_max_request_rate }}
+    http-request deny deny_status 429 if exceeds_max_request_rate_per_ip
     # Deny the request when no valid host header is used
     http-request deny if ! valid_vhost
 

--- a/roles/haproxy/templates/haproxy_frontend.cfg.j2
+++ b/roles/haproxy/templates/haproxy_frontend.cfg.j2
@@ -58,6 +58,9 @@ frontend local_ip
     # Create an ACL when the request rate exceeds {{ haproxy_max_request_rate }} per 10s and deny them
     acl exceeds_max_request_rate_per_ip sc_http_req_rate(0) gt {{ haproxy_max_request_rate }}
     http-request deny deny_status 429 if exceeds_max_request_rate_per_ip
+    # Measure and log the request rate per path and ip 
+    http-request track-sc1 base32+src table st_httpreqs_per_ip_and_path
+    http-request capture sc_http_req_rate(1) len 4
     # Deny the request when no valid host header is used
     http-request deny if ! valid_vhost
     http-request redirect location %[req.hdr(host),lower,map(/etc/haproxy/maps/redirects.map)] if { req.hdr(host),lower,map_str(/etc/haproxy/maps/redirects.map) -m found }
@@ -120,6 +123,9 @@ frontend localhost_restricted
     # Create an ACL when the request rate exceeds {{ haproxy_max_request_rate }} per 10s and deny them
     acl exceeds_max_request_rate_per_ip sc_http_req_rate(0) gt {{ haproxy_max_request_rate }}
     http-request deny deny_status 429 if exceeds_max_request_rate_per_ip
+    # Measure and log the request rate per path and ip 
+    http-request track-sc1 base32+src table st_httpreqs_per_ip_and_path
+    http-request capture sc_http_req_rate(1) len 4
     # Deny the request when no valid host header is used
     http-request deny if ! valid_vhost
 

--- a/roles/haproxy/templates/haproxy_stick_table_backend.cfg.j2
+++ b/roles/haproxy/templates/haproxy_stick_table_backend.cfg.j2
@@ -2,3 +2,7 @@
 # ipv4 addresses are mapped to ipv6 for type ipv6, and work for both
 backend st_httpreqs_per_ip
   stick-table type ipv6 size 1m expire 10s store http_req_rate(10s)
+
+# Measure the unique ip and path request rates per minute
+backend st_httpreqs_per_ip_and_path
+    stick-table type binary len 8 size 1m expire 1m store http_req_rate(1m)

--- a/roles/haproxy/templates/haproxy_stick_table_backend.cfg.j2
+++ b/roles/haproxy/templates/haproxy_stick_table_backend.cfg.j2
@@ -1,0 +1,4 @@
+# Measure number of http requests per 10 seconds
+# ipv4 addresses are mapped to ipv6 for type ipv6, and work for both
+backend st_httpreqs_per_ip
+  stick-table type ipv6 size 1m expire 10s store http_req_rate(10s)


### PR DESCRIPTION
A few changes are present in this PR:

I've rewritten the collection of request rates so that each sticky table is in its' own backend: There is only one such definition allowed per front- or backend. I've also created a seperate config file for the sticky tables. Furthermore, ipv6 addresses are now taken into account as well. 

Up until now, the request rate per ip address was only logged, no blocklist acl was yet in place. I've added it here, and the default is 1000 requests per 10s (total connections to all applications behind the loadbalancer). Some NATted ip addresses are capable of generating over 500 valid requests per 10s. Logging showed that all requests over 1000 per 10s are bots. When the amount of requests drops below 1000 per 10s requests will be allowed again. The rate limit is configurable by setting `haproxy_max_request_rate`

Of course, the measure above is course grained, but meant to keep out abusive bots generating too many requests per second.
I've added a second sticky table to log the amount of requests per ip address/URL path combination: the path is everything after the hostname, and before the first "?" in a URL. The idea is to block abusers that generate lots of requests to a single path. For now, only logging is added to get an idea of what is considered normal, and what is typical abusive behaviour so we can block it with a 429 in the future. 
