### PR TITLE
Centralise loa definitions for most apps in group_vars

### DIFF
--- a/environments/template/group_vars/template.yml
+++ b/environments/template/group_vars/template.yml
@@ -382,14 +382,11 @@ oidcng:
   api_user: manage
   key_rollover_cron_expression: "0 0 0 * * *"
   acr_values_supported:
-    - http://{{ base_domain }}/assurance/loa1
-    - http://{{ base_domain }}/assurance/loa2
-    - http://{{ base_domain }}/assurance/loa3
     - https://eduid.nl/trust/validate-names
     - https://eduid.nl/trust/linked-institution
     - https://eduid.nl/trust/affiliation-student
     - https://refeds.org/profile/mfa
-  default_acr_value: http://{{ base_domain }}/assurance/loa1
+  default_acr_value: "{{ stepup_intrinsic_loa }}"
   eduid_attribute_manipulation_enabled: false
   consent_enabled: false
   token_api_enabled: false
@@ -479,9 +476,6 @@ manage:
         password: "{{ aa_manage_password }}",
         scopes: ["READ"]
       }
-  loa_values_supported:
-    - http://{{ base_domain }}/assurance/loa2
-    - http://{{ base_domain }}/assurance/loa3
   oidc_rp_redirect_url_format: "url"
 
 loadbalancing:

--- a/environments/vm/group_vars/vm.yml
+++ b/environments/vm/group_vars/vm.yml
@@ -272,14 +272,11 @@ oidcng:
   api_user: manage
   key_rollover_cron_expression: "0 0 0 * * *"
   acr_values_supported:
-    - http://{{ base_domain }}/assurance/loa1
-    - http://{{ base_domain }}/assurance/loa2
-    - http://{{ base_domain }}/assurance/loa3
     - https://eduid.nl/trust/validate-names
     - https://eduid.nl/trust/linked-institution
     - https://eduid.nl/trust/affiliation-student
     - https://refeds.org/profile/mfa
-  default_acr_value: http://{{ base_domain }}/assurance/loa1
+  default_acr_value: "{{ stepup_intrinsic_loa }}"
   eduid_attribute_manipulation_enabled: false
   consent_enabled: false
   token_api_enabled: false
@@ -375,9 +372,6 @@ manage:
         password: "{{ aa_manage_password }}",
         scopes: ["READ"]
       }
-  loa_values_supported:
-    - http://{{ base_domain }}/assurance/loa2
-    - http://{{ base_domain }}/assurance/loa3
   oidc_rp_redirect_url_format: "url"
 
 manage_show_oidc_rp_tab: true

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -68,6 +68,15 @@ logback_max_history: 7
 # The manage spring_app port is used by various roles
 manage_springapp_tcpport: 9393
 
+# OpenConext Stepup Level of Assurance Identifiers
+# The intrinsic loa is "LoA 1" / just first factor / no stepup required
+stepup_intrinsic_loa: "http://{{ base_domain }}/assurance/loa1"
+# This does not include the intrinsic loa since most apps only require the >1 loa's
+stepup_loa_values_supported:
+ - "http://{{ base_domain }}/assurance/loa1.5"
+ - "http://{{ base_domain }}/assurance/loa2"
+ - "http://{{ base_domain }}/assurance/loa3"
+
 mfa_values_supported:
  - "http://schemas.microsoft.com/claims/multipleauthn"
  - "https://refeds.org/profile/mfa"

--- a/roles/dashboard-server/templates/application.properties.j2
+++ b/roles/dashboard-server/templates/application.properties.j2
@@ -91,7 +91,7 @@ guestidp.entityids={{ dashboard.guestidp_entityids }}
 # tabs that can be hidden are: statistics,apps,policies,tickets,my_idp and user_invite
 dashboard.hide_tabs={{ dashboard_hide_tabs }}
 
-default_loa_level={{ manage.loa_values_supported[0] }}
-loa_values_supported={% for loa in manage.loa_values_supported %}{{ loa }}{{ "," if not loop.last else ""}} {% endfor %}
+default_loa_level={{ stepup_intrinsic_loa }}
+loa_values_supported={{ stepup_loa_values_supported | join(",") }}
 
-authn_context_levels={% for mfa in mfa_values_supported %}{{ mfa }}{{ "," if not loop.last else ""}} {% endfor %}
+authn_context_levels={{ mfa_values_supported | join(",") }}

--- a/roles/engineblock/defaults/main.yml
+++ b/roles/engineblock/defaults/main.yml
@@ -72,11 +72,11 @@ engine_maximum_authentication_procedures_allowed: 5
 engine_stepup_authn_context_class_ref_blacklist_regex: '/http:\/\/{{ base_domain | regex_escape }}\/assurance\/loa[1-3]/'
 # The loa mapping from the internal used LoA's to the Stepup Gateway LOA's
 engine_stepup_engineblock_loa1: "http://{{ base_domain }}/assurance/loa1"
-engine_stepup_engineblock_loa1_5: "http://{{ base_domain }}/assurance/loa1_5"
+engine_stepup_engineblock_loa1_5: "http://{{ base_domain }}/assurance/loa1.5"
 engine_stepup_engineblock_loa2: "http://{{ base_domain }}/assurance/loa2"
 engine_stepup_engineblock_loa3: "http://{{ base_domain }}/assurance/loa3"
 engine_stepup_gateway_loa1: "http://{{ engine_stepup_base_domain }}/assurance/loa1"
-engine_stepup_gateway_loa1_5: "http://{{ engine_stepup_base_domain }}/assurance/loa1_5"
+engine_stepup_gateway_loa1_5: "http://{{ engine_stepup_base_domain }}/assurance/loa1.5"
 engine_stepup_gateway_loa2: "http://{{ engine_stepup_base_domain }}/assurance/loa2"
 engine_stepup_gateway_loa3: "http://{{ engine_stepup_base_domain }}/assurance/loa3"
 # The EntityId (metadata URL) used in the callout to the SFO endpoint of the configured Stepup Gateway

--- a/roles/manage-server/files/metadata_configuration/oidc10_rp.schema.json.j2
+++ b/roles/manage-server/files/metadata_configuration/oidc10_rp.schema.json.j2
@@ -457,11 +457,11 @@
           "type": "string",
           "format": "url",
           "enum": [
-            {% for loa in manage.loa_values_supported %}
+            {% for loa in stepup_loa_values_supported %}
             "{{ loa }}"{{ "," if not loop.last else ""}}
             {% endfor %}
           ],
-          "default": "{{ manage.loa_values_supported[0] }}",
+          "default": "{{ stepup_loa_values_supported[0] }}",
           "info": "Set to require Stepup Authentication for this SP with the specified minimum Level of Assurance."
         },
         "coin:stepup:allow_no_token": {

--- a/roles/manage-server/files/metadata_configuration/saml20_idp.schema.json.j2
+++ b/roles/manage-server/files/metadata_configuration/saml20_idp.schema.json.j2
@@ -128,11 +128,11 @@
               "string"
             ],
             "enum": [
-              {% for loa in manage.loa_values_supported %}
+              {% for loa in stepup_loa_values_supported %}
               "{{ loa }}"{{ "," if not loop.last else ""}}
               {% endfor %}
             ],
-            "default": "{{ manage.loa_values_supported[0] }}"
+            "default": "{{ stepup_loa_values_supported[0] }}"
           }
         }
       },

--- a/roles/manage-server/files/metadata_configuration/saml20_sp.schema.json.j2
+++ b/roles/manage-server/files/metadata_configuration/saml20_sp.schema.json.j2
@@ -559,11 +559,11 @@
           "type": "string",
           "format": "url",
           "enum": [
-            {% for loa in manage.loa_values_supported %}
+            {% for loa in stepup_loa_values_supported %}
             "{{ loa }}"{{ "," if not loop.last else ""}}
             {% endfor %}
           ],
-          "default": "{{ manage.loa_values_supported[0] }}",
+          "default": "{{ stepup_loa_values_supported[0] }}",
           "info": "Set to require Stepup Authentication for this SP with the specified minimum Level of Assurance."
         },
         "coin:stepup:allow_no_token": {

--- a/roles/manage-server/files/metadata_configuration/single_tenant_template.schema.json.j2
+++ b/roles/manage-server/files/metadata_configuration/single_tenant_template.schema.json.j2
@@ -471,11 +471,11 @@
           "type": "string",
           "format": "url",
           "enum": [
-            {% for loa in manage.loa_values_supported %}
+            {% for loa in stepup_loa_values_supported %}
             "{{ loa }}"{{ "," if not loop.last else ""}}
             {% endfor %}
           ],
-          "default": "{{ manage.loa_values_supported[0] }}",
+          "default": "{{ stepup_loa_values_supported[0] }}",
           "info": "Set to require Stepup Authentication for this SP with the specified minimum Level of Assurance."
         },
         "coin:stepup:allow_no_token": {

--- a/roles/oidc-playground-server/templates/application.yml.j2
+++ b/roles/oidc-playground-server/templates/application.yml.j2
@@ -32,6 +32,6 @@ gui:
 
 acr:
   values:
-  {% for loa in oidcng.acr_values_supported %}
+  {% for loa in [stepup_intrinsic_loa] + stepup_loa_values_supported + oidcng.acr_values_supported %}
     - "{{ loa }}"
   {% endfor %}

--- a/roles/oidcng/templates/openid-configuration.json.j2
+++ b/roles/oidcng/templates/openid-configuration.json.j2
@@ -90,7 +90,7 @@
   "request_parameter_supported": true,
   "request_uri_parameter_supported": true,
   "acr_values_supported": [
-     {% for loa in oidcng.acr_values_supported %}
+     {% for loa in [stepup_intrinsic_loa] + stepup_loa_values_supported + oidcng.acr_values_supported %}
         "{{ loa }}"{{ "," if not loop.last else ""}}
      {% endfor %}
   ],

--- a/roles/pdp-server/templates/application.properties.j2
+++ b/roles/pdp-server/templates/application.properties.j2
@@ -83,7 +83,7 @@ logging.level.pdp: DEBUG
 # In a multi master database setup toggle which machine is reponsible for cron jobs
 pdpCronJobResponsible= {{ pdp_cronjobmaster }}
 
-loa.levels=http://{{ base_domain }}/assurance/loa1_5,http://{{ base_domain }}/assurance/loa2,http://{{ base_domain }}/assurance/loa3
+loa.levels={{ stepup_loa_values_supported | join(",") }}
 
 management.health.mail.enabled=true
 management.endpoints.web.exposure.include=health,info


### PR DESCRIPTION
For most apps this sufficices since they only need the list of externally published LoA urls (PDP, Dashboard, Manage, OIDC(playground)..)

EB remains special because it has an intricate config which maps different values to others and also references EB internal constants while it's at it. Might be refactored further sometime.