### PR TITLE
Feature/haproxy server maxconn variable

### DIFF
--- a/roles/haproxy/templates/haproxy_backend.cfg.j2
+++ b/roles/haproxy/templates/haproxy_backend.cfg.j2
@@ -34,7 +34,7 @@
   cookie HTTPSERVERID insert nocache indirect httponly secure maxidle {{ haproxy_cookie_max_idle }}
 
   {% for server in application.servers %}
-  server {{ server.label }} {{ server.ip }}:{{ application.port }} cookie {{ server.label }} check inter 8000 fall 5 rise 2 maxconn 1024 {% if application.sslbackend is defined%} ssl verify required verifyhost {{ application.backend_vhost_name }} ca-file {{ application.backend_ca_file }}{% endif %} weight 100
+  server {{ server.label }} {{ server.ip }}:{{ application.port }} cookie {{ server.label }} check inter 8000 fall 5 rise 2 maxconn {{ application.maxconn | default('35') }} {% if application.sslbackend is defined%} ssl verify required verifyhost {{ application.backend_vhost_name }} ca-file {{ application.backend_ca_file }}{% endif %} weight 100
     
   {% endfor %}
 

--- a/roles/haproxy/templates/haproxy_backend.cfg.j2
+++ b/roles/haproxy/templates/haproxy_backend.cfg.j2
@@ -34,9 +34,8 @@
   cookie HTTPSERVERID insert nocache indirect httponly secure maxidle {{ haproxy_cookie_max_idle }}
 
   {% for server in application.servers %}
-  server {{ server.label }} {{ server.ip }}:{{ application.port }} cookie {{ server.label }} check inter 8000 fall 5 rise 2 maxconn 1024 {% if application.sslbackend is defined%} ssl verify required verifyhost {{ application.backend_vhost_name }} ca-file {{ application.backend_ca_file }} weight 100
-  {% endif %}
-  
+  server {{ server.label }} {{ server.ip }}:{{ application.port }} cookie {{ server.label }} check inter 8000 fall 5 rise 2 maxconn 1024 {% if application.sslbackend is defined%} ssl verify required verifyhost {{ application.backend_vhost_name }} ca-file {{ application.backend_ca_file }}{% endif %} weight 100
+    
   {% endfor %}
 
 {% endfor %}


### PR DESCRIPTION
This change makes the amount of concurrent requests to a backend configurable. After reaching this limit, Haproxy will queue the requests. It makes sure that the backends are not saturated 
The default is 35 concurrent connections (as is the default currently in the php fpm servers as well). It can be overriden on a per application basis in haproxy_applications, setting the maxconn variable per app. If it's not defined, the default of 35 is used. 