### PR TITLE
Fix missing TRUSTED_PROXIES environment var in stepup apps.

### DIFF
--- a/roles/stepupazuremfa/templates/env.j2
+++ b/roles/stepupazuremfa/templates/env.j2
@@ -1,3 +1,4 @@
 KERNEL_CLASS='App\Kernel'
 APP_ENV=prod
 APP_SECRET={{ azuremfa_secret }}
+TRUSTED_PROXIES='{{ engine_trusted_proxy_ips|join(',') }}'

--- a/roles/stepupgateway/templates/env.j2
+++ b/roles/stepupgateway/templates/env.j2
@@ -1,3 +1,4 @@
 KERNEL_CLASS='App\Kernel'
 APP_ENV=prod
 APP_SECRET={{ gateway_secret }}
+TRUSTED_PROXIES='{{ engine_trusted_proxy_ips|join(',') }}'

--- a/roles/stepupmiddleware/templates/parameters.yaml.j2
+++ b/roles/stepupmiddleware/templates/parameters.yaml.j2
@@ -1,9 +1,7 @@
 parameters:
     # Name of the application, used in lifecycle API
     application_name: "{{ lifecycle_application_name }}"
-    # IP addresses of any HTTP proxies that are sitting in from of the application
-    # See: http://symfony.com/doc/current/request/load_balancer_reverse_proxy.html
-    trusted_proxies:   [ 127.0.0.1 ]
+    trusted_proxies:   [ {{ engine_trusted_proxy_ips|join(',') }} ]
 
     database_driver:   pdo_mysql
 

--- a/roles/stepupra/templates/parameters.yml.j2
+++ b/roles/stepupra/templates/parameters.yml.j2
@@ -1,5 +1,5 @@
 parameters:
-    trusted_proxies:   [ 127.0.0.1 ]
+    trusted_proxies:   [ {{ engine_trusted_proxy_ips|join(',') }} ]
 
     mailer_transport:  smtp
     mailer_host:       127.0.0.1

--- a/roles/stepupselfservice/templates/parameters.yml.j2
+++ b/roles/stepupselfservice/templates/parameters.yml.j2
@@ -1,5 +1,5 @@
 parameters:
-    trusted_proxies:   [ 127.0.0.1 ]
+    trusted_proxies:   [ {{ engine_trusted_proxy_ips|join(',') }} ]
 
     mailer_transport:  smtp
     mailer_host:       127.0.0.1

--- a/roles/stepuptiqr/templates/env.j2
+++ b/roles/stepuptiqr/templates/env.j2
@@ -1,3 +1,4 @@
 KERNEL_CLASS='App\Kernel'
 APP_ENV=prod
 APP_SECRET={{ tiqr_secret }}
+TRUSTED_PROXIES='{{ engine_trusted_proxy_ips|join(',') }}'

--- a/roles/stepupwebauthn/templates/env.j2
+++ b/roles/stepupwebauthn/templates/env.j2
@@ -17,8 +17,7 @@
 KERNEL_CLASS='App\Kernel'
 APP_ENV=prod
 APP_SECRET={{ webauthn_secret }}
-#TRUSTED_PROXIES=127.0.0.1,127.0.0.2
-#TRUSTED_HOSTS='^localhost|example\.com$'
+TRUSTED_PROXIES='{{ engine_trusted_proxy_ips|join(',') }}'
 ###< symfony/framework-bundle ###
 
 ###> doctrine/doctrine-bundle ###


### PR DESCRIPTION
Name of "engine"_trusted_proxy_ips might be a bit of a misnomer now but it's the correct variable to use.