### PR TITLE
Galera_create_users: remove deployhost

### DIFF
--- a/environments/template/inventory
+++ b/environments/template/inventory
@@ -41,7 +41,6 @@ lifecycle
 oidc
 dbcluster
 dbcluster_nodes
-galera_provision_host
 stats
 
 [sysloghost]
@@ -51,7 +50,6 @@ stats
 [oidc]
 [dbcluster]
 [dbcluster_nodes]
-[galera_provision_host]
 [stats]
 [php_apps_vm]
 
@@ -62,7 +60,6 @@ loadbalancer
 php_apps
 java_apps
 storage
-oidc
 dbcluster
 sysloghost
 elk
@@ -82,7 +79,6 @@ lifecycle
 storage
 dbcluster
 dbcluster_nodes
-galera_provision_host
 
 [db_mongo:children]
 mongod_primary

--- a/environments/vm/inventory
+++ b/environments/vm/inventory
@@ -54,7 +54,6 @@ lifecycle
 oidc
 dbcluster
 dbcluster_nodes
-galera_provision_host
 stats
 
 [sysloghost]
@@ -64,7 +63,6 @@ stats
 [oidc]
 [dbcluster]
 [dbcluster_nodes]
-[galera_provision_host]
 [stats]
 
 # Overview of "services"
@@ -74,7 +72,6 @@ loadbalancer
 php_apps
 java_apps
 storage
-oidc
 dbcluster
 sysloghost
 elk
@@ -94,7 +91,6 @@ lifecycle
 storage
 dbcluster
 dbcluster_nodes
-galera_provision_host
 
 [db_mongo:children]
 mongod_primary

--- a/molecule/galera/converge.yml
+++ b/molecule/galera/converge.yml
@@ -19,7 +19,6 @@
         mariadb_root_password: secret
         mariadb_backup_password: secret
         galera_bootstrap_node: openconext-rocky8-mysql
-        galera_provision_host: localhost
         galera_server_key: "{{lookup('file', inventory_dir + '/files/certs/galera/galera_server.key') }}"
         galera_client_key: "{{lookup('file', inventory_dir + '/files/certs/galera/galera_server.key') }}"
 
@@ -38,4 +37,3 @@
       databases:
         users:
           - { name: amolecule, db_name: amolecule, password: secret, privilege: ALL }
-  

--- a/molecule/galera/molecule.yml
+++ b/molecule/galera/molecule.yml
@@ -18,7 +18,6 @@ platforms:
       - storage
       - dbcluster
       - dbcluster_nodes
-      - galera_provision_host
   - name: openconext-rocky8-mysql-2
     image: rocky8-ansible
     dockerfile: ../Dockerfile-Rocky8.j2

--- a/molecule/mysql/molecule.yml
+++ b/molecule/mysql/molecule.yml
@@ -18,7 +18,6 @@ platforms:
       - storage
       - dbcluster
       - dbcluster_nodes
-      - galera_provision_host
   - name: openconext-centos7-mysql-2
     image: centos7-ansible
     dockerfile: ../Dockerfile.j2

--- a/provision.yml
+++ b/provision.yml
@@ -72,7 +72,7 @@
       tags: ['core', 'db_mysql', 'keepalived']
     - role: galera_create_users
       when:
-        - inventory_hostname in groups['galera_provision_host']
+        - inventory_hostname in groups['dbcluster']
       tags: ['core', 'db_mysql', 'galera', 'galera_create_users']
 
 - hosts: db_mongo

--- a/roles/galera_create_users/defaults/main.yml
+++ b/roles/galera_create_users/defaults/main.yml
@@ -1,4 +1,0 @@
-galera_provision_user: root
-galera_provision_password: "{{ mariadb_root_password }}"
-galera_provision_host: localhost
-


### PR DESCRIPTION
I removed the option to deploy galera users from a deployhost (using a mysql connection to the one galera cluster node) already from the role galera_create_users. This PR removes the leftover configuration