### PR TITLE
Set umask to 0077 in Mongo and Mariadb backup scripts

### DIFF
--- a/molecule/mysql/converge.yml
+++ b/molecule/mysql/converge.yml
@@ -31,7 +31,8 @@
       galera_root_users:
         - name: molecule
           password: secret
-          privs: '*.*:ALL'
+          privs: 
+            - '*.*:ALL'
           hosts:
             - '%'
     - role: galera_create_users

--- a/molecule/mysql/prepare.yml
+++ b/molecule/mysql/prepare.yml
@@ -96,16 +96,9 @@
           dest: "{{ inventory_dir }}/files/certs/galera/galera_server.key"
         - src: /root/example_com.crt
           dest: "{{ inventory_dir }}/files/certs/galera/galera_server.pem"
-      run_once: true
-
-    - name: "Fetch files all servers"
-      fetch:
-        src: "{{ item.src }}"
-        dest: "{{ item.dest }}"
-        flat: true
-      with_items:
         - src: /root/example_com.crt
           dest: "{{ inventory_dir }}/files/certs/galera/{{ inventory_hostname }}-galera_client.pem"
+      run_once: true
 
   roles:
     - role: keepalived

--- a/roles/galera/tasks/cluster_nodes.yml
+++ b/roles/galera/tasks/cluster_nodes.yml
@@ -237,7 +237,7 @@
     name: "{{ item.0.name }}"
     host: "{{ item.1 }}"
     password: "{{ item.0.password }}"
-    priv: "{{ item.0.privs }}"
+    priv: "{{ item.0.privs | join('/') }}"
     state: present
     login_user: root
     login_password: "{{ mariadb_root_password }}"

--- a/roles/galera/tasks/cluster_nodes.yml
+++ b/roles/galera/tasks/cluster_nodes.yml
@@ -196,6 +196,14 @@
     - galera_bootstrap_node is defined
     - galera_bootstrap_node == inventory_hostname
 
+- name: Create the backup directory
+  file:
+    path: /home/backup
+    state: directory
+    owner: root
+    group: root
+    mode: 0700
+
 - name: Put mariadb_backup script
   template:
     src: "mariadb_backup.sh.j2"

--- a/roles/galera/templates/mariadb_backup.sh.j2
+++ b/roles/galera/templates/mariadb_backup.sh.j2
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+umask 0077
+
 declare -x PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin
 
 MYSQL_USER="{{ mariadb_backup_user }}"
@@ -60,3 +62,5 @@ rm tmp_sqlend.sql
 
 echo "-- FINISH --"
 fi
+
+umask 0022

--- a/roles/mongo/tasks/main.yml
+++ b/roles/mongo/tasks/main.yml
@@ -73,6 +73,16 @@
   when:
     - mongo_tls | bool
 
+- name: Create the backup directory
+  file:
+    path: /home/backup
+    state: directory
+    owner: root
+    group: root
+    mode: 0700
+  when:
+    - mongo_cluster | bool
+
 - name: Install the backup script
   template:
     src: "backup_mongo.pl.j2"

--- a/roles/mongo/templates/backup_mongo.pl.j2
+++ b/roles/mongo/templates/backup_mongo.pl.j2
@@ -5,6 +5,8 @@ $backupdir = "/home/backup";
 $username = "admin";
 $password = "{{ mongo_admin_password }}";
 
+umask 0077;
+
 # First check if this is the keepalived master: If it is, no backups are performed, to keep the backup load on the database standby node
 
 my $keepalived_status;
@@ -52,4 +54,4 @@ if ( -d "$backupdir/mongo-dump-$day/$dir") {
 }
 }
 }
-
+umask 0022; 

--- a/roles/mysql/tasks/main.yml
+++ b/roles/mysql/tasks/main.yml
@@ -153,6 +153,16 @@
   when:
     - backup_node | bool
 
+- name: Create the backup directory
+  file:
+    path: /home/backup
+    state: directory
+    owner: root
+    group: root
+    mode: 0700
+  when:
+    - backup_node | bool
+
 - name: Put mariadb_backup script
   template:
     src: "mariadb_backup.sh.j2"

--- a/roles/mysql/templates/mariadb_backup.sh.j2
+++ b/roles/mysql/templates/mariadb_backup.sh.j2
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+umask 0077
+
 declare -x PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin
 
 MYSQL_USER="{{ mysql_backup_user }}"
@@ -60,3 +62,5 @@ rm tmp_sqlend.sql
 
 echo "-- FINISH —"
 fi
+
+umask 0022


### PR DESCRIPTION
This changes the umask to 0377, so the produced dumpfiles are not
readable for other users on the system