### PR TITLE
Feature/keepalived maintenance scripts

### DIFF
--- a/roles/keepalived/files/clustercheck
+++ b/roles/keepalived/files/clustercheck
@@ -17,7 +17,7 @@ fi
 
 # if the disabled file is present, return 503. This allows
 # admins to manually remove a node from a cluster easily.
-if [ -e "/var/tmp/clustercheck.disabled" ]; then
+if [ -e "/var/lib/keepalived/maintenance" ]; then
     # Shell return-code is 1
     echo -en "HTTP/1.1 503 Service Unavailable\r\n"
     echo -en "Content-Type: text/plain\r\n"

--- a/roles/keepalived/files/keepalived_check_maintenance
+++ b/roles/keepalived/files/keepalived_check_maintenance
@@ -1,0 +1,7 @@
+#!/bin/bash
+#Check if there is a maintenance file 
+if [ -f "/var/lib/keepalived/maintenance" ]; then
+   exit 1
+else
+   exit 0
+fi

--- a/roles/keepalived/files/keepalived_notify
+++ b/roles/keepalived/files/keepalived_notify
@@ -4,14 +4,21 @@ TYPE=$1
 NAME=$2
 STATE=$3
 
+case $NAME in
+        "ipv6")   FILENAME=/var/lib/keepalived/keepalived6.state ;;
+
+        *)        FILENAME=/var/lib/keepalived/keepalived.state ;;
+
+esac
+
 case $STATE in
-        "MASTER") /bin/echo master > /var/lib/keepalived/keepalived.state
+        "MASTER") /bin/echo master > $FILENAME
                   exit 0
                   ;;
-        "BACKUP") /bin/echo backup > /var/lib/keepalived/keepalived.state 
+        "BACKUP") /bin/echo backup > $FILENAME
                   exit 0
                   ;;
-        "FAULT")  /bin/echo fault > /var/lib/keepalived/keepalived.state
+        "FAULT")  /bin/echo fault > $FILENAME
                   exit 0
                   ;;
         *)        echo "unknown state"

--- a/roles/keepalived/tasks/main.yml
+++ b/roles/keepalived/tasks/main.yml
@@ -22,17 +22,19 @@
   register: keepalived_package_installed
   until: keepalived_package_installed is succeeded
 
-- name: Create keepalived_scripts user to execute scripts 
-  user: 
+- name: Create keepalived_scripts user to execute scripts
+  user:
     name: keepalived_script
     shell: /sbin/nologin
     state: present
+  when: "'dbcluster_nodes' in group_names"
 
 - name: Add the keepalived_scripts user to the group mysqlusers on the dbcluster nodes
-  user: 
+  user:
     name: keepalived_script
     groups: mysqlusers
     append: yes
+  when: "'dbcluster_nodes' in group_names"
 
 - name: Create directory to keep the statefile
   file:
@@ -49,7 +51,7 @@
     mode: 0750
     owner: root
     group: mysqlusers
-  when : "'dbcluster_nodes' in group_names"
+  when: "'dbcluster_nodes' in group_names"
 
 - name: Put the notify script to the correct location
   copy:
@@ -58,6 +60,18 @@
     mode: 0750
     owner: root
     group: mysqlusers
+  when: "'dbcluster_nodes' in group_names"
+
+- name: Put the notify and maintenance checkscript to the correct location
+  copy:
+    src:
+      - "keepalived_notify"
+      - "keepalived_check_maintenance"
+    dest: "/usr/local/bin/"
+    mode: 0750
+    owner: root
+    group: keepalived_script
+  when: "'loadbalancer' in group_names"
 
 - name: Copy config file
   template:

--- a/roles/keepalived/tasks/main.yml
+++ b/roles/keepalived/tasks/main.yml
@@ -27,7 +27,6 @@
     name: keepalived_script
     shell: /sbin/nologin
     state: present
-  when: "'dbcluster_nodes' in group_names"
 
 - name: Add the keepalived_scripts user to the group mysqlusers on the dbcluster nodes
   user:
@@ -64,13 +63,14 @@
 
 - name: Put the notify and maintenance checkscript to the correct location
   copy:
-    src:
-      - "keepalived_notify"
-      - "keepalived_check_maintenance"
+    src: "{{ item }}"
     dest: "/usr/local/bin/"
     mode: 0750
     owner: root
     group: keepalived_script
+  with_items:
+    - "keepalived_notify"
+    - "keepalived_check_maintenance"
   when: "'loadbalancer' in group_names"
 
 - name: Copy config file

--- a/roles/keepalived/templates/keepalived_dbcluster.conf.j2
+++ b/roles/keepalived/templates/keepalived_dbcluster.conf.j2
@@ -15,7 +15,7 @@ vrrp_instance galera {
    state {{ keepalived.state }}
    virtual_router_id {{ keepalived_vrid }}          # Assign one ID for this route
    priority {{ keepalived.prio }}                 # 101 on master, 100 on backup
-   advert_int 5
+   advert_int 1
    authentication {
         auth_type PASS
         auth_pass {{ keepalived_dbcluster_vrrp_password }}

--- a/roles/keepalived/templates/keepalived_loadbalancer.conf.j2
+++ b/roles/keepalived/templates/keepalived_loadbalancer.conf.j2
@@ -16,7 +16,7 @@ vrrp_instance ipv4 {
    state {{ keepalived.state_master }}
    virtual_router_id 55                                 # Assign one ID for this route
    priority {{ keepalived.masterprio }}                 # 101 on master, 100 on backup
-   advert_int 5
+   advert_int 1
    authentication {
         auth_type PASS
         auth_pass {{ keepalived_loadbalancer_vrrp_password }}

--- a/roles/keepalived/templates/keepalived_loadbalancer.conf.j2
+++ b/roles/keepalived/templates/keepalived_loadbalancer.conf.j2
@@ -3,6 +3,14 @@ global_defs {
   vrrp_garp_master_refresh 60
   enable_script_security true
 }
+
+vrrp_script chk_maint {
+        script "/usr/local/bin/keepalived_check_maintenance"
+        interval 1
+        fall 3
+        rise 1
+}
+
 vrrp_instance ipv4 {
    interface {{ ansible_default_ipv4.interface }}       # interface to monitor
    state {{ keepalived.state_master }}
@@ -18,6 +26,9 @@ vrrp_instance ipv4 {
        {% if haproxy_sni_ip_restricted.ipv4 is defined %}
        {{ haproxy_sni_ip_restricted.ipv4 }}
        {% endif %}
+   }
+   track_script {
+        chk_maint
    }
    
        notify_master "/bin/echo 'master' > /var/lib/keepalived/keepalived.state"
@@ -37,6 +48,9 @@ vrrp_instance ipv6 {
         {% if haproxy_sni_ip_restricted.ipv6 is defined %}
         {{ haproxy_sni_ip_restricted.ipv6 }}
         {% endif %}
+   }
+   track_script {
+        chk_maint
    }
    
        notify_master "/bin/echo 'master' > /var/lib/keepalived/keepalived6.state"

--- a/roles/keepalived/templates/keepalived_loadbalancer.conf.j2
+++ b/roles/keepalived/templates/keepalived_loadbalancer.conf.j2
@@ -30,10 +30,7 @@ vrrp_instance ipv4 {
    track_script {
         chk_maint
    }
-   
-       notify_master "/bin/echo 'master' > /var/lib/keepalived/keepalived.state"
-       notify_backup "/bin/echo 'backup' > /var/lib/keepalived/keepalived.state"
-       notify_fault "/bin/echo 'fault' > /var/lib/keepalived/keepalived.state"
+   notify /usr/local/bin/keepalived_notify   
 }
 vrrp_instance ipv6 {        
    interface {{ ansible_default_ipv4.interface }} 
@@ -52,8 +49,5 @@ vrrp_instance ipv6 {
    track_script {
         chk_maint
    }
-   
-       notify_master "/bin/echo 'master' > /var/lib/keepalived/keepalived6.state"
-       notify_backup "/bin/echo 'backup' > /var/lib/keepalived/keepalived6.state"
-       notify_fault "/bin/echo 'fault' > /var/lib/keepalived/keepalived6.state"
+   notify /usr/local/bin/keepalived_notify
 }


### PR DESCRIPTION
This PR enables maintenance on loadbalancers and database servers which use keepalived.
If the file /var/lib/keepalived/maintenance exists, the VRRP instances will go into FAULT mode, and the IP address will be failed over to the other node. 