### PR TITLE
Make use of globally defined Content-Security-Policy flavours.

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -15,10 +15,16 @@ ssl_key_dir: /etc/httpd/keys
 
 apache_user: apache
 
-httpd_scp:
+# Virtal host that hosts shared static images (logos primarily)
+# Can be overridden in environments if it lives outside this env's base domain
+static_vhost: "static.{{ base_domain }}"
+
+httpd_csp:
   lenient: default-src; object-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self'; connect-src 'self'; img-src 'self' data:;
-  lenient_with_static_img: default-src; object-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self'; connect-src 'self'; img-src 'self' https://static.surfconext.nl data:;
+  lenient_with_static_img: default-src; object-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self'; connect-src 'self'; img-src 'self' {{ static_vhost }} data:;
   strict: default-src; object-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; connect-src 'self'; img-src 'self' data:;
+  strict_with_static_img: default-src; object-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; connect-src 'self'; img-src 'self' {{ static_vhost }} data:;
+  nothing: default-src 'none';
 
 error_subject_prefix: "[{{ ansible_hostname }}] "
 

--- a/roles/account-gui/templates/account.conf.j2
+++ b/roles/account-gui/templates/account.conf.j2
@@ -58,10 +58,10 @@ Listen {{ apache_app_listen_address.account }}:{{ loadbalancing.account.port }}
       satisfy any
     </Location>
 
-    Header set Content-Security-Policy "{{ httpd_scp.lenient }}"
-    Header set X-Frame-Options "DENY"
-    Header set Referrer-Policy "same-origin"
-    Header set X-Content-Type-Options "nosniff"
+    Header always set Content-Security-Policy "{{ httpd_csp.lenient }}"
+    Header always set X-Frame-Options "DENY"
+    Header always set Referrer-Policy "same-origin"
+    Header always set X-Content-Type-Options "nosniff"
 
     {% if haproxy_backend_tls %}
     SSLEngine on

--- a/roles/attribute-aggregation-gui/templates/attribute_aggregation.conf.j2
+++ b/roles/attribute-aggregation-gui/templates/attribute_aggregation.conf.j2
@@ -69,10 +69,10 @@ Listen {{ apache_app_listen_address.aa }}:{{ loadbalancing.aa.port }}
       require valid-user
     </Location>
 
-    Header set Content-Security-Policy "script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:;"
-    Header set X-Frame-Options "DENY"
-    Header set Referrer-Policy "same-origin"
-    Header set X-Content-Type-Options "nosniff"
+    Header always set Content-Security-Policy "{{ httpd_csp.lenient }}"
+    Header always set X-Frame-Options "DENY"
+    Header always set Referrer-Policy "same-origin"
+    Header always set X-Content-Type-Options "nosniff"
 
     {% if haproxy_backend_tls %}
     SSLEngine on
@@ -143,10 +143,10 @@ Listen {{ apache_app_listen_address.aa }}:{{ loadbalancing.aa.port }}
       require valid-user
     </Location>
 
-    Header set Content-Security-Policy "script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:;"
-    Header set X-Frame-Options "DENY"
-    Header set Referrer-Policy "origin-when-cross-origin"
-    Header set X-Content-Type-Options "nosniff"
+    Header always set Content-Security-Policy {{ httpd_csp.lenient }}
+    Header always set X-Frame-Options "DENY"
+    Header always set Referrer-Policy "origin-when-cross-origin"
+    Header always set X-Content-Type-Options "nosniff"
 
     {% if haproxy_backend_tls %}
     SSLEngine on

--- a/roles/dashboard-gui/templates/dashboard.conf.j2
+++ b/roles/dashboard-gui/templates/dashboard.conf.j2
@@ -64,10 +64,10 @@ Listen {{ apache_app_listen_address.dashboard }}:{{ loadbalancing.dashboard.port
       require valid-user
     </Location>
 
-    Header set Content-Security-Policy "script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' static.surfconext.nl static.{{ base_domain }} data:;"
-    Header set X-Frame-Options "DENY"
-    Header set Referrer-Policy "origin-when-cross-origin"
-    Header set X-Content-Type-Options "nosniff"
+    Header always set Content-Security-Policy "{{ httpd_csp.lenient_with_static_img }}"
+    Header always set X-Frame-Options "DENY"
+    Header always set Referrer-Policy "origin-when-cross-origin"
+    Header always set X-Content-Type-Options "nosniff"
 
     {% if haproxy_backend_tls %}
     SSLEngine on

--- a/roles/elk/templates/kibana.conf.j2
+++ b/roles/elk/templates/kibana.conf.j2
@@ -36,10 +36,10 @@ Listen {{ apache_app_listen_address.kibana }}:{{ loadbalancing.kibana.port }}
 
         Header always set Strict-Transport-Security "max-age=34214400"
 {% endif %}
-        Header set X-Frame-Options "DENY"
+        Header always set X-Frame-Options "DENY"
         Header always set X-Content-Type-Options "nosniff"
         Header always set X-Xss-Protection "1; mode=block"
-        Header set Referrer-Policy "same-origin"
+        Header always set Referrer-Policy "same-origin"
 
         ErrorLog "|/usr/bin/logger -S 32k -p local3.err  -t 'Apache-Kibana'"
         CustomLog "|/usr/bin/logger -S 32k -p local3.info  -t 'Apache-Kibana'" combined

--- a/roles/engineblock/templates/engine-api.conf.j2
+++ b/roles/engineblock/templates/engine-api.conf.j2
@@ -24,9 +24,9 @@ Listen {{ apache_app_listen_address.engine_api }}:{{ loadbalancing.engine_api.po
     SSLCertificateChainFile {{ tls.cert_path_ca }}/{{ tls_ca }}
 {% endif %}
 
-    Header set X-Content-Type-Options "nosniff"
-    Header set X-Frame-Options "DENY"
-    Header set Content-Security-Policy "default-src 'none';"
+    Header always set X-Content-Type-Options "nosniff"
+    Header always set X-Frame-Options "DENY"
+    Header always set Content-Security-Policy "{{ httpd_csp.nothing }}"
 
     SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
     SetEnv ENGINEBLOCK_ENV {{ engine_apache_environment }}

--- a/roles/engineblock/templates/engine.conf.j2
+++ b/roles/engineblock/templates/engine.conf.j2
@@ -18,7 +18,7 @@ Listen {{ apache_app_listen_address.engine }}:{{ loadbalancing.engine.port }}
       RewriteRule ^(.*)$ app{% if develop %}_dev{% endif %}.php [QSA,L]
     </Directory>
 
-    Header set X-Content-Type-Options "nosniff"
+    Header always set X-Content-Type-Options "nosniff"
 
     SetEnv ENGINEBLOCK_ENV {{ engine_apache_environment }}
     SetEnv SYMFONY_ENV {{ engine_apache_symfony_environment }}

--- a/roles/manage-gui/templates/manage.conf.backdoor.j2
+++ b/roles/manage-gui/templates/manage.conf.backdoor.j2
@@ -39,10 +39,10 @@ Listen {{ apache_app_listen_address.manage }}:{{ loadbalancing.manage.port }}
       Options     -Indexes
     </Directory>
 
-    Header set Content-Security-Policy "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' static.surfconext.nl static.{{ base_domain }} data:;"
-    Header set X-Frame-Options "DENY"
-    Header set Referrer-Policy "same-origin"
-    Header set X-Content-Type-Options "nosniff"
+    Header always set Content-Security-Policy "{{ httpd_csp.lenient_with_static_img }}"
+    Header always set X-Frame-Options "DENY"
+    Header always set Referrer-Policy "same-origin"
+    Header always set X-Content-Type-Options "nosniff"
 
     {% if haproxy_backend_tls %}
     SSLEngine on

--- a/roles/manage-gui/templates/manage.conf.j2
+++ b/roles/manage-gui/templates/manage.conf.j2
@@ -66,10 +66,10 @@ Listen {{ apache_app_listen_address.manage }}:{{ loadbalancing.manage.port }}
       require valid-user
     </Location>
 
-    Header set Content-Security-Policy "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' static.surfconext.nl static.{{ base_domain }} data:;"
-    Header set X-Frame-Options "DENY"
-    Header set Referrer-Policy "same-origin"
-    Header set X-Content-Type-Options "nosniff"
+    Header always set Content-Security-Policy "{{ httpd_csp.lenient_with_static_img }}"
+    Header always set X-Frame-Options "DENY"
+    Header always set Referrer-Policy "same-origin"
+    Header always set X-Content-Type-Options "nosniff"
 
     {% if haproxy_backend_tls %}
     SSLEngine on

--- a/roles/metadata/templates/metadata.conf.j2
+++ b/roles/metadata/templates/metadata.conf.j2
@@ -11,11 +11,11 @@ Listen {{ apache_app_listen_address.metadata }}:{{ loadbalancing.metadata.port }
           Require all granted
     </Directory>
 
-    Header set Content-Security-Policy "default-src 'self'; style-src 'self' 'unsafe-inline'"
-    Header set X-Frame-Options "DENY"
-    Header set Referrer-Policy "origin-when-cross-origin"
-    Header set X-Content-Type-Options "nosniff"
-    Header set X-XSS-Protection "1; mode=block"
+    Header always set Content-Security-Policy "{{ httpd_csp.strict }}"
+    Header always set X-Frame-Options "DENY"
+    Header always set Referrer-Policy "origin-when-cross-origin"
+    Header always set X-Content-Type-Options "nosniff"
+    Header always set X-XSS-Protection "1; mode=block"
 
     AddType application/x-pem-file .pem
     <Location "/sp/">

--- a/roles/myconext-gui/templates/myconext.conf.j2
+++ b/roles/myconext-gui/templates/myconext.conf.j2
@@ -86,10 +86,10 @@ Listen {{ apache_app_listen_address.myconext }}:{{ loadbalancing.myconext.port }
       require valid-user
     </Location>
 
-    Header set Content-Security-Policy "{{ httpd_scp.lenient_with_static_img }}"
-    Header set X-Frame-Options "DENY"
-    Header set Referrer-Policy "same-origin"
-    Header set X-Content-Type-Options "nosniff"
+    Header always set Content-Security-Policy "{{ httpd_csp.lenient_with_static_img }}"
+    Header always set X-Frame-Options "DENY"
+    Header always set Referrer-Policy "same-origin"
+    Header always set X-Content-Type-Options "nosniff"
 
     {% if haproxy_backend_tls %}
     SSLEngine on

--- a/roles/oidc-playground-client/templates/oidc-playground.conf.j2
+++ b/roles/oidc-playground-client/templates/oidc-playground.conf.j2
@@ -36,10 +36,10 @@ Listen {{ apache_app_listen_address.oidc_playground }}:{{ loadbalancing.oidc_pla
       Options     -Indexes
     </Directory>
 
-    Header set Content-Security-Policy "script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:;"
-    Header set X-Frame-Options "DENY"
-    Header set Referrer-Policy "unsafe-url"
-    Header set X-Content-Type-Options "nosniff"
+    Header always set Content-Security-Policy "{{ httpd_csp.lenient }}"
+    Header always set X-Frame-Options "DENY"
+    Header always set Referrer-Policy "unsafe-url"
+    Header always set X-Content-Type-Options "nosniff"
 
     {% if haproxy_backend_tls %}
     SSLEngine on

--- a/roles/pdp-gui/templates/pdp.conf.j2
+++ b/roles/pdp-gui/templates/pdp.conf.j2
@@ -59,10 +59,10 @@ Listen {{ apache_app_listen_address.pdp }}:{{ loadbalancing.pdp.port }}
       require valid-user
     </Location>
 
-    Header set Content-Security-Policy "script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:;"
-    Header set X-Frame-Options "DENY"
-    Header set Referrer-Policy "same-origin"
-    Header set X-Content-Type-Options "nosniff"
+    Header always set Content-Security-Policy "{{ httpd_csp.lenient }}"
+    Header always set X-Frame-Options "DENY"
+    Header always set Referrer-Policy "same-origin"
+    Header always set X-Content-Type-Options "nosniff"
 
     {% if haproxy_backend_tls %}
     SSLEngine on

--- a/roles/profile/templates/profile.conf.j2
+++ b/roles/profile/templates/profile.conf.j2
@@ -21,7 +21,8 @@ Listen {{ apache_app_listen_address.profile }}:{{ loadbalancing.profile.port }}
 	RewriteRule ^(.*)$ index.php [QSA,L]
     </Directory>
 
-    Header set Referrer-Policy "origin-when-cross-origin"
+    Header always set Referrer-Policy "origin-when-cross-origin"
+    Header always set Content-Security-Policy "{{ httpd_csp.strict_with_static_img }}"
 
     # Proxy the requests to FPM
     ProxyPassMatch ^/(.*\.php(/.*)?)$ unix:/var/run/php-fpm/profile-pool-72.sock|fcgi://localhost/{{ profile_current_release_symlink }}/public/$1

--- a/roles/static/templates/static.conf.j2
+++ b/roles/static/templates/static.conf.j2
@@ -8,9 +8,9 @@ Listen {{ apache_app_listen_address.static }}:{{ loadbalancing.static.port }}
 
     DocumentRoot {{ static_dir }}
 
-    Header set Referrer-Policy "origin-when-cross-origin"
-    Header set X-Content-Type-Options "nosniff"
-    Header set X-XSS-Protection "1; mode=block"
+    Header always set Referrer-Policy "origin-when-cross-origin"
+    Header always set X-Content-Type-Options "nosniff"
+    Header always set X-XSS-Protection "1; mode=block"
 
     ErrorLog "|/usr/bin/logger -S 32k -p local3.err  -t 'Apache-STATIC'"
     CustomLog "|/usr/bin/logger -S 32k -p local3.info  -t 'Apache-STATIC'" combined

--- a/roles/stats/templates/stats.conf.j2
+++ b/roles/stats/templates/stats.conf.j2
@@ -68,9 +68,9 @@ Listen {{ apache_app_listen_address.stats }}:{{ loadbalancing.stats.port }}
       Require valid-user
     </Location>
 
-    Header set Content-Security-Policy "script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:;"
-    Header set X-Frame-Options "DENY"
-    Header set Referrer-Policy "same-origin"
-    Header set X-Content-Type-Options "nosniff"
+    Header always set Content-Security-Policy "{{ httpd_csp.lenient }}"
+    Header always set X-Frame-Options "DENY"
+    Header always set Referrer-Policy "same-origin"
+    Header always set X-Content-Type-Options "nosniff"
 
 </VirtualHost>

--- a/roles/teams-gui/templates/teams.conf.j2
+++ b/roles/teams-gui/templates/teams.conf.j2
@@ -89,10 +89,10 @@ Listen {{ apache_app_listen_address.teams }}:{{ loadbalancing.teams.port }}
       AuthType none
     </LocationMatch>
 
-    Header set Content-Security-Policy "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' static.surfconext.nl static.{{ base_domain }} data:;"
-    Header set X-Frame-Options "DENY"
-    Header set Referrer-Policy "origin-when-cross-origin"
-    Header set X-Content-Type-Options "nosniff"
+    Header always set Content-Security-Policy "{{ httpd_csp.strict_with_static_img }}"
+    Header always set X-Frame-Options "DENY"
+    Header always set Referrer-Policy "origin-when-cross-origin"
+    Header always set X-Content-Type-Options "nosniff"
 
     {% if haproxy_backend_tls %}
     SSLEngine on

--- a/roles/voot/templates/voot.conf.j2
+++ b/roles/voot/templates/voot.conf.j2
@@ -19,7 +19,7 @@ Listen {{ apache_app_listen_address.voot }}:{{ loadbalancing.voot.port }}
     Include ssl_backend.conf
     {% endif %}
 
-    Header set Content-Security-Policy "default-src 'none';"
+    Header always set Content-Security-Policy "{{ httpd_csp.nothing }}"
 
     {% if apache_app_listen_address.all is defined %}
     SSLEngine on


### PR DESCRIPTION
Also define static_vhost globally. Environments may override this. So e.g. test2 can define it as "static.surfconext.nl" (not static.test2.surfconext.nl). Removes another surfconext-ism.