### PR TITLE
Shibboleth: Make sure only one server run cleanup jobs

### DIFF
--- a/roles/shibboleth/defaults/main.yml
+++ b/roles/shibboleth/defaults/main.yml
@@ -4,3 +4,4 @@ shibboleth_metadata_sources:
 shibd_sp_crt_not_in_inventory: false
 mariadb_odbc_version: 3.0.8
 shibboleth_database_backend: false
+shibboleth_db_cleanup_interval: 900

--- a/roles/shibboleth/templates/shibboleth/shibboleth2.xml.j2
+++ b/roles/shibboleth/templates/shibboleth/shibboleth2.xml.j2
@@ -11,13 +11,13 @@
         <Library path="odbc-store.so" fatal="true"/>
     </Extensions>
     </OutOfProcess>
-    <StorageService type="ODBC" id="db" cleanupInterval="900" isolationLevel="REPEATABLE_READ">
+    <StorageService type="ODBC" id="db" cleanupInterval="{{ shibboleth_db_cleanup_interval }}" isolationLevel="REPEATABLE_READ">
       <ConnectionString>
       DRIVER=MariaDB;SERVER={{ shib.db_host }};USER=shibrw;PASSWORD={{ mysql_passwords.shibboleth }};DATABASE=shibboleth
       </ConnectionString>
     </StorageService>
     <SessionCache type="StorageService" StorageService="db" cacheAssertions="false"
-              cacheTimeout="3600" inprocTimeout="900" cleanupInterval="900"/>
+              cacheTimeout="3600" inprocTimeout="900" cleanupInterval="{{ shibboleth_db_cleanup_interval }}"/>
     <ReplayCache StorageService="db"/>
     <ArtifactMap StorageService="db" artifactTTL="180"/>
     {% endif %}


### PR DESCRIPTION
In a multiserver setup with a shared database, you could have multiple shib instances trying to run the same delete operation while running cleaning up tasks. You can now set shibboleth_db_cleanup_interval to 0 on hosts where you don't want to run the db cleanup tasks, leaving one master to run these tasks.