### PR TITLE
GHA: Run actions on ubuntu 20.04 which supports cgroups v1

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   remove-package-versions:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: purge packages
         uses: dylanratcliffe/delete-untagged-containers@main

--- a/.github/workflows/docker-build-image.yml
+++ b/.github/workflows/docker-build-image.yml
@@ -12,7 +12,7 @@ on:
     
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/molecule-base.yml
+++ b/.github/workflows/molecule-base.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/molecule-frontend.yml
+++ b/.github/workflows/molecule-frontend.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/molecule-java.yml
+++ b/.github/workflows/molecule-java.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/molecule-loadbalancer.yml
+++ b/.github/workflows/molecule-loadbalancer.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/molecule-mongo.yml
+++ b/.github/workflows/molecule-mongo.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/molecule-mysql.yml
+++ b/.github/workflows/molecule-mysql.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/molecule-php.yml
+++ b/.github/workflows/molecule-php.yml
@@ -28,7 +28,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/syntax.yml
+++ b/.github/workflows/syntax.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
The ubuntu-latest runs on ubuntu 22.10 which does not support cgroups v1 anymore.
upgrading systemd in the CentOS image was tried at first, but the images created with this need the option cgroupsns=host to start. Which is not supported by docker-compose :(
So, back to cgroups v1 it is ... 