### PR TITLE
Fix: Gateway SFO uses a different identifier than full 2FA

### DIFF
--- a/roles/stepupgateway/templates/parameters.yml.j2
+++ b/roles/stepupgateway/templates/parameters.yml.j2
@@ -100,7 +100,7 @@ parameters:
     gateway_loa_self_asserted: '{{ stepup_uri_self_asserted }}'
     second_factor_only_loa_loa2: '{{ stepup_uri_sfo_loa2 }}'
     second_factor_only_loa_loa3: '{{ stepup_uri_sfo_loa3 }}'
-    second_factor_only_loa_self_asserted: '{{ stepup_uri_self_asserted }}'
+    second_factor_only_loa_self_asserted: '{{ stepup_uri_sfo_self_asserted }}'
 
     second_factor_only: {{ gateway_second_factor_only | default(false) }}
 


### PR DESCRIPTION
E.g:

stepup_uri_self_asserted: 'http://stepup.example.com/assurance/loa1.5'
stepup_uri_sfo_self_asserted: 'http://stepup.example.com/assurance/sfo-level1.5'
