### PR TITLE
Increase PHP post_max_size from 8M to 16M.

### DIFF
--- a/roles/engineblock/templates/engine-pool-72.conf.j2
+++ b/roles/engineblock/templates/engine-pool-72.conf.j2
@@ -219,6 +219,7 @@ slowlog = /var/log/php-fpm/www-slow.log
 php_admin_value[error_log] = /var/log/php-fpm/engine-error.log
 php_admin_flag[log_errors] = on
 php_admin_value[memory_limit] = {{ engine_fpm_memory }}
+php_admin_value[post_max_size] = 16M
 
 ; Set session path to a directory owned by process user
 php_value[session.save_handler] = files


### PR DESCRIPTION
Manage metadata push to EB can be over 8 MB when you have thousands of entities, so increase it a bit. Cannot be set at runtime for only the push endpoint unfortunately. Do not increase it too much as this would be a DoS risk.