### PR TITLE
Haproxy: block excessive request on the basis of ip / path / host

### DIFF
--- a/roles/haproxy/defaults/main.yml
+++ b/roles/haproxy/defaults/main.yml
@@ -4,7 +4,10 @@ haproxy_metricbeat: False
 # The default http methods whitelist is meant to disable methods like TRACE or DEBUG.
 # OPTIONS is mainly used for CORS requests in OIDC-NG (like SPA apps)
 haproxy_supported_http_methods: "GET HEAD OPTIONS POST PUT DELETE"
+# maximum number of requests per 10s
 haproxy_max_request_rate: 1000
+# maximum number of requests per host header src ip and path per 1 m
+haproxy_max_request_rate_ip_path: 250
 # You can create an allowlist of ips that are allowed to go over the configured ratelimit
 haproxy_allowlistips:
   - ''

--- a/roles/haproxy/templates/haproxy_frontend.cfg.j2
+++ b/roles/haproxy/templates/haproxy_frontend.cfg.j2
@@ -75,12 +75,16 @@ frontend local_ip
     # Measure and log the request rate per path and ip 
     http-request track-sc1 base32+src table st_httpreqs_per_ip_and_path
     http-request capture sc_http_req_rate(1) len 4
+    # Create an ACL when the request rate per host header url path and src ip exceeds {{ haproxy_max_request_rate_ip_path }} per 1m
+    acl exceeds_max_request_rate_per_ip_and_path sc_http_req_rate(1) gt {{ haproxy_max_request_rate_ip_path }}
     # Deny the request when the ip address is on the blocklist
     http-request deny if blocklist
     # Deny the request when no valid host header is used
     http-request deny if ! valid_vhost
     # Deny the request when the request rate exceeds {{ haproxy_max_request_rate }} per 10s
     http-request deny deny_status 429 if exceeds_max_request_rate_per_ip !allowlist
+    # Deny the request when the request rate per host header url path and src ip exceeds {{ haproxy_max_request_rate_ip_path }} per 1 m 
+    http-request deny deny_status 429 if exceeds_max_request_rate_per_ip_and_path !allowlist
     # Create some http redirects
     http-request redirect location %[req.hdr(host),lower,map(/etc/haproxy/maps/redirects.map)] if { req.hdr(host),lower,map_str(/etc/haproxy/maps/redirects.map) -m found }
 
@@ -155,11 +159,15 @@ frontend localhost_restricted
     # Measure and log the request rate per path and ip 
     http-request track-sc1 base32+src table st_httpreqs_per_ip_and_path
     http-request capture sc_http_req_rate(1) len 4
+    # Create an ACL when the request rate per host header url path and src ip exceeds {{ haproxy_max_request_rate_ip_path }} per 1m
+    acl exceeds_max_request_rate_per_ip_and_path sc_http_req_rate(1) gt {{ haproxy_max_request_rate_ip_path }}
     # Deny the request when the ip address is on the blocklist
     http-request deny if blocklist
     # Deny the request when no valid host header is used
     http-request deny if ! valid_vhost
     # Deny the request when the request rate exceeds {{ haproxy_max_request_rate }} per 10s
     http-request deny deny_status 429 if exceeds_max_request_rate_per_ip !allowlist
+    # Deny the request when the request rate per host header url path and src ip exceeds {{ haproxy_max_request_rate_ip_path }} per 1 m 
+    http-request deny deny_status 429 if exceeds_max_request_rate_per_ip_and_path !allowlist
 
 {% endif %}


### PR DESCRIPTION
An ACL was already in place to measure the # of requests to a unique path and host header coming from a unique ip address (the basee32+src fetch method of Haproxy). This change will block an ip address when it hits more than a configured amount of requests per minute (250 in de default setup).

In the future it would be even nice to be able to configure the max rate in a map file (so you don't need to change the whole config file if you want to change the ratelimit)