### PR TITLE
Properly anchor RewriteConds

### DIFF
--- a/roles/account-gui/templates/account.conf.j2
+++ b/roles/account-gui/templates/account.conf.j2
@@ -26,13 +26,13 @@ Listen {{ apache_app_listen_address.account }}:{{ loadbalancing.account.port }}
     RewriteCond %{REQUEST_URI} !\.woff2$
     RewriteCond %{REQUEST_URI} !\.ttf$
     RewriteCond %{REQUEST_URI} !\.eot$
-    RewriteCond %{REQUEST_URI} !myconext
-    RewriteCond %{REQUEST_URI} !config
-    RewriteCond %{REQUEST_URI} !register
-    RewriteCond %{REQUEST_URI} !doLogin
-    RewriteCond %{REQUEST_URI} !saml
-    RewriteCond %{REQUEST_URI} !actuator
-    RewriteCond %{REQUEST_URI} !fonts
+    RewriteCond %{REQUEST_URI} !^/myconext
+    RewriteCond %{REQUEST_URI} !^/config
+    RewriteCond %{REQUEST_URI} !^/register
+    RewriteCond %{REQUEST_URI} !^/doLogin
+    RewriteCond %{REQUEST_URI} !^/saml
+    RewriteCond %{REQUEST_URI} !^/actuator
+    RewriteCond %{REQUEST_URI} !^/fonts
     RewriteRule (.*) /index.html [L]
 
     ProxyPreserveHost On

--- a/roles/attribute-aggregation-gui/templates/attribute_aggregation.conf.j2
+++ b/roles/attribute-aggregation-gui/templates/attribute_aggregation.conf.j2
@@ -23,9 +23,9 @@ Listen {{ apache_app_listen_address.aa }}:{{ loadbalancing.aa.port }}
     RewriteCond %{REQUEST_URI} !\.woff2$
     RewriteCond %{REQUEST_URI} !\.ttf$
     RewriteCond %{REQUEST_URI} !\.eot$
-    RewriteCond %{REQUEST_URI} !aa
-    RewriteCond %{REQUEST_URI} !redirect
-    RewriteCond %{REQUEST_URI} !fonts
+    RewriteCond %{REQUEST_URI} !^/aa/
+    RewriteCond %{REQUEST_URI} !^/redirect
+    RewriteCond %{REQUEST_URI} !^/fonts/
     RewriteRule (.*) /index.html [L]
 
     ProxyPass /Shibboleth.sso !
@@ -114,10 +114,10 @@ Listen {{ apache_app_listen_address.aa }}:{{ loadbalancing.aa.port }}
     RewriteCond %{REQUEST_URI} !\.woff2$
     RewriteCond %{REQUEST_URI} !\.ttf$
     RewriteCond %{REQUEST_URI} !\.eot$
-    RewriteCond %{REQUEST_URI} !aa
-    RewriteCond %{REQUEST_URI} !redirect
-    RewriteCond %{REQUEST_URI} !fonts
-    RewriteCond %{REQUEST_URI} !orcid
+    RewriteCond %{REQUEST_URI} !^/aa/
+    RewriteCond %{REQUEST_URI} !^/redirect
+    RewriteCond %{REQUEST_URI} !^/fonts/
+    RewriteCond %{REQUEST_URI} !^/orcid
     RewriteRule (.*) /index.html [L]
 
     Redirect /orcid https://link.{{ base_domain }}/aa/api/client/information.html

--- a/roles/dashboard-gui/templates/dashboard.conf.j2
+++ b/roles/dashboard-gui/templates/dashboard.conf.j2
@@ -22,13 +22,13 @@ Listen {{ apache_app_listen_address.dashboard }}:{{ loadbalancing.dashboard.port
     RewriteCond %{REQUEST_URI} !\.woff2$
     RewriteCond %{REQUEST_URI} !\.ttf$
     RewriteCond %{REQUEST_URI} !\.eot$
-    RewriteCond %{REQUEST_URI} !dashboard
-    RewriteCond %{REQUEST_URI} !spDashboard
-    RewriteCond %{REQUEST_URI} !health
-    RewriteCond %{REQUEST_URI} !info
-    RewriteCond %{REQUEST_URI} !login
-    RewriteCond %{REQUEST_URI} !startSSO
-    RewriteCond %{REQUEST_URI} !fonts
+    RewriteCond %{REQUEST_URI} !^/dashboard
+    RewriteCond %{REQUEST_URI} !^/spDashboard
+    RewriteCond %{REQUEST_URI} !^/health
+    RewriteCond %{REQUEST_URI} !^/info
+    RewriteCond %{REQUEST_URI} !^/login
+    RewriteCond %{REQUEST_URI} !^/startSSO
+    RewriteCond %{REQUEST_URI} !^/fonts
     RewriteRule (.*) /index.html [L]
 
     ProxyPreserveHost On

--- a/roles/eduid-gui/templates/eduid.conf.j2
+++ b/roles/eduid-gui/templates/eduid.conf.j2
@@ -26,9 +26,9 @@ Listen {{ apache_app_listen_address.eduid }}:{{ loadbalancing.eduid.port }}
     RewriteCond %{REQUEST_URI} !\.woff2$
     RewriteCond %{REQUEST_URI} !\.ttf$
     RewriteCond %{REQUEST_URI} !\.eot$
-    RewriteCond %{REQUEST_URI} !config
-    RewriteCond %{REQUEST_URI} !actuator
-    RewriteCond %{REQUEST_URI} !fonts
+    RewriteCond %{REQUEST_URI} !^/config
+    RewriteCond %{REQUEST_URI} !^/actuator
+    RewriteCond %{REQUEST_URI} !^/fonts
     RewriteRule (.*) /index.html [L]
 
     ProxyPreserveHost On

--- a/roles/manage-gui/templates/manage.conf.backdoor.j2
+++ b/roles/manage-gui/templates/manage.conf.backdoor.j2
@@ -22,8 +22,8 @@ Listen {{ apache_app_listen_address.manage }}:{{ loadbalancing.manage.port }}
     RewriteCond %{REQUEST_URI} !\.woff2$
     RewriteCond %{REQUEST_URI} !\.ttf$
     RewriteCond %{REQUEST_URI} !\.eot$
-    RewriteCond %{REQUEST_URI} !manage
-    RewriteCond %{REQUEST_URI} !fonts
+    RewriteCond %{REQUEST_URI} !^/manage
+    RewriteCond %{REQUEST_URI} !^/fonts
     RewriteRule (.*) /index.html [L]
 
     ProxyPass /manage/api/health http://localhost:{{ springapp_tcpport }}/actuator/health retry=0

--- a/roles/manage-gui/templates/manage.conf.j2
+++ b/roles/manage-gui/templates/manage.conf.j2
@@ -22,8 +22,8 @@ Listen {{ apache_app_listen_address.manage }}:{{ loadbalancing.manage.port }}
     RewriteCond %{REQUEST_URI} !\.woff2$
     RewriteCond %{REQUEST_URI} !\.ttf$
     RewriteCond %{REQUEST_URI} !\.eot$
-    RewriteCond %{REQUEST_URI} !manage
-    RewriteCond %{REQUEST_URI} !fonts
+    RewriteCond %{REQUEST_URI} !^/manage
+    RewriteCond %{REQUEST_URI} !^/fonts
     RewriteRule (.*) /index.html [L]
 
     ProxyPass /Shibboleth.sso !

--- a/roles/myconext-gui/templates/myconext.conf.j2
+++ b/roles/myconext-gui/templates/myconext.conf.j2
@@ -26,12 +26,12 @@ Listen {{ apache_app_listen_address.myconext }}:{{ loadbalancing.myconext.port }
     RewriteCond %{REQUEST_URI} !\.woff2$
     RewriteCond %{REQUEST_URI} !\.ttf$
     RewriteCond %{REQUEST_URI} !\.eot$
-    RewriteCond %{REQUEST_URI} !myconext
-    RewriteCond %{REQUEST_URI} !actuator
-    RewriteCond %{REQUEST_URI} !config
-    RewriteCond %{REQUEST_URI} !login
-    RewriteCond %{REQUEST_URI} !startSSO
-    RewriteCond %{REQUEST_URI} !fonts
+    RewriteCond %{REQUEST_URI} !^/myconext
+    RewriteCond %{REQUEST_URI} !^/actuator
+    RewriteCond %{REQUEST_URI} !^/config
+    RewriteCond %{REQUEST_URI} !^/login
+    RewriteCond %{REQUEST_URI} !^/startSSO
+    RewriteCond %{REQUEST_URI} !^/fonts
     RewriteRule (.*) /index.html [L]
 
     ProxyPreserveHost On

--- a/roles/oidc-playground-client/templates/oidc-playground.conf.j2
+++ b/roles/oidc-playground-client/templates/oidc-playground.conf.j2
@@ -22,8 +22,8 @@ Listen {{ apache_app_listen_address.oidc_playground }}:{{ loadbalancing.oidc_pla
     RewriteCond %{REQUEST_URI} !\.woff2$
     RewriteCond %{REQUEST_URI} !\.ttf$
     RewriteCond %{REQUEST_URI} !\.eot$
-    RewriteCond %{REQUEST_URI} !oidc
-    RewriteCond %{REQUEST_URI} !fonts
+    RewriteCond %{REQUEST_URI} !^/oidc
+    RewriteCond %{REQUEST_URI} !^/fonts
     RewriteRule (.*) /index.html [L]
 
     ProxyPass /oidc/api http://localhost:{{ springapp_tcpport }}/ retry=0

--- a/roles/pdp-gui/templates/pdp.conf.j2
+++ b/roles/pdp-gui/templates/pdp.conf.j2
@@ -23,8 +23,8 @@ Listen {{ apache_app_listen_address.pdp }}:{{ loadbalancing.pdp.port }}
     RewriteCond %{REQUEST_URI} !\.woff2$
     RewriteCond %{REQUEST_URI} !\.ttf$
     RewriteCond %{REQUEST_URI} !\.eot$
-    RewriteCond %{REQUEST_URI} !pdp
-    RewriteCond %{REQUEST_URI} !fonts
+    RewriteCond %{REQUEST_URI} !^/pdp
+    RewriteCond %{REQUEST_URI} !^/fonts
     RewriteRule (.*) /index.html [L]
 
     ProxyPass /Shibboleth.sso !

--- a/roles/stats/templates/stats.conf.j2
+++ b/roles/stats/templates/stats.conf.j2
@@ -23,11 +23,11 @@ Listen {{ apache_app_listen_address.stats }}:{{ loadbalancing.stats.port }}
     RewriteCond %{REQUEST_URI} !\.woff2$
     RewriteCond %{REQUEST_URI} !\.ttf$
     RewriteCond %{REQUEST_URI} !\.eot$
-    RewriteCond %{REQUEST_URI} !api
-    RewriteCond %{REQUEST_URI} !health
-    RewriteCond %{REQUEST_URI} !version
-    RewriteCond %{REQUEST_URI} !info
-    RewriteCond %{REQUEST_URI} !fonts
+    RewriteCond %{REQUEST_URI} !^/api/
+    RewriteCond %{REQUEST_URI} !^/health
+    RewriteCond %{REQUEST_URI} !^/version
+    RewriteCond %{REQUEST_URI} !^/info
+    RewriteCond %{REQUEST_URI} !^/fonts
     RewriteRule (.*) /index.html [L]
 
     RequestHeader set X-Forwarded-Port 443 early

--- a/roles/teams-gui/templates/teams.conf.j2
+++ b/roles/teams-gui/templates/teams.conf.j2
@@ -22,9 +22,9 @@ Listen {{ apache_app_listen_address.teams }}:{{ loadbalancing.teams.port }}
     RewriteCond %{REQUEST_URI} !\.woff2$
     RewriteCond %{REQUEST_URI} !\.ttf$
     RewriteCond %{REQUEST_URI} !\.eot$
-    RewriteCond %{REQUEST_URI} !api
-    RewriteCond %{REQUEST_URI} !deprovision
-    RewriteCond %{REQUEST_URI} !fonts
+    RewriteCond %{REQUEST_URI} !^/api/
+    RewriteCond %{REQUEST_URI} !^/deprovision/
+    RewriteCond %{REQUEST_URI} !^/fonts/
     RewriteRule (.*) /index.html [L]
 
     ProxyPass /Shibboleth.sso !


### PR DESCRIPTION
Properly anchor excluded paths so they do not match an unintended part of the URL.

This fixes that some Teams invitations would yield an (Apache) 404, namely those that by chance contained the letters `api` in that order somewhere in the randomly generated activation code.

Also preventively fixed in other apps although I'm not yet aware of any concrete issues there.