### PR TITLE
Direct shib outloggers to engine logout

### DIFF
--- a/roles/shibboleth/defaults/main.yml
+++ b/roles/shibboleth/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 shibboleth_metadata_sources:
   engine: "https://engine.{{ base_domain }}/authentication/idp/metadata"
+engine_logout_url: "https://engine.{{ base_domain }}/logout"
 shibd_sp_crt_not_in_inventory: false
 mariadb_odbc_version: 3.0.8
 shibboleth_database_backend: false

--- a/roles/shibboleth/templates/shibboleth/localLogout.html.j2
+++ b/roles/shibboleth/templates/shibboleth/localLogout.html.j2
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>{{ instance_name }} - Local logout</title>
+  <meta http-equiv="refresh" content="0;url={{ engine_logout_url }}">
   <link rel="stylesheet" href="<shibmlp styleSheet/>">
   <link rel="stylesheet" href="<shibmlp styleSheet2/>">
 </head>


### PR DESCRIPTION
Which is slightly more informative & platform styled than the
localLogout HTML we shi(b/p).