### PR TITLE
Java apps: Remove quotes in logback maxHistory setting

### DIFF
--- a/roles/attribute-aggregation-server/templates/logback.xml.j2
+++ b/roles/attribute-aggregation-server/templates/logback.xml.j2
@@ -7,7 +7,7 @@
    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
      <!-- daily rollover -->
      <fileNamePattern>/var/log/attribute-aggregation/attribute-aggregation-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
-     <maxHistory>"{{ logback_max_history }}"</maxHistory>
+     <maxHistory>{{ logback_max_history }}</maxHistory>
    </rollingPolicy>
    <encoder>
      <pattern>%d{ISO8601} %5p [%t] %logger{40}:%L - %m%n</pattern>
@@ -19,7 +19,7 @@
    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
      <!-- daily rollover -->
      <fileNamePattern>/var/log/attribute-aggregation/analytics-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
-     <maxHistory>"{{ logback_max_history }}"</maxHistory>
+     <maxHistory>{{ logback_max_history }}</maxHistory>
    </rollingPolicy>
    <encoder>
      <pattern>%d{ISO8601} %5p [%t] %logger{40}:%L - %m%n</pattern>

--- a/roles/dashboard-server/templates/logback.xml.j2
+++ b/roles/dashboard-server/templates/logback.xml.j2
@@ -7,7 +7,7 @@
    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
      <!-- daily rollover -->
      <fileNamePattern>/var/log/dashboard/dashboard-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
-     <maxHistory>"{{ logback_max_history }}"</maxHistory>
+     <maxHistory>{{ logback_max_history }}</maxHistory>
    </rollingPolicy>
    <encoder>
      <pattern>%d{ISO8601} %5p [%t] %logger{40}:%L - %m%n</pattern>

--- a/roles/manage-server/templates/logback.xml.j2
+++ b/roles/manage-server/templates/logback.xml.j2
@@ -7,7 +7,7 @@
    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
      <!-- daily rollover -->
      <fileNamePattern>/var/log/manage/manage-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
-     <maxHistory>"{{ logback_max_history }}"</maxHistory>
+     <maxHistory>{{ logback_max_history }}</maxHistory>
    </rollingPolicy>
    <encoder>
      <pattern>%d{ISO8601} %5p [%t] %logger{40}:%L - %m%n</pattern>

--- a/roles/monitoring-tests/templates/logback.xml.j2
+++ b/roles/monitoring-tests/templates/logback.xml.j2
@@ -6,7 +6,7 @@
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
        <!-- daily rollover -->
        <fileNamePattern>/var/log/{{ springapp_service_name }}/monitoring-tests-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
-       <maxHistory>"{{ logback_max_history }}"</maxHistory>
+       <maxHistory>{{ logback_max_history }}</maxHistory>
      </rollingPolicy>
      <encoder>
        <pattern>%d{ISO8601} %5p [%t] %logger{40}:%L - %m%n</pattern>

--- a/roles/mujina-idp/templates/logback.xml.j2
+++ b/roles/mujina-idp/templates/logback.xml.j2
@@ -6,7 +6,7 @@
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
        <!-- daily rollover -->
        <fileNamePattern>/var/log/{{ springapp_service_name }}/{{ springapp_service_name }}-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
-       <maxHistory>"{{ logback_max_history }}"</maxHistory>
+       <maxHistory>{{ logback_max_history }}</maxHistory>
      </rollingPolicy>
      <encoder>
        <pattern>%d{ISO8601} %5p [%t] %logger{40}:%L - %m%n</pattern>

--- a/roles/mujina-sp/templates/logback.xml.j2
+++ b/roles/mujina-sp/templates/logback.xml.j2
@@ -6,7 +6,7 @@
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
        <!-- daily rollover -->
        <fileNamePattern>/var/log/{{ springapp_service_name }}/{{ springapp_service_name }}-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
-       <maxHistory>"{{ logback_max_history }}"</maxHistory>
+       <maxHistory>{{ logback_max_history }}</maxHistory>
      </rollingPolicy>
      <encoder>
        <pattern>%d{ISO8601} %5p [%t] %logger{40}:%L - %m%n</pattern>

--- a/roles/myconext-server/templates/logback.xml.j2
+++ b/roles/myconext-server/templates/logback.xml.j2
@@ -7,7 +7,7 @@
    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
      <!-- daily rollover -->
      <fileNamePattern>/var/log/myconext/myconext-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
-     <maxHistory>"{{ logback_max_history }}"</maxHistory>
+     <maxHistory>{{ logback_max_history }}</maxHistory>
    </rollingPolicy>
    <encoder>
      <pattern>%d{ISO8601} %5p [%t] %logger{40}:%L - %m%n</pattern>

--- a/roles/oidc-playground-server/templates/logback.xml.j2
+++ b/roles/oidc-playground-server/templates/logback.xml.j2
@@ -7,7 +7,7 @@
    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
      <!-- daily rollover -->
      <fileNamePattern>/var/log/oidc-playground/oidc-playground-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
-     <maxHistory>"{{ logback_max_history }}"</maxHistory>
+     <maxHistory>{{ logback_max_history }}</maxHistory>
    </rollingPolicy>
    <encoder>
      <pattern>%d{ISO8601} %5p [%t] %logger{40}:%L - %m%n</pattern>

--- a/roles/oidcng/templates/logback.xml.j2
+++ b/roles/oidcng/templates/logback.xml.j2
@@ -7,7 +7,7 @@
    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
      <!-- daily rollover -->
      <fileNamePattern>/var/log/oidcng/oidcng-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
-     <maxHistory>"{{ logback_max_history }}"</maxHistory>
+     <maxHistory>{{ logback_max_history }}</maxHistory>
    </rollingPolicy>
    <encoder>
      <pattern>%d{ISO8601} %5p [%t] %logger{40}:%L - %m%n</pattern>

--- a/roles/pdp-server/templates/logback.xml.j2
+++ b/roles/pdp-server/templates/logback.xml.j2
@@ -15,7 +15,7 @@
       <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
          <!-- daily rollover -->
          <fileNamePattern>/var/log/pdp/pdp-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
-         <maxHistory>"{{ logback_max_history }}"</maxHistory>
+         <maxHistory>{{ logback_max_history }}</maxHistory>
       </rollingPolicy>
       <encoder>
          <pattern>%d{ISO8601} %5p [%t] %logger{40}:%L - %m%n</pattern>

--- a/roles/teams-server/templates/logback.xml.j2
+++ b/roles/teams-server/templates/logback.xml.j2
@@ -7,7 +7,7 @@
    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
      <!-- daily rollover -->
      <fileNamePattern>/var/log/teams/teams-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
-     <maxHistory>"{{ logback_max_history }}"</maxHistory>
+     <maxHistory>{{ logback_max_history }}</maxHistory>
    </rollingPolicy>
    <encoder>
      <pattern>%d{ISO8601} %5p [%t] %logger{40}:%L - %m%n</pattern>

--- a/roles/voot/templates/logback.xml.j2
+++ b/roles/voot/templates/logback.xml.j2
@@ -12,7 +12,7 @@
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
       <!-- daily rollover -->
       <fileNamePattern>/var/log/voot/voot-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
-      <maxHistory>"{{ logback_max_history }}"</maxHistory>
+      <maxHistory>{{ logback_max_history }}</maxHistory>
     </rollingPolicy>
     <encoder>
      <pattern>%d{ISO8601} %5p [%t] %logger{40}:%L - %m%n</pattern>


### PR DESCRIPTION
With quotes around the logback maxHistory settings they would be interpreted as string, and not evaluated at all. The quotes will make sure that the Java apps logfile rotation works as expected again