### PR TITLE
Update EngineBlock ACL task and add missing EB Parameter

### DIFF
--- a/roles/engineblock/tasks/develop.yml
+++ b/roles/engineblock/tasks/develop.yml
@@ -31,10 +31,8 @@
     entity: "{{ item[0] }}"
     default: "{{ item[1] }}"
     path: "{{ item[2] }}"
-    etype: user
     permissions: rwx
-    recursive: yes
-    state: present
+    use_nfsv4_acls: yes
   with_nested:
     - [ "{{ engine_fpm_user }}", "vagrant" ]
     - [ "no", "yes" ]


### PR DESCRIPTION
1. Since we specified use of NFS4 in the Vagrantfile, the setfacl task in the EB role failed. Making that task NFS4 proof, that issue is resolved. Thanks for pointing me in this direction @quartje 
2. parameters.yml.j2 was missing a recent paramters change. Resulting in a EB error after deploying the parameters.yml. Adding the missing param to the Jinja template resolved this issue.