### PR TITLE
Synchronise PHP FPM disable_functions settting.

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -37,7 +37,6 @@ httpd_csp:
   strict: "default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; connect-src 'self'; img-src 'self' data:; form-action 'self'; frame-ancestors 'none'; base-uri 'none'"
   strict_with_static_img: "default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; connect-src 'self'; img-src 'self' https://{{ static_vhost }} data:; form-action 'self'; frame-ancestors 'none'; base-uri 'none'"
   lenient_with_static_img_for_idp: "default-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self'; connect-src 'self' https://{{ oidcng_vhost }}; img-src 'self' https://{{ static_vhost }} data:; form-action 'self' https://*.{{ base_domain }}; frame-ancestors 'none'; base-uri 'none'"
-
   nothing: "default-src 'none'; frame-ancestors 'none'; form-action 'none'; base-uri 'none'"
 
 error_subject_prefix: "[{{ ansible_hostname }}] "
@@ -58,6 +57,7 @@ lifecycle_api_username: lifecycle
 
 # PHP vars
 php_session_dir: /var/lib/openconext/session/
+php_disabled_functions: "exec,passthru,shell_exec,system,proc_open,popen,curl_multi_exec,show_source,pcntl_alarm,pcntl_fork,pcntl_waitpid,pcntl_wait,pcntl_wifexited,pcntl_wifstopped,pcntl_wifsignaled,pcntl_wifcontinued,pcntl_wexitstatus,pcntl_wtermsig,pcntl_wstopsig,pcntl_signal,pcntl_signal_dispatch,pcntl_get_last_error,pcntl_strerror,pcntl_sigprocmask,pcntl_sigwaitinfo,pcntl_sigtimedwait,pcntl_exec,pcntl_getpriority,pcntl_setpriority,"
 openconext_releases_dir:   "/opt/openconext"
 openconext_builds_dir:     "{{ openconext_releases_dir }}/builds"
 

--- a/roles/apachefpm/templates/phpfpm.j2
+++ b/roles/apachefpm/templates/phpfpm.j2
@@ -1,5 +1,5 @@
 [{{ appname }}]
-listen = /var/run/php-fpm/{{ appname  }}-pool-72.sock
+listen = /var/run/php-fpm/{{ appname }}-pool-72.sock
 listen.allowed_clients = 127.0.0.1
 listen.owner = apache
 listen.group = apache
@@ -15,8 +15,8 @@ pm.status_path = /status
 php_admin_flag[log_errors] = on
 php_admin_value[memory_limit] = {{ fpmmemory | default('128M') }}
 php_value[session.save_handler] = files
-php_value[session.save_path] = {{ php_session_dir}}/{{ appname }}
-php_value[disable_functions] = exec,passthru,shell_exec,system,popen,curl_multi_exec,show_source,pcntl_alarm,pcntl_fork,pcntl_waitpid,pcntl_wait,pcntl_wifexited,pcntl_wifstopped,pcntl_wifsignaled,pcntl_wifcontinued,pcntl_wexitstatus,pcntl_wtermsig,pcntl_wstopsig,pcntl_signal,pcntl_signal_dispatch,pcntl_get_last_error,pcntl_strerror,pcntl_sigprocmask,pcntl_sigwaitinfo,pcntl_sigtimedwait,pcntl_exec,pcntl_getpriority,pcntl_setpriority,
+php_value[session.save_path] = {{ php_session_dir }}/{{ appname }}
+php_value[disable_functions] = {{ php_disabled_functions }}
 php_value[session.cookie_domain] = {{ vhost_name }}
 php_value[session.cookie_lifetime] = 0
 php_value[session.gc_maxlifetime] = {{ app_session_expiry_time }}

--- a/roles/diyidp/templates/diyidp-pool-72.conf.j2
+++ b/roles/diyidp/templates/diyidp-pool-72.conf.j2
@@ -222,3 +222,4 @@ php_admin_flag[log_errors] = on
 ; Set session path to a directory owned by process user
 php_value[session.save_handler] = files
 php_value[session.save_path] = {{ php_session_dir }}/diyidp
+php_value[disable_functions] = {{ php_disabled_functions }}

--- a/roles/engineblock/templates/engine-pool-72.conf.j2
+++ b/roles/engineblock/templates/engine-pool-72.conf.j2
@@ -223,5 +223,5 @@ php_admin_value[post_max_size] = 16M
 
 ; Set session path to a directory owned by process user
 php_value[session.save_handler] = files
-php_value[session.save_path] = {{ php_session_dir}}/engine
-php_value[disable_functions] = exec,passthru,shell_exec,system,popen,curl_multi_exec,show_source,pcntl_alarm,pcntl_fork,pcntl_waitpid,pcntl_wait,pcntl_wifexited,pcntl_wifstopped,pcntl_wifsignaled,pcntl_wifcontinued,pcntl_wexitstatus,pcntl_wtermsig,pcntl_wstopsig,pcntl_signal,pcntl_signal_dispatch,pcntl_get_last_error,pcntl_strerror,pcntl_sigprocmask,pcntl_sigwaitinfo,pcntl_sigtimedwait,pcntl_exec,pcntl_getpriority,pcntl_setpriority,
+php_value[session.save_path] = {{ php_session_dir }}/engine
+php_value[disable_functions] = {{ php_disabled_functions }}

--- a/roles/lifecycle/templates/lifecycle-pool-72.conf.j2
+++ b/roles/lifecycle/templates/lifecycle-pool-72.conf.j2
@@ -222,3 +222,4 @@ php_admin_flag[log_errors] = on
 ; Set session path to a directory owned by process user
 php_value[session.save_handler] = files
 php_value[session.save_path] = {{ php_session_dir }}/lifecycle
+php_value[disable_functions] = {{ php_disabled_functions }}

--- a/roles/profile/templates/profile-pool-72.conf.j2
+++ b/roles/profile/templates/profile-pool-72.conf.j2
@@ -222,4 +222,4 @@ php_admin_flag[log_errors] = on
 ; Set session path to a directory owned by process user
 php_value[session.save_handler] = files
 php_value[session.save_path] = {{ php_session_dir }}/profile
-php_value[disable_functions] = exec,passthru,shell_exec,system,proc_open,popen,curl_multi_exec,show_source,pcntl_alarm,pcntl_fork,pcntl_waitpid,pcntl_wait,pcntl_wifexited,pcntl_wifstopped,pcntl_wifsignaled,pcntl_wifcontinued,pcntl_wexitstatus,pcntl_wtermsig,pcntl_wstopsig,pcntl_signal,pcntl_signal_dispatch,pcntl_get_last_error,pcntl_strerror,pcntl_sigprocmask,pcntl_sigwaitinfo,pcntl_sigtimedwait,pcntl_exec,pcntl_getpriority,pcntl_setpriority,
+php_value[disable_functions] = {{ php_disabled_functions }}


### PR DESCRIPTION
This creates one set to use for all PHP apps. The chosen set is the most restrictive one. This means that:
- For profile nothing changes
- For engine and apachefpm (stepup), proc_open is added
- For diyidp and lifecycle, the setting is completely new