### PR TITLE
Haproxy: Allow certain paths to have higher rate limits

### DIFF
--- a/roles/haproxy/defaults/main.yml
+++ b/roles/haproxy/defaults/main.yml
@@ -8,6 +8,8 @@ haproxy_supported_http_methods: "GET HEAD OPTIONS POST PUT DELETE"
 haproxy_max_request_rate: 1000
 # maximum number of requests per host header src ip and path per 1 m
 haproxy_max_request_rate_ip_path: 250
+# Some paths allow for higher ratelimits (now by default introspect, userinfo and token)
+haproxy_max_request_rate_ip_path_exceptions: 500
 # You can create an allowlist of ips that are allowed to go over the configured ratelimit
 haproxy_allowlistips:
   - ''

--- a/roles/haproxy/tasks/main.yml
+++ b/roles/haproxy/tasks/main.yml
@@ -184,6 +184,7 @@
   with_items:
     - backends.map
     - redirects.map
+    - ratelimits.map
   notify:
     - "reload haproxy"
  

--- a/roles/haproxy/templates/haproxy_frontend.cfg.j2
+++ b/roles/haproxy/templates/haproxy_frontend.cfg.j2
@@ -75,8 +75,11 @@ frontend local_ip
     # Measure and log the request rate per path and ip 
     http-request track-sc1 base32+src table st_httpreqs_per_ip_and_path
     http-request capture sc_http_req_rate(1) len 4
+    # Some paths allow for a higher ratelimit. These are in a seperate mapfile
+    http-request set-var(req.rate_limit)  path,map_beg(/etc/haproxy/maps/ratelimits.map,{{ haproxy_max_request_rate_ip_path }})
+    http-request set-var(req.request_rate)  sc_http_req_rate(1)
     # Create an ACL when the request rate per host header url path and src ip exceeds {{ haproxy_max_request_rate_ip_path }} per 1m
-    acl exceeds_max_request_rate_per_ip_and_path sc_http_req_rate(1) gt {{ haproxy_max_request_rate_ip_path }}
+    acl exceeds_max_request_rate_per_ip_and_path var(req.rate_limit),sub(req.request_rate) lt 0
     # Deny the request when the ip address is on the blocklist
     http-request deny if blocklist
     # Deny the request when no valid host header is used
@@ -159,8 +162,11 @@ frontend localhost_restricted
     # Measure and log the request rate per path and ip 
     http-request track-sc1 base32+src table st_httpreqs_per_ip_and_path
     http-request capture sc_http_req_rate(1) len 4
+    # Some paths allow for a higher ratelimit. These are in a seperate mapfile
+    http-request set-var(req.rate_limit)  path,map_beg(/etc/haproxy/maps/ratelimits.map,{{ haproxy_max_request_rate_ip_path }})
+    http-request set-var(req.request_rate)  sc_http_req_rate(1)
     # Create an ACL when the request rate per host header url path and src ip exceeds {{ haproxy_max_request_rate_ip_path }} per 1m
-    acl exceeds_max_request_rate_per_ip_and_path sc_http_req_rate(1) gt {{ haproxy_max_request_rate_ip_path }}
+    acl exceeds_max_request_rate_per_ip_and_path var(req.rate_limit),sub(req.request_rate) lt 0
     # Deny the request when the ip address is on the blocklist
     http-request deny if blocklist
     # Deny the request when no valid host header is used

--- a/roles/haproxy/templates/ratelimits.map.j2
+++ b/roles/haproxy/templates/ratelimits.map.j2
@@ -1,0 +1,3 @@
+/oidc/introspect {{ haproxy_max_request_rate_ip_path_exceptions }}
+/oidc/token {{ haproxy_max_request_rate_ip_path_exceptions }}
+/oidc/userinfo {{ haproxy_max_request_rate_ip_path_exceptions }}


### PR DESCRIPTION
Rate limits are based on source ip address. Some paths in OpenCoenxt are meant to be accessed with high rates from the same originating IP address. . Like some of the OIDC endpoints. You can now set a higher rate limit for these paths. For now
the ratelimits and paths are static, but if needed in the future they can be made into variables that can be put in the environment variables. 