### PR TITLE
TIQR: Add cleanup probability config option

### DIFF
--- a/roles/stepuptiqr/templates/parameters.yaml.j2
+++ b/roles/stepuptiqr/templates/parameters.yaml.j2
@@ -65,6 +65,7 @@ parameters:
                 dsn: 'mysql:host={{ tiqr_db_host }};dbname={{ database_tiqr_name }}'
                 username: '{{ database_tiqr_user }}'
                 password: '{{ mysql_passwords.tiqr }}'
+                cleanup_probability: '{{ tiqr_cleanup_probability | default('0.01') }}'
 
 {% else %}
               type: 'memcache'


### PR DESCRIPTION
This allows you to set a probability that the database session cleanup is triggered.
The default is set to 0.01 (so 1% probability)