### PR TITLE
Haproxy: Fix cookie SameSite attribute rewrite

### DIFF
--- a/roles/haproxy/templates/haproxy_frontend.cfg.j2
+++ b/roles/haproxy/templates/haproxy_frontend.cfg.j2
@@ -32,7 +32,6 @@ frontend internet_ip
     # Create ACLs to make samesite=origin execeptions for unsupported browsers
     # See https://www.chromium.org/updates/same-site/incompatible-clients
     acl no_same_site_uas var(txn.useragent) -m reg -f /etc/haproxy/maps/nosamesitebrowsers.lst
-    acl has_same_site_flag res.fhdr(Set-Cookie) -m sub SameSite
     # ACL to protect APIs of public vhosts
     acl internal src -f /etc/haproxy/acls/internalips.acl
     # Deny the requests to internal APIs from IP addresses that are not on the internal ips list
@@ -42,7 +41,8 @@ frontend internet_ip
     # Set HSTS on all outgoing responses
     http-response set-header Strict-Transport-Security max-age=34214400
     # Add samesite=none to all outgoing cookies except unsupported browsers
-    http-response replace-header Set-Cookie (.*) \1;\ SameSite=None if !no_same_site_uas !has_same_site_flag
+    # or when the SameSite cookie parameter is already present
+    http-response replace-header Set-Cookie (?i)(^(?!.*samesite).*$) \1;\ SameSite=None if !no_same_site_uas 
     # We need a dummy backend in order to be able to rewrite the loadbalancer cookies
     use_backend dummy_backend
 
@@ -110,12 +110,13 @@ frontend internet_restricted_ip
     # Create ACLs to make samesite=origin execeptions for unsupported browsers
     # See https://www.chromium.org/updates/same-site/incompatible-clients
     acl no_same_site_uas var(txn.useragent) -m reg -f /etc/haproxy/maps/nosamesitebrowsers.lst
-    acl has_same_site_flag res.fhdr(Set-Cookie) -m sub SameSite
     # Rewrite responses
     # Set HSTS on all outgoing responses
     http-response set-header Strict-Transport-Security max-age=34214400
     # Add samesite=none to all outgoing cookies except unsupported browsers
-    http-response replace-header Set-Cookie (.*) \1;\ SameSite=None if !no_same_site_uas !has_same_site_flag
+    # Add samesite=none to all outgoing cookies except unsupported browsers
+    # or when the SameSite cookie parameter is already present
+    http-response replace-header Set-Cookie (?i)(^(?!.*samesite).*$) \1;\ SameSite=None if !no_same_site_uas 
     # We need a dummy backend in order to be able to rewrite the loadbalancer cookies
     use_backend dummy_backend_restricted
 

--- a/roles/haproxy/templates/haproxy_frontend.cfg.j2
+++ b/roles/haproxy/templates/haproxy_frontend.cfg.j2
@@ -40,9 +40,11 @@ frontend internet_ip
     # Rewrite responses
     # Set HSTS on all outgoing responses
     http-response set-header Strict-Transport-Security max-age=34214400
-    # Add samesite=none to all outgoing cookies except unsupported browsers
-    # or when the SameSite cookie parameter is already present
-    http-response replace-header Set-Cookie (?i)(^(?!.*samesite).*$) \1;\ SameSite=None if !no_same_site_uas 
+    # Add samesite=none to all outgoing cookies except for unsupported browsers,
+    # or when the SameSite cookie attribute is already present
+    http-response replace-header Set-Cookie (?i)(^(?!.*samesite).*$) \1;\ SameSite=None if !no_same_site_uas
+    # Remove an already present SameSite cookie attribute for unsupported browsers
+    http-response replace-value Set-Cookie (^.*)(?i);\ *SameSite=(Lax|Strict|None)(.*$) \1\3 if no_same_site_uas
     # We need a dummy backend in order to be able to rewrite the loadbalancer cookies
     use_backend dummy_backend
 
@@ -113,10 +115,11 @@ frontend internet_restricted_ip
     # Rewrite responses
     # Set HSTS on all outgoing responses
     http-response set-header Strict-Transport-Security max-age=34214400
-    # Add samesite=none to all outgoing cookies except unsupported browsers
-    # Add samesite=none to all outgoing cookies except unsupported browsers
-    # or when the SameSite cookie parameter is already present
-    http-response replace-header Set-Cookie (?i)(^(?!.*samesite).*$) \1;\ SameSite=None if !no_same_site_uas 
+    # Add samesite=none to all outgoing cookies except for unsupported browsers,
+    # or when the SameSite cookie attribute is already present
+    http-response replace-header Set-Cookie (?i)(^(?!.*samesite).*$) \1;\ SameSite=None if !no_same_site_uas
+    # Remove an already present SameSite cookie attribute for unsupported browsers
+    http-response replace-value Set-Cookie (^.*)(?i);\ *SameSite=(Lax|Strict|None)(.*$) \1\3 if no_same_site_uas
     # We need a dummy backend in order to be able to rewrite the loadbalancer cookies
     use_backend dummy_backend_restricted
 


### PR DESCRIPTION
Cookies were rewritten to add the SameSite attribute. Since some cookies already had that attribute an ACL was in place to make sure those cookies were not rewritten. However, the ACL is valid for the whole request, resulting in the other cookies not being rewritten, including the loadbalancer cookie. This change uses a regex to check whether SameSite is present in cookie during the rewrite itself, so the presence of the SameSite attribute is checked on a per cookie basis 

If a backend has already inserted a cookie with the SameSite attribute, and an unsupported browser is detected, then the SameSite attribute will be removed from that particular cookie.



