### PR TITLE
Feature/tiqr add apple api http2 proxy

### DIFF
--- a/roles/haproxy/files/sysconfig_haproxy
+++ b/roles/haproxy/files/sysconfig_haproxy
@@ -1,5 +1,0 @@
-# Add extra options to the haproxy daemon here. This can be useful for
-# specifying multiple configuration files with multiple -f options.
-# See haproxy(1) for a complete list of options.
-# This overrides the default haproxy.cfg config file
-CONFIG="/etc/haproxy/haproxy_global.cfg -f /etc/haproxy/haproxy_frontend.cfg -f /etc/haproxy/haproxy_backend.cfg -f /etc/haproxy/haproxy_stick_table_backend.cfg"

--- a/roles/haproxy/tasks/main.yml
+++ b/roles/haproxy/tasks/main.yml
@@ -19,8 +19,8 @@
   until: haproxy_package_installed is succeeded
 
 - name: Copy haproxy sysconfig file
-  copy:
-    src: sysconfig_haproxy 
+  template:
+    src: sysconfig_haproxy.j2
     dest: /etc/sysconfig/haproxy
   notify:
     - "restart haproxy"
@@ -131,6 +131,7 @@
     - haproxy_frontend.cfg
     - haproxy_backend.cfg
     - haproxy_stick_table_backend.cfg
+    - haproxy_proxy.cfg
   notify:
     - "reload haproxy"
 

--- a/roles/haproxy/templates/haproxy_proxy.cfg.j2
+++ b/roles/haproxy/templates/haproxy_proxy.cfg.j2
@@ -1,0 +1,14 @@
+{% if 'stepuppapp' in group_names %}
+# Apple API v2 only uses http/2. Since curl on Centos7 does not support http/2 we provide a seperate proxy to fix that.
+frontend apple_fe
+
+    bind 127.0.0.1:5000
+    mode http
+    default_backend apple_be
+
+backend apple_be    
+    mode http
+    server apple api.push.apple.com:443 ssl verify required ca-file /etc/pki/tls/certs/ca-bundle.crt alpn h2 crt /opt/openconext/OpenConext-tiqr/app/files/apns.pem
+{% else %}
+# Empty placeholder. This functionality is only used on StepupTIQR servers that also have the loadbalancer role installed locally
+{% endif %}

--- a/roles/haproxy/templates/sysconfig_haproxy.j2
+++ b/roles/haproxy/templates/sysconfig_haproxy.j2
@@ -1,0 +1,1 @@
+CONFIG="/etc/haproxy/haproxy_global.cfg -f /etc/haproxy/haproxy_frontend.cfg -f /etc/haproxy/haproxy_backend.cfg -f /etc/haproxy/haproxy_stick_table_backend.cfg -f /etc/haproxy/haproxy_proxy.cfg"

--- a/roles/stepuptiqr/files/haproxy.cfg
+++ b/roles/stepuptiqr/files/haproxy.cfg
@@ -1,0 +1,35 @@
+global
+    log         127.0.0.1 local2
+    chroot      /var/lib/haproxy
+    pidfile     /var/run/haproxy.pid
+    maxconn     4000
+    user        haproxy
+    group       tiqr
+    daemon
+    stats socket /var/lib/haproxy/stats
+
+defaults
+    mode                    http
+    log                     global
+    option                  httplog
+    option                  http-server-close
+    option                  log-health-checks
+    option                  redispatch
+    retries                 3
+    timeout http-request    10s
+    timeout queue           1m
+    timeout connect         10s
+    timeout client          1m
+    timeout server          1m
+    timeout http-keep-alive 10s
+    timeout check           10s
+    maxconn                 3000
+
+frontend apple_fe
+    bind 127.0.0.1:5000
+    mode http
+    default_backend             apple_be
+
+backend apple_be    
+    mode http
+    server apple api.push.apple.com:443 ssl verify required ca-file /etc/pki/tls/certs/ca-bundle.crt alpn h2 crt /opt/openconext/OpenConext-tiqr/app/files/apns.pem

--- a/roles/stepuptiqr/handlers/main.yml
+++ b/roles/stepuptiqr/handlers/main.yml
@@ -6,3 +6,8 @@
   service:
     name: php72-php-fpm
     state: reloaded
+
+- name: reload haproxy
+  service: 
+    name: haproxy
+    state: reloaded

--- a/roles/stepuptiqr/tasks/haproxy.yml
+++ b/roles/stepuptiqr/tasks/haproxy.yml
@@ -1,0 +1,27 @@
+---
+- name: Enable ius repo
+  yum:
+    name: "https://repo.ius.io/ius-release-el7.rpm"
+    state: present
+
+- name: Install haproxy and socat
+  yum:
+    name:
+      - haproxy20.x86_64
+      - socat
+
+- name: Install haproxy config file
+  copy:
+    src: haproxy.cfg
+    dest: /etc/haproxy/haproxy.cfg
+    owner: root
+    group: haproxy
+    mode: 0640
+  notify:
+    - "reload haproxy"
+
+- name: Start and enable haproxy
+  service:
+    name: haproxy
+    state: started
+    enabled: true

--- a/roles/stepuptiqr/tasks/main.yml
+++ b/roles/stepuptiqr/tasks/main.yml
@@ -77,6 +77,10 @@
   - "02-tiqr-migrate-to-keyserver.php"
   when: keyserver_consumerkey is defined
 
+- name: Inlude haproxy tasks 
+  include_tasks: "haproxy.yml"
+  when: "'loadbalancer' not in group_names"
+
 - meta: flush_handlers
 
 - name: Include post installation tasks

--- a/roles/stepuptiqr/tasks/main.yml
+++ b/roles/stepuptiqr/tasks/main.yml
@@ -79,7 +79,7 @@
 
 - name: Inlude haproxy tasks 
   include_tasks: "haproxy.yml"
-  when: "'loadbalancer' not in group_names"
+  when: "'loadbalancer' not in group_names and apns_http2_proxy |default(false) | bool"
 
 - meta: flush_handlers
 

--- a/roles/stepuptiqr/templates/parameters.yaml.j2
+++ b/roles/stepuptiqr/templates/parameters.yaml.j2
@@ -52,6 +52,11 @@ parameters:
           apns:
             certificate: '{{ current_release_config_file_dir_name }}/apns.pem'
             environment: production
+{% if apns_http2_proxy |default(false) | bool %}
+            version: 2
+            proxy_host_url: 'http://localhost'
+            apns.proxy_host_port: 5000
+{% endif %}
         accountblocking:
             maxAttempts: 5
             # temporarilyBlockDuration:


### PR DESCRIPTION
The  Apple Push Notification service (APNs) only supports http/2. Since curl shipped with CentOS7 only supports http/1 we are not able to send push messages to this Apple API.
We use haproxy to create a simple reverse http proxy between the Apple API and the TIQR application to  proxy the requests (since Haproxy understands http/2). 
On hosts where the whole stack is installed on 1 machine (and an Haproxy loadbalancer is already present) we add an extra back- and frontend for this purpose.  TIQR can simple push the messages to http://localhost:5000
