### PR TITLE
manage - oidcng - myconext: Use old cacert entrypoint update script

### DIFF
--- a/roles/manage/files/__cacert_entrypoint.sh
+++ b/roles/manage/files/__cacert_entrypoint.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env sh
+# Converted to POSIX shell to avoid the need for bash in the image
+
+set -e
+
+# Opt-in is only activated if the environment variable is set
+if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
+
+  # Copy certificates from /certificates to the system truststore, but only if the directory exists and is not empty.
+  # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
+  # system location, for whatever reason.
+  if [ -d /certificates ] && [ -n "$(ls -A /certificates 2>/dev/null)" ]; then
+    cp -a /certificates/* /usr/local/share/ca-certificates/
+  fi
+
+  CACERT="$JAVA_HOME/lib/security/cacerts"
+
+  # JDK8 puts its JRE in a subdirectory
+  if [ -f "$JAVA_HOME/jre/lib/security/cacerts" ]; then
+    CACERT="$JAVA_HOME/jre/lib/security/cacerts"
+  fi
+
+  # OpenJDK images used to create a hook for `update-ca-certificates`. Since we are using an entrypoint anyway, we
+  # might as well just generate the truststore and skip the hooks.
+  update-ca-certificates
+
+  trust extract --overwrite --format=java-cacerts --filter=ca-anchors --purpose=server-auth "$CACERT"
+fi
+
+exec "$@"

--- a/roles/manage/tasks/main.yml
+++ b/roles/manage/tasks/main.yml
@@ -18,7 +18,7 @@
     mode: "0644"
 
 - name: copy invite certificate
-  copy:
+  ansible.builtin.copy:
     src: "{{ inventory_dir }}/files/certs/invite/public_key.pem"
     dest: "/opt/openconext/manage/public_invite_key.pem"
     owner: root
@@ -39,6 +39,14 @@
     - logback.xml
     - manage-api-users.yml
   notify: restart manageserver
+
+- name: Place old __cacert_entrypoint.sh script
+  ansible.builtin.copy:
+    src: "__cacert_entrypoint.sh"
+    dest: "/opt/openconext/manage"
+    owner: "root"
+    group: "root"
+    mode: "0755"
 
 - name: copy metadata configuration
   ansible.builtin.template:
@@ -81,6 +89,10 @@
       - source: /opt/openconext/manage/mongoca.pem
         target: /certificates/mongoca.crt
         type: bind
+      - source: /opt/openconext/manage/__cacert_entrypoint.sh
+        target: /__cacert_entrypoint.sh
+        type: bind
+
     command: "java -jar /app.jar -Xmx512m --spring.config.location=./config/"
     etc_hosts:
       host.docker.internal: host-gateway

--- a/roles/myconext/files/__cacert_entrypoint.sh
+++ b/roles/myconext/files/__cacert_entrypoint.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env sh
+# Converted to POSIX shell to avoid the need for bash in the image
+
+set -e
+
+# Opt-in is only activated if the environment variable is set
+if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
+
+  # Copy certificates from /certificates to the system truststore, but only if the directory exists and is not empty.
+  # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
+  # system location, for whatever reason.
+  if [ -d /certificates ] && [ -n "$(ls -A /certificates 2>/dev/null)" ]; then
+    cp -a /certificates/* /usr/local/share/ca-certificates/
+  fi
+
+  CACERT="$JAVA_HOME/lib/security/cacerts"
+
+  # JDK8 puts its JRE in a subdirectory
+  if [ -f "$JAVA_HOME/jre/lib/security/cacerts" ]; then
+    CACERT="$JAVA_HOME/jre/lib/security/cacerts"
+  fi
+
+  # OpenJDK images used to create a hook for `update-ca-certificates`. Since we are using an entrypoint anyway, we
+  # might as well just generate the truststore and skip the hooks.
+  update-ca-certificates
+
+  trust extract --overwrite --format=java-cacerts --filter=ca-anchors --purpose=server-auth "$CACERT"
+fi
+
+exec "$@"

--- a/roles/myconext/tasks/main.yml
+++ b/roles/myconext/tasks/main.yml
@@ -84,6 +84,14 @@
     group: "root"
     mode: "0750"
 
+- name: Place old __cacert_entrypoint.sh script
+  ansible.builtin.copy:
+    src: "__cacert_entrypoint.sh"
+    dest: "/opt/openconext/myconext"
+    owner: "root"
+    group: "root"
+    mode: "0755"
+
 - name: Create and start the server container
   community.docker.docker_container:
     name: myconextserver
@@ -92,7 +100,7 @@
     restart_policy: "always"
     state: started
     env:
-      USE_SYSTEM_CA_CERTS: "true"
+      USE_SYSTEM_CA_CERTS: "1"
       TZ: "{{ timezone }}"
     networks:
       - name: "loadbalancer"
@@ -103,8 +111,11 @@
       - source: /opt/openconext/certs/mongoca.crt
         target: /certificates/mongoca.crt
         type: bind
-    entrypoint: /__cacert_entrypoint.sh
-    command: 'java -jar /app.jar -Xmx256M --spring.config.location=./config/'
+      - source: /opt/openconext/myconext/__cacert_entrypoint.sh
+        target: /__cacert_entrypoint.sh
+        type: bind
+    entrypoint: ["sh","/__cacert_entrypoint.sh"]
+    command: ["java" , "-jar" , "/app.jar" , "-Xmx256M" , "--spring.config.location=./config/"]
     etc_hosts:
       host.docker.internal: host-gateway
     healthcheck:
@@ -113,7 +124,6 @@
       timeout: 10s
       retries: 3
       start_period: 10s
-  notify: restart myconextserver
 
 - name: Create the client container
   community.docker.docker_container:

--- a/roles/oidcng/files/__cacert_entrypoint.sh
+++ b/roles/oidcng/files/__cacert_entrypoint.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env sh
+# Converted to POSIX shell to avoid the need for bash in the image
+
+set -e
+
+# Opt-in is only activated if the environment variable is set
+if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
+
+  # Copy certificates from /certificates to the system truststore, but only if the directory exists and is not empty.
+  # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
+  # system location, for whatever reason.
+  if [ -d /certificates ] && [ -n "$(ls -A /certificates 2>/dev/null)" ]; then
+    cp -a /certificates/* /usr/local/share/ca-certificates/
+  fi
+
+  CACERT="$JAVA_HOME/lib/security/cacerts"
+
+  # JDK8 puts its JRE in a subdirectory
+  if [ -f "$JAVA_HOME/jre/lib/security/cacerts" ]; then
+    CACERT="$JAVA_HOME/jre/lib/security/cacerts"
+  fi
+
+  # OpenJDK images used to create a hook for `update-ca-certificates`. Since we are using an entrypoint anyway, we
+  # might as well just generate the truststore and skip the hooks.
+  update-ca-certificates
+
+  trust extract --overwrite --format=java-cacerts --filter=ca-anchors --purpose=server-auth "$CACERT"
+fi
+
+exec "$@"

--- a/roles/oidcng/tasks/main.yml
+++ b/roles/oidcng/tasks/main.yml
@@ -80,6 +80,14 @@
   notify:
     - "restart oidcng"
 
+- name: Place old __cacert_entrypoint.sh script
+  ansible.builtin.copy:
+    src: "__cacert_entrypoint.sh"
+    dest: "/opt/openconext/oidcng"
+    owner: "root"
+    group: "root"
+    mode: "0755"
+
 - name: Create and start the server container
   community.docker.docker_container:
     name: oidcngserver
@@ -94,8 +102,11 @@
       - source: "{{ oidcng_dir }}"
         target: /config/
         type: bind
-      - source: /opt/openconext/manage/mongoca.pem
+      - source: /opt/openconext/certs/mongoca.crt
         target: /certificates/mongoca.crt
+        type: bind
+      - source: /opt/openconext/oidcng/__cacert_entrypoint.sh
+        target: /__cacert_entrypoint.sh
         type: bind
     command: "java -jar /app.jar -Xmx512m --spring.config.location=./config/"
     etc_hosts:


### PR DESCRIPTION
This reverts the new cacert update script, which leads to errors when restarting a container. See also: https://github.com/adoptium/containers/issues/612

This fix should be temporary until the issue is resolved upstream.

We only need this in the containers that use mongo, since they need to import the mongo root CA certificate. 