### PR TITLE
Replace deprecated include with (include/import)_tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ With the above commands you get the latest versions. There might be incompatibil
 
 Ansible is the configuration tool we use to describe our servers.
 Installation instruction can be found on the [Ansible website](http://docs.ansible.com/intro_installation.html).
-The minimum required version of Ansible is 1.9. 
+The minimum required version of Ansible is 2.4.
 To install for development with Homebrew:
 
     brew install python

--- a/provision.yml
+++ b/provision.yml
@@ -124,7 +124,7 @@
 
 # run -t springboot -e springboot_service_to_deploy=manage,voot to only install
 # the manage and voot app. Both GUI as servers will be installed.
-- hosts: java_apps
+- hosts: java-apps
   become: true
   roles:
     - { role: springboot,       tags: ['core', 'springboot'] }

--- a/provision.yml
+++ b/provision.yml
@@ -109,7 +109,7 @@
         - inventory_hostname in groups['lifecycle']
       tags: ['app_php', 'lifecycle']
   handlers:
-    - include: roles/httpd/handlers/main.yml
+    - import_tasks: roles/httpd/handlers/main.yml
 
 - hosts: app_java
   gather_facts: true
@@ -120,17 +120,17 @@
     - role: shibboleth
       tags: ['core', 'app_java', 'shib']
   handlers:
-    - include: roles/httpd/handlers/main.yml
+    - import_tasks: roles/httpd/handlers/main.yml
 
 # run -t springboot -e springboot_service_to_deploy=manage,voot to only install
 # the manage and voot app. Both GUI as servers will be installed.
-- hosts: java-apps
+- hosts: java_apps
   become: true
   roles:
     - { role: springboot,       tags: ['core', 'springboot'] }
 
   handlers:
-    - include: roles/httpd/handlers/main.yml
+    - import_tasks: roles/httpd/handlers/main.yml
 
 - hosts: app_php
   gather_facts: no
@@ -141,7 +141,7 @@
        - inventory_hostname not in groups['lifecycle']
      tags: ['core', 'app_php', 'profile']
   handlers:
-    - include: roles/httpd/handlers/main.yml
+    - import_tasks: roles/httpd/handlers/main.yml
 
 - hosts: elk
   gather_facts: true
@@ -159,7 +159,7 @@
     - role: influxdb
       tags: ['influxdb' ]
   handlers:
-    - include: roles/httpd/handlers/main.yml
+    - include_tasks: roles/httpd/handlers/main.yml
 
 - hosts: stepuppapp
   become: true

--- a/roles/elk/tasks/logstash.yml
+++ b/roles/elk/tasks/logstash.yml
@@ -52,11 +52,11 @@
 
 
 - name: Include OpenConext-stats specific tasks
-  include: logstash_stats.yml
+  include_tasks: logstash_stats.yml
   when: logstash_stats | bool
 
 - name: Include ELK stack specific tasks
-  include: logstash_elk.yml
+  include_tasks: logstash_elk.yml
   when: logstash_elk | bool
 
 - name: Enable and start logstash service

--- a/roles/elk/tasks/main.yml
+++ b/roles/elk/tasks/main.yml
@@ -22,13 +22,13 @@
     mode: 0775
 
 - name: Include logstash specific tasks
-  include: logstash.yml
+  include_tasks: logstash.yml
   when: "'logstash' in group_names"
 
 - name: Include elastic specific tasks
-  include: elastic.yml
+  include_tasks: elastic.yml
   when: "'elasticsearch' in group_names"
 
 - name: Include kibana specific tasks
-  include: kibana.yml
+  include_tasks: kibana.yml
   when: "'kibana' in group_names" 

--- a/roles/engineblock/tasks/main.yml
+++ b/roles/engineblock/tasks/main.yml
@@ -20,27 +20,27 @@
     mode: 0770
 
 - name: Install build tools (npm, composer)
-  include: build.yml
+  include_tasks: build.yml
   when:
     - "(engine_branch is defined and engine_branch != '') or develop"
 
 - name: Include install-release.yml
-  include: install-release.yml
+  include_tasks: install-release.yml
   when:
     - "(engine_branch is not defined or engine_branch == '') and not develop"
 
 - name: Include install-branch.yml
-  include: install-branch.yml
+  include_tasks: install-branch.yml
   when:
     - "(engine_branch is defined and engine_branch != '') and not develop"
 
 - name: Include develop.yml
-  include: develop.yml
+  include_tasks: develop.yml
   when:
     - develop | bool
 
 - name: Include test.yml
-  include: test.yml
+  include_tasks: test.yml
   when:
     - develop | bool
 

--- a/roles/galera/tasks/main.yml
+++ b/roles/galera/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 - name: Include arbiter installation
-  include: arbiter_node.yml
+  include_tasks: arbiter_node.yml
   when: arbiter_node is defined
 
 - name: Include cluster node installation
-  include: cluster_nodes.yml
+  include_tasks: cluster_nodes.yml
   when: arbiter_node is not defined

--- a/roles/lifecycle/tasks/main.yml
+++ b/roles/lifecycle/tasks/main.yml
@@ -39,11 +39,11 @@
     - "restart php72-php-fpm"
 
 - name: Include install-branch.yml
-  include: install-branch.yml
+  include_tasks: install-branch.yml
   when: lifecycle_branch is defined and lifecycle_branch != ''
 
 - name: Include install-release.yml
-  include: install-release.yml
+  include_tasks: install-release.yml
   when: lifecycle_branch is not defined or lifecycle_branch == ''
 
 - name: Place parameters.yml

--- a/roles/monitoring-tests/tasks/main.yml
+++ b/roles/monitoring-tests/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 - name: Include preinstallation.yml
-  include: ../../../tasks/springbootapp/preinstallation.yml
+  import_tasks: ../../../tasks/springbootapp/preinstallation.yml
 
-- include: ../../../tasks/springbootapp/install-maven-release.yml
+- import_tasks: ../../../tasks/springbootapp/install-maven-release.yml
 
 - name: Copy logging config
   template:
@@ -25,4 +25,4 @@
     - "restart monitoring-tests"
 
 - name: Include postinstallation.yml
-  include: ../../../tasks/springbootapp/postinstallation.yml
+  import_tasks: ../../../tasks/springbootapp/postinstallation.yml

--- a/roles/profile/tasks/main.yml
+++ b/roles/profile/tasks/main.yml
@@ -20,11 +20,11 @@
     mode: 0770
 
 - name: Include install-release.yml
-  include: install-release.yml
+  include_tasks: install-release.yml
   when: profile_branch is not defined or profile_branch == ''
 
 - name: Include install-branch.yml
-  include: install-branch.yml
+  include_tasks: install-branch.yml
   when: profile_branch is defined and profile_branch != ''
 
 - name: Create the cache dir for Symfony

--- a/roles/rsyslog/tasks/main.yml
+++ b/roles/rsyslog/tasks/main.yml
@@ -51,9 +51,9 @@
     - "restart rsyslog"
 
 - name: include tasks for central syslog server
-  include: rsyslog_central.yml
+  include_tasks: rsyslog_central.yml
   when:  "'sysloghost' in group_names"
 
 - name: Include tasks for authentication log processing 
-  include: process_auth_logs.yml
+  include_tasks: process_auth_logs.yml
   when: "'auth_processor' in group_names"

--- a/roles/shibboleth/tasks/main.yml
+++ b/roles/shibboleth/tasks/main.yml
@@ -14,7 +14,7 @@
     state: present
 
 - name: Include tasks to save Shibboleth sessions to the database
-  include: shibboleth_database_backend.yml
+  include_tasks: shibboleth_database_backend.yml
   when: shibboleth_database_backend | bool
 
 - name: Remove default conf files apache

--- a/roles/springboot/tasks/springboot.yml
+++ b/roles/springboot/tasks/springboot.yml
@@ -23,17 +23,17 @@
     _springapp_java_binary: "{{ springboot.java_binary if springboot.java_binary is defined else springboot_java_binary }}"
 
 - name: "{{ _springapp_service_name }}-{{ _springapp_type }} | Include user related tasks"
-  include: user.yml
+  include_tasks: user.yml
   when:
     - _springapp_type == "server"
 
 - name: "{{ _springapp_service_name }}-{{ _springapp_type }} | Include GUI related tasks"
-  include: gui.yml
+  include_tasks: gui.yml
   when:
     - _springapp_type == "gui"
 
 - name: "{{ _springapp_service_name }}-{{ _springapp_type }} | Include maven related tasks"
-  include: maven.yml
+  include_tasks: maven.yml
   when:
     - _springapp_type == "server"
 
@@ -53,6 +53,6 @@
     name: "{{ _springapp_role }}"
 
 - name: "{{ _springapp_service_name }}-{{ _springapp_type }} | Include service related tasks"
-  include: service.yml
+  include_tasks: service.yml
   when:
     - _springapp_type == "server"


### PR DESCRIPTION
`include:` is deprecated and will be removed in Ansible 2.19. Replaced with include_tasks (dynamically, e.g. based on output of earlier task) and import_taks (just statically import file at compile time).

Minimum Ansible requirement is then 2.4.