### PR TITLE
Docker build: Remove ipv6 listen address in Haproxy

### DIFF
--- a/tests/githubactions-build.sh
+++ b/tests/githubactions-build.sh
@@ -65,6 +65,9 @@ sed -i 's/%target_host%/ansible-test-ga ansible_connection=docker/g' environment
 # Create the proper host_vars file
 /bin/cp environments/template/host_vars/template.yml environments-external/github/host_vars/ansible-test-ga.yml
 
+# Remove ipv6 listening address in Haproxy
+sed -i '/haproxy_sni_ip\.ipv6/d' roles/haproxy/templates/haproxy_frontend.cfg.j2
+
 echo
 echo "================================================================="
 echo "================================================================="


### PR DESCRIPTION
Some docker installations do no not allow listening on an ipv6 localhost address, and Haproxy then refuses to start. This PR fixes that issue