### PR TITLE
Haproxy: Add an ACL to allowing the blocking of ip addresses

### DIFF
--- a/roles/haproxy/README.md
+++ b/roles/haproxy/README.md
@@ -96,13 +96,47 @@ haproxy_allowlistips:
 
 You can also do this on a running loadbalancer by using entering this command:
 ```
-echo "add acl /etc/haproxy/acls/allowedips 1.1.1.1" | socat unix-connect:/var/lib/haproxy/haproxy.stats stdio
-echo "add acl /etc/haproxy/acls/allowedips 2.2.2.2" | socat unix-connect:/var/lib/haproxy/haproxy.stats stdio
+echo "add acl /etc/haproxy/acls/allowedips.acl 1.1.1.1" | socat unix-connect:/var/lib/haproxy/haproxy.stats stdio
+echo "add acl /etc/haproxy/acls/allowedips.acl 2.2.2.2" | socat unix-connect:/var/lib/haproxy/haproxy.stats stdio
 ```
 Please note that such a change does not survive a restart of haproxy. Adding them to the acl and deploying haproxy makes it permanent. 
 
+Removing an ip address is done using the command del acl:
+```
+echo "del acl /etc/haproxy/acls/allowedips.acl 1.1.1.1" | socat unix-connect:/var/lib/haproxy/haproxy.stats stdio
+echo "del acl /etc/haproxy/acls/allowedips.acl 2.2.2.2" | socat unix-connect:/var/lib/haproxy/haproxy.stats stdio
+```
+If you want to view the current list, you can enter:
+```
+echo "show acl /etc/haproxy/acls/allowedips.acl" | socat unix-connect:/var/lib/haproxy/haproxy.stats stdio
+```
 
+## Blocking IP addresses
+A blocklist ACL is present to block IP addresses. This can be usefull to quickly block abusers.
+If you want to block IP addresses (either in cidr notation, or single ip addresses), you can add them to your configuration under ```haproxy_blocklistips```. Suppose you want to put the ip address 1.1.1.1 and the ip addres 2.2.2.2 to the blocklist, you can do so by putting the following in your environment:
 
+```
+haproxy_blocklistips:
+  - 1.1.1.1
+  - 2.2.2.2
+```
+
+You can also do this on a running loadbalancer by using entering this command:
+```
+echo "add acl /etc/haproxy/acls/blockedips.acl 1.1.1.1" | socat unix-connect:/var/lib/haproxy/haproxy.stats stdio
+echo "add acl /etc/haproxy/acls/blockedips.acl 2.2.2.2" | socat unix-connect:/var/lib/haproxy/haproxy.stats stdio
+```
+Please note that such a change does not survive a restart of haproxy. Adding them to the acl and deploying haproxy makes it permanent. 
+Removing an ip address is done using the command del acl:
+```
+echo "del acl /etc/haproxy/acls/blockedips.acl 1.1.1.1" | socat unix-connect:/var/lib/haproxy/haproxy.stats stdio
+echo "del acl /etc/haproxy/acls/blockedips.acl 2.2.2.2" | socat unix-connect:/var/lib/haproxy/haproxy.stats stdio
+```
+
+If you want to view the current list, you can enter:
+```
+echo "show acl /etc/haproxy/acls/blockedips.acl" | socat unix-connect:/var/lib/haproxy/haproxy.stats stdio
+```
 
 
 

--- a/roles/haproxy/defaults/main.yml
+++ b/roles/haproxy/defaults/main.yml
@@ -8,3 +8,6 @@ haproxy_max_request_rate: 1000
 # You can create an allowlist of ips that are allowed to go over the configured ratelimit
 haproxy_allowlistips:
   - ''
+# You can create a blocklist of ips that are blocked. 
+haproxy_blocklistips:
+  - ''

--- a/roles/haproxy/tasks/main.yml
+++ b/roles/haproxy/tasks/main.yml
@@ -169,6 +169,7 @@
     - validvhostsrestricted.acl
     - validvhostsunrestricted.acl
     - allowedips.acl
+    - blockedips.acl
   notify:
     - "reload haproxy"
 

--- a/roles/haproxy/templates/blockedips.acl.j2
+++ b/roles/haproxy/templates/blockedips.acl.j2
@@ -1,0 +1,3 @@
+{% for ip in haproxy_blocklistips %}
+{{ ip }}
+{% endfor %}

--- a/roles/haproxy/templates/haproxy_frontend.cfg.j2
+++ b/roles/haproxy/templates/haproxy_frontend.cfg.j2
@@ -54,6 +54,8 @@ frontend local_ip
     capture request header X-TLS-Client len 256
     # Allowlist ACL
     acl allowlist src -f /etc/haproxy/acls/allowedips.acl
+    # Blocklist ACL
+    acl blocklist src -f /etc/haproxy/acls/blockedips.acl
     # Measure and log the request rate per 10s
     http-request track-sc0 src table st_httpreqs_per_ip
     http-request capture sc_http_req_rate(0) len 4
@@ -62,6 +64,8 @@ frontend local_ip
     # Measure and log the request rate per path and ip 
     http-request track-sc1 base32+src table st_httpreqs_per_ip_and_path
     http-request capture sc_http_req_rate(1) len 4
+    # Deny the request when the ip address is on the blocklist
+    http-request deny if blocklist
     # Deny the request when no valid host header is used
     http-request deny if ! valid_vhost
     # Deny the request when the request rate exceeds {{ haproxy_max_request_rate }} per 10s
@@ -123,6 +127,8 @@ frontend localhost_restricted
     capture request header X-TLS-Client len 256
     # Allowlist ACL
     acl allowlist src -f /etc/haproxy/acls/allowedips.acl
+    # Blocklist ACL
+    acl blocklist src -f /etc/haproxy/acls/blockedips.acl
     # Measure and log the request rate per 10s
     http-request track-sc0 src table st_httpreqs_per_ip
     http-request capture sc_http_req_rate(0) len 4
@@ -132,6 +138,8 @@ frontend localhost_restricted
     # Measure and log the request rate per path and ip 
     http-request track-sc1 base32+src table st_httpreqs_per_ip_and_path
     http-request capture sc_http_req_rate(1) len 4
+    # Deny the request when the ip address is on the blocklist
+    http-request deny if blocklist
     # Deny the request when no valid host header is used
     http-request deny if ! valid_vhost
     # Deny the request when the request rate exceeds {{ haproxy_max_request_rate }} per 10s


### PR DESCRIPTION
This PR adds the ability to add ip address to a blocklist. If the IP is on the blocklist, Haproxy generates a 403 when it tries to access on of the resources behind the loadbalancer. 
The blocklist can either be deployed using ansible, or by adding it to the running config using the socket. More details are in the README.md