### PR TITLE
Update lifecycle role to conform to Symfony 5.4

### DIFF
--- a/roles/lifecycle/defaults/main.yml
+++ b/roles/lifecycle/defaults/main.yml
@@ -9,7 +9,7 @@ lifecycle_build_path: "{{ openconext_builds_dir }}/OpenConext-user-lifecycle-{{ 
 lifecycle_download_url: "https://github.com/OpenConext/OpenConext-user-lifecycle/releases/download/{{ lifecycle_version }}/OpenConext-user-lifecycle-{{ lifecycle_version_dir }}.tar.gz"
 lifecycle_current_release_symlink: "{{ openconext_releases_dir }}/OpenConext-user-lifecycle"
  
-front_controller: app.php
+front_controller: index.php
 lifecycle_user: lifecycle
 lifecycle_data_dir: /opt/openconext/OpenConext-lifecycle
 lifecycle_symfony_env: prod

--- a/roles/lifecycle/templates/lifecycle.conf.j2
+++ b/roles/lifecycle/templates/lifecycle.conf.j2
@@ -5,15 +5,15 @@ Listen {{ apache_app_listen_address.lifecycle }}:{{ loadbalancing.lifecycle.port
 <Virtualhost *:443 >
 {% endif %}
     ServerAdmin {{ admin_email }}
-    DocumentRoot "{{ lifecycle_current_release_symlink }}/web"
+    DocumentRoot "{{ lifecycle_current_release_symlink }}/public"
     SetEnv SYMFONY_ENV prod
     SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
-    <Directory "{{ lifecycle_current_release_symlink }}/web">
+    <Directory "{{ lifecycle_current_release_symlink }}/public">
         Require all granted
      	Options -MultiViews
 	RewriteEngine On
 	RewriteCond %{REQUEST_FILENAME} !-f
-	RewriteRule ^(.*)$ app.php [QSA,L]
+	RewriteRule ^(.*)$ index.php [QSA,L]
     </Directory>
     ProxyPassMatch ^/(.*\.php(/.*)?)$ unix:/var/run/php-fpm/lifecycle-pool-72.sock|fcgi://localhost{{ lifecycle_current_release_symlink }}/web/$1
     ErrorLog "|/usr/bin/logger -S 32k -p local3.err  -t 'Apache-LIFECYCLE'"

--- a/roles/lifecycle/templates/makeRelease.sh.j2
+++ b/roles/lifecycle/templates/makeRelease.sh.j2
@@ -54,17 +54,19 @@ echo "Commit: ${COMMITHASH}" >> ${PROJECT_DIR}/RELEASE &&
 echo "Cleaning build of dev files" &&
 rm -rf ${PROJECT_DIR}/.idea &&
 rm -rf ${PROJECT_DIR}/.git &&
+rm -rf ${PROJECT_DIR}/tests &&
 rm -f ${PROJECT_DIR}/.gitignore &&
 rm -f ${PROJECT_DIR}/makeRelease.sh &&
 rm -f ${PROJECT_DIR}/bin/composer.phar &&
-rm -rf ${PROJECT_DIR}/features &&
-rm -rf ${PROJECT_DIR}/behat.yml &&
-rm -rf ${PROJECT_DIR}/build.xml &&
-rm -rf ${PROJECT_DIR}/tests &&
-rm -rf ${PROJECT_DIR}/ci &&
-rm -rf ${PROJECT_DIR}/.travis.yml &&
-rm -rf ${PROJECT_DIR}/ansible &&
-rm -rf ${PROJECT_DIR}/Vagrantfile &&
+rm -f ${PROJECT_DIR}/build.xml &&
+rm -f ${PROJECT_DIR}/.travis.yml &&
+rm -f ${PROJECT_DIR}/travis.php.ini &&
+rm -f ${PROJECT_DIR}/docker-compose.yml &&
+rm -f ${PROJECT_DIR}/phpcs.xml &&
+rm -f ${PROJECT_DIR}/phpcs_test.xml &&
+rm -f ${PROJECT_DIR}/phpmd.xml &&
+rm -f ${PROJECT_DIR}/phpunit.xml &&
+rm -f ${PROJECT_DIR}/phpunit.yml.dist &&
 
 echo "Create tarball" &&
 cd ${RELEASE_DIR} &&


### PR DESCRIPTION
The role is currently set to handle a SF 3.4 project. The recent upgrade to version 4.4 (and the pending SF 5.4 upgrade) require some changes to the lifecycle role.

Most important is the front-controller change. `app.php` no longer exists and is replaced with an `index.php` file. Also, the web folder is no longer the document root. This changed to be the `public` folder.

While at it, I also updated the release script. Removing old, non existing constructions. And replacing them with more correct substitutions.

Disclaimer: I did not test this change. Dear reviewer, would you be so kind to give these changes a test-spin?