### PR TITLE
Haproxy: Cookie based staging environment

### DIFF
--- a/roles/haproxy/README.md
+++ b/roles/haproxy/README.md
@@ -27,6 +27,7 @@ haproxy_applications:
     ha_url: "/health"
     port: "{{ loadbalancing.manage.port }}"
     servers: "{{ php_servers }}"
+    stagingservers: "{{ staging_servers }}"
     sslbackend: yes
     backend_vhost_name: backend.myapp.tld
     backend_ca_file: "/etc/pki/tls/certs/ca-bundle.crt"
@@ -43,6 +44,7 @@ port: This is the port that the backend server listens on.
 ha_url: The url used to check the health of the backend application. If it is not reachable, or it gives an HTTP error that backend will be marked down. For most applications that defaults to /health
 ha_method: The http method used in the health check. 
 servers: A list of the servers that is used for  this application. 
+stagingservers (optional): A list of the servers that is used for staging an application. If the cookie staging=true is present, this staging server is used as backend. 
 restricted: If it is present and set to "yes" the application will be served from te restricted IP address. 
 sslbackend: If it is present and set to "yes" the backend connection will be performed over https. 
 backend_vhost_name: If you have enabled "sslbackend" you need to configure the backend vhost name as well (which should also be present in the certificate on the backend"

--- a/roles/haproxy/defaults/main.yml
+++ b/roles/haproxy/defaults/main.yml
@@ -21,3 +21,6 @@ haproxy_internalips:
   - 0.0.0.0/0
   - ::0/0
 haproxy_hsts_value: "max-age=34214400"
+# If you have a staging server you want to be accessed from certain ips, and them to this list
+haproxy_stagingips:
+  - ''

--- a/roles/haproxy/tasks/main.yml
+++ b/roles/haproxy/tasks/main.yml
@@ -147,6 +147,7 @@
     - allowedips.acl
     - blockedips.acl
     - internalips.acl
+    - stagingips.acl
   notify:
     - "reload haproxy"
 

--- a/roles/haproxy/tasks/main.yml
+++ b/roles/haproxy/tasks/main.yml
@@ -159,6 +159,7 @@
     mode: 0664
   with_items:
     - backends.map
+    - backendsstaging.map
     - redirects.map
     - ratelimits.map
   notify:

--- a/roles/haproxy/templates/backendsstaging.map.j2
+++ b/roles/haproxy/templates/backendsstaging.map.j2
@@ -1,0 +1,5 @@
+{% for application in haproxy_applications %}
+{% if application.stagingservers is defined %}
+{{ application.vhost_name }} {{ application.name }}_staging_be
+{% endif %}
+{% endfor %}

--- a/roles/haproxy/templates/haproxy_backend.cfg.j2
+++ b/roles/haproxy/templates/haproxy_backend.cfg.j2
@@ -40,3 +40,28 @@
 
 {% endfor %}
 
+{% for application in haproxy_applications %}
+{% if application.stagingservers is defined %}
+#---------------------------------------------------------------------
+# {{ application.name }} staging backend
+#---------------------------------------------------------------------
+#
+  backend {{ application.name }}_staging_be
+  option httpchk {{ application.ha_method }} {{ application.ha_url }} "HTTP/1.0\r\nHost: {{ application.vhost_name }}"
+
+  {%if application.x_forwarded_port is defined %}
+  http-request set-header X-Forwarded-Port {{ application.x_forwarded_port }}
+  {% endif %}
+  http-response del-header ^Strict-Transport-Security:.* #Remove hsts header from backend applications
+  mode http
+  balance roundrobin
+  option httpclose
+
+  cookie HTTPSERVERIDSTAGING insert nocache indirect httponly secure maxidle {{ haproxy_cookie_max_idle }}
+
+  {% for server in application.stagingservers %}
+  server {{ server.label }} {{ server.ip }}:{{ application.port }} cookie {{ server.label }} check inter 8000 fall 5 rise 2 maxconn {{ application.maxconn | default('35') }} {% if application.sslbackend is defined%} ssl verify required verifyhost {{ application.backend_vhost_name }} ca-file {{ application.backend_ca_file }}{% endif %} weight 100
+    
+  {% endfor %}
+{% endif %}
+{% endfor %}

--- a/roles/haproxy/templates/haproxy_frontend.cfg.j2
+++ b/roles/haproxy/templates/haproxy_frontend.cfg.j2
@@ -58,9 +58,10 @@ frontend internet_ip
 frontend local_ip
     bind 127.0.0.1:81 accept-proxy
     acl valid_vhost hdr(host) -f /etc/haproxy/acls/validvhostsunrestricted.acl
+    acl staging req.cook(staging) -m str true
+    acl staging src -f /etc/haproxy/acls/stagingips.acl
     acl stagingvhost hdr(host) -i -M -f /etc/haproxy/maps/backendsstaging.map 
-    acl stagingcookie req.cook(staging) -m str true
-    use_backend %[req.hdr(host),lower,map(/etc/haproxy/maps/backendsstaging.map)] if stagingvhost stagingcookie
+    use_backend %[req.hdr(host),lower,map(/etc/haproxy/maps/backendsstaging.map)] if stagingvhost staging
     use_backend %[req.hdr(host),lower,map(/etc/haproxy/maps/backends.map)]
     option httplog
     capture request header User-agent len 256
@@ -151,9 +152,10 @@ frontend internet_restricted_ip
 frontend localhost_restricted    
     bind 127.0.0.1:82 accept-proxy
     acl valid_vhost hdr(host) -f /etc/haproxy/acls/validvhostsrestricted.acl
+    acl staging req.cook(staging) -m str true
+    acl staging src -f /etc/haproxy/acls/stagingips.acl
     acl stagingvhost hdr(host) -i -M -f /etc/haproxy/maps/backendsstaging.map 
-    acl stagingcookie req.cook(staging) -m str true
-    use_backend %[req.hdr(host),lower,map(/etc/haproxy/maps/backendsstaging.map)] if stagingvhost stagingcookie
+    use_backend %[req.hdr(host),lower,map(/etc/haproxy/maps/backendsstaging.map)] if stagingvhost staging
     use_backend %[req.hdr(host),lower,map(/etc/haproxy/maps/backends.map)]
     option httplog
     capture request header User-agent len 256

--- a/roles/haproxy/templates/haproxy_frontend.cfg.j2
+++ b/roles/haproxy/templates/haproxy_frontend.cfg.j2
@@ -58,6 +58,9 @@ frontend internet_ip
 frontend local_ip
     bind 127.0.0.1:81 accept-proxy
     acl valid_vhost hdr(host) -f /etc/haproxy/acls/validvhostsunrestricted.acl
+    acl stagingvhost hdr(host) -i -M -f /etc/haproxy/maps/backendsstaging.map 
+    acl stagingcookie req.cook(staging) -m str true
+    use_backend %[req.hdr(host),lower,map(/etc/haproxy/maps/backendsstaging.map)] if stagingvhost stagingcookie
     use_backend %[req.hdr(host),lower,map(/etc/haproxy/maps/backends.map)]
     option httplog
     capture request header User-agent len 256
@@ -148,6 +151,9 @@ frontend internet_restricted_ip
 frontend localhost_restricted    
     bind 127.0.0.1:82 accept-proxy
     acl valid_vhost hdr(host) -f /etc/haproxy/acls/validvhostsrestricted.acl
+    acl stagingvhost hdr(host) -i -M -f /etc/haproxy/maps/backendsstaging.map 
+    acl stagingcookie req.cook(staging) -m str true
+    use_backend %[req.hdr(host),lower,map(/etc/haproxy/maps/backendsstaging.map)] if stagingvhost stagingcookie
     use_backend %[req.hdr(host),lower,map(/etc/haproxy/maps/backends.map)]
     option httplog
     capture request header User-agent len 256

--- a/roles/haproxy/templates/stagingips.acl.j2
+++ b/roles/haproxy/templates/stagingips.acl.j2
@@ -1,0 +1,3 @@
+{% for ip in haproxy_stagingips %}
+{{ ip }}
+{% endfor %}


### PR DESCRIPTION
If you want to add a staging server (to test new features) you can set the cookie staging=true. If that is present,  and you've added a list of servers to the key stagingservers in haproxy_applications that staging server will be used as a backend

We are planning to add the setting of the cookie in Profile and eduID. 
To test, you can set in any Apache configuration of you app:
```
Header always set Set-Cookie "staging=true; path=/; domain=.test2.surfconext.nl; secure; HttpOnly"
```