### PR TITLE
oidcng: Make file and json logs toggable

### DIFF
--- a/roles/oidcng/defaults/main.yml
+++ b/roles/oidcng/defaults/main.yml
@@ -9,6 +9,8 @@ oidcng_saml_sp_entityid: https://connect.{{ base_domain }}
 oidcng_idp_metadata_url: https://engine.{{ base_domain }}/authentication/idp/metadata
 oidcng_base_hostname: connect.{{ base_domain }}
 oidcng_logback_email: true
+oidcng_logback_file: true
+oidcng_logback_json: true
 oidcng_idp_sso_location: https://engine.{{ base_domain }}/authentication/idp/single-sign-on
 oidcng_manage_provision_samlsp_client_id: "https://connect.{{ base_domain }}"
 oidcng_manage_provision_samlsp_name_en: "{{ instance_name }} OIDC Gateway"

--- a/roles/oidcng/templates/logback.xml.j2
+++ b/roles/oidcng/templates/logback.xml.j2
@@ -34,7 +34,6 @@
       </prefix>
   </appender>
 
-{%if oidcng_logback_email | bool %}
  <appender name="EMAIL" class="ch.qos.logback.classic.net.SMTPAppender">
    <smtpHost>{{ smtp_server }}</smtpHost>
    <from>{{ noreply_email }}</from>
@@ -52,17 +51,20 @@
      <level>ERROR</level>
    </filter>
  </appender>
-{%endif%}
 
  <logger name="oidc" level="WARN" />
  <logger name="org.springframework" level="WARN" />
  <root level="WARN">
+{%if oidcng_logback_file |bool  %}
    <appender-ref ref="FILE" />
+{%endif%}
 {%if oidcng_logback_email |bool  %}
    <appender-ref ref="EMAIL" />
 {%endif%}
    <appender-ref ref="SYSLOG" />
+{%if oidcng_logback_json |bool  %}
    <appender-ref ref="JSON_SYSLOG" />
+{%endif%}
  </root>
 
 </configuration>


### PR DESCRIPTION
With this change it is possible to toggle the oidcng file log (located in /var/log/oidcng) and the json logs. The file logs are also in
/var/log/messages present and can be switched off. The json logs are a bit verbose, which will be fixed in a feature release". For now they can be switched off