### PR TITLE
Only restart docker containers if not new

### DIFF
--- a/roles/attribute-aggregation/handlers/main.yml
+++ b/roles/attribute-aggregation/handlers/main.yml
@@ -3,3 +3,4 @@
     name: aaserver
     state: started
     restart: true
+  when: attribute-aggregationservercontainer is success and attribute-aggregationservercontainer is not change

--- a/roles/attribute-aggregation/tasks/main.yml
+++ b/roles/attribute-aggregation/tasks/main.yml
@@ -57,7 +57,7 @@
       timeout: 10s
       retries: 3
       start_period: 10s
-  notify: restart attribute-aggregationserver
+    register: attribute-aggregationservercontainer
 
 - name: Create the gui container
   community.docker.docker_container:

--- a/roles/dashboard/handlers/main.yml
+++ b/roles/dashboard/handlers/main.yml
@@ -3,3 +3,4 @@
     name: dashboardserver
     state: started
     restart: true
+  when: dashboardservercontainer is success and dashboardservercontainer is not change

--- a/roles/dashboard/tasks/main.yml
+++ b/roles/dashboard/tasks/main.yml
@@ -55,7 +55,7 @@
       timeout: 10s
       retries: 3
       start_period: 10s
-  notify: restart dashboardserver
+  register: dashboardservercontainer
 
 - name: Create the gui container
   community.docker.docker_container:

--- a/roles/invite/handlers/main.yml
+++ b/roles/invite/handlers/main.yml
@@ -3,6 +3,7 @@
     name: inviteserver
     state: started
     restart: true
+  when: inviteservercontainer is success and inviteservercontainer is not change
 
 - name: restart inviteprovisioningmock
   community.docker.docker_container:

--- a/roles/invite/tasks/main.yml
+++ b/roles/invite/tasks/main.yml
@@ -78,6 +78,8 @@
       timeout: 10s
       retries: 3
       start_period: 10s
+  register: inviteservercontainer
+
 
 - name: Create the client container
   community.docker.docker_container:

--- a/roles/lifecycle/handlers/main.yml
+++ b/roles/lifecycle/handlers/main.yml
@@ -4,3 +4,4 @@
     name: lifecycle
     state: started
     restart: true
+  when: lifecycleservercontainer is success and lifecycleservercontainer is not change

--- a/roles/lifecycle/tasks/main.yml
+++ b/roles/lifecycle/tasks/main.yml
@@ -56,6 +56,8 @@
       - source: /opt/openconext/lifecycle
         target: /var/www/html/config/openconext
         type: bind
+  register: lifecyclecontainer
+
 
 #- name: Create daily cronjob
   #  cron:

--- a/roles/manage/handlers/main.yml
+++ b/roles/manage/handlers/main.yml
@@ -3,3 +3,4 @@
     name: manageserver
     state: started
     restart: true
+  when: manageservercontainer is success and manageservercontainer is not change

--- a/roles/manage/tasks/main.yml
+++ b/roles/manage/tasks/main.yml
@@ -5,7 +5,7 @@
     state: directory
     owner: root
     group: root
-    mode: 0750
+    mode: "0750"
   with_items:
     - "/opt/openconext/manage/metadata_configuration"
     - "/opt/openconext/manage/metadata_templates"
@@ -92,7 +92,6 @@
       - source: /opt/openconext/manage/__cacert_entrypoint.sh
         target: /__cacert_entrypoint.sh
         type: bind
-
     command: "java -jar /app.jar -Xmx512m --spring.config.location=./config/"
     etc_hosts:
       host.docker.internal: host-gateway
@@ -114,6 +113,7 @@
       timeout: 10s
       retries: 3
       start_period: 10s
+  register: manageservercontainer
 
 - name: Create the gui container
   community.docker.docker_container:

--- a/roles/myconext/handlers/main.yml
+++ b/roles/myconext/handlers/main.yml
@@ -3,3 +3,4 @@
     name: myconextserver
     state: started
     restart: true
+  when: myconextservercontainer is success and myconextservercontainer is not change

--- a/roles/myconext/tasks/main.yml
+++ b/roles/myconext/tasks/main.yml
@@ -14,7 +14,7 @@
     owner: root
     group: root
     mode: "0644"
-    
+
 - name: Create directory to keep configfiles
   ansible.builtin.file:
     dest: "/opt/openconext/myconext"
@@ -124,6 +124,8 @@
       timeout: 10s
       retries: 3
       start_period: 10s
+  register: myconextservercontainer
+
 
 - name: Create the client container
   community.docker.docker_container:
@@ -191,4 +193,3 @@
     env:
       HTTPD_CSP: "{{ httpd_csp.lenient_with_static_img_for_idp }}"
       HTTPD_SERVERNAME: "login.{{ myconext_base_domain }}"
-

--- a/roles/oidc-playground/handlers/main.yml
+++ b/roles/oidc-playground/handlers/main.yml
@@ -3,3 +3,4 @@
     name: oidcplaygroundserver
     state: started
     restart: true
+  when: oidcplaygroundservercontainer is success and oidcplaygroundservercontainer is not change

--- a/roles/oidc-playground/tasks/main.yml
+++ b/roles/oidc-playground/tasks/main.yml
@@ -53,7 +53,7 @@
       timeout: 10s
       retries: 3
       start_period: 10s
-  notify: restart oidc-playground-docker
+  register: oidcplaygroundservercontainer
 
 - name: Create the gui container
   community.docker.docker_container:
@@ -92,7 +92,7 @@
 #     entity_type: oauth20_rs
 #
 # - name: Include the role manage_provision_entities to provision oidc-playground client to Manage
-#   include_role: 
+#   include_role:
 #     name: manage_provision_entities
-#   vars: 
+#   vars:
 #     entity_type: oidc10_rp

--- a/roles/oidcng/handlers/main.yml
+++ b/roles/oidcng/handlers/main.yml
@@ -1,6 +1,7 @@
 ---
 - name: "restart oidcng"
   community.docker.docker_container:
-    name: dashboardserver
+    name: oidcngserver
     state: started
     restart: true
+  when: oidcngservercontainer is success and oidcngservercontainer is not change

--- a/roles/oidcng/tasks/main.yml
+++ b/roles/oidcng/tasks/main.yml
@@ -45,7 +45,7 @@
     src: oidc_saml_mapping.json
     dest: "{{ oidcng_dir }}"
     owner: "root"
-    group: "root"  
+    group: "root"
     mode: "0640"
   notify:
     - "restart oidcng"
@@ -136,6 +136,7 @@
       traefik.http.routers.oidcng.middlewares: oidcngmw@docker
       traefik.http.middlewares.oidcngmw.replacepathregex.regex: "^/.well-known/openid-configuration"
       traefik.http.middlewares.oidcngmw.replacepathregex.replacement: "/oidc/.well-known/openid-configuration"
+  register: oidcngservercontainer
 
 
 

--- a/roles/pdp/handlers/main.yml
+++ b/roles/pdp/handlers/main.yml
@@ -3,3 +3,4 @@
     name: pdpserver
     state: started
     restart: true
+  when: pdpservercontainer is success and pdpservercontainer is not change

--- a/roles/pdp/tasks/main.yml
+++ b/roles/pdp/tasks/main.yml
@@ -58,8 +58,8 @@
       timeout: 10s
       retries: 3
       start_period: 10s
-  notify: restart pdpserver
-
+  register: pdpservercontainer
+    
 - name: Create the gui container
   community.docker.docker_container:
     name: pdpgui

--- a/roles/profile/handlers/main.yml
+++ b/roles/profile/handlers/main.yml
@@ -4,3 +4,4 @@
     name: profile
     state: started
     restart: true
+  when: profileservercontainer is success and profileservercontainer is not change

--- a/roles/profile/tasks/main.yml
+++ b/roles/profile/tasks/main.yml
@@ -108,7 +108,8 @@
       - source: /etc/localtime
         target: /etc/localtime
         type: bind
-    
+  register: profilecontainer
+
 
 - name: Include the role manage_provision_entities to provision profile to Manage
   ansible.builtin.include_role:

--- a/roles/stats/handlers/main.yml
+++ b/roles/stats/handlers/main.yml
@@ -3,10 +3,11 @@
     name: statsserver
     state: started
     restart: true
+  when: statsservercontainer is success and statsservercontainer is not change
+
 
 - name: restart statsgui
   community.docker.docker_container:
     name: statsgui
     state: started
     restart: true
-

--- a/roles/stats/tasks/main.yml
+++ b/roles/stats/tasks/main.yml
@@ -45,6 +45,7 @@
       - source: /dev/log
         target: /dev/log
         type: bind
+  register: statsservercontainer
 
 - name: Create and start the guicontainer
   community.docker.docker_container:

--- a/roles/stepupazuremfa/handlers/main.yml
+++ b/roles/stepupazuremfa/handlers/main.yml
@@ -12,3 +12,4 @@
     name: azuremfa
     state: started
     restart: true
+  when: azuremfacontainer is success and azuremfacontainer is not change

--- a/roles/stepupazuremfa/tasks/main.yml
+++ b/roles/stepupazuremfa/tasks/main.yml
@@ -76,3 +76,4 @@
       - source: /opt/openconext/azuremfa
         target: /var/www/html/config/openconext
         type: bind
+  register: azuremfacontainer

--- a/roles/stepupgateway/handlers/main.yml
+++ b/roles/stepupgateway/handlers/main.yml
@@ -8,4 +8,8 @@
     state: reloaded
 
 - name: restart gateway
-  command: docker restart gateway
+  community.docker.docker_container:
+    name: gateway
+    state: started
+    restart: true
+  when: gatewaycontainer is success and gatewaycontainer is not change

--- a/roles/stepupgateway/tasks/main.yml
+++ b/roles/stepupgateway/tasks/main.yml
@@ -133,3 +133,4 @@
       - source: /opt/openconext/gateway/
         target: /var/www/html/config/openconext
         type: bind
+  register: gatewaycontainer

--- a/roles/stepupmiddleware/handlers/main.yml
+++ b/roles/stepupmiddleware/handlers/main.yml
@@ -12,3 +12,4 @@
     name: middleware
     state: started
     restart: true
+  when: middlewarecontainer is success and middlewarecontainer is not change

--- a/roles/stepupmiddleware/tasks/docker.yml
+++ b/roles/stepupmiddleware/tasks/docker.yml
@@ -65,6 +65,7 @@
       start_period: 10s
     etc_hosts:
       host.docker.internal: host-gateway
+  register: middlewarecontainer
 
 - name: Put middleware configuration scripts in /root/
   ansible.builtin.template:
@@ -96,7 +97,7 @@
   - "middleware-config.json"
   - "middleware-whitelist.json"
   - "middleware-institution.json"
-  tags: 
+  tags:
     - push_mw_config
     - push_mw_institution
     - push_mw_whitelist
@@ -127,20 +128,20 @@
     "middleware-push-institution.sh": "05-middleware-institution.sh"
 
 # The following push scripts have an additional conditional check on the presence of
-# a tag, so these are only ran when explicitly called. 
+# a tag, so these are only ran when explicitly called.
 
 - name: Push middleware configuration
   ansible.builtin.command: /opt/scripts/middleware-push-config.sh
   run_once: true
   when:
     - "'push_mw_config' in ansible_run_tags"
-  tags: 
+  tags:
     - push_mw_config
 
 - name: Push middleware whitelist
   ansible.builtin.command: /opt/scripts/middleware-push-whitelist.sh
   run_once: True
-  when: 
+  when:
     - "'push_mw_whitelist' in ansible_run_tags"
   tags:
     - push_mw_whitelist

--- a/roles/stepupra/handlers/main.yml
+++ b/roles/stepupra/handlers/main.yml
@@ -12,3 +12,4 @@
     name: ra
     state: started
     restart: true
+  when: racontainer is success and racontainer is not change

--- a/roles/stepupra/tasks/main.yml
+++ b/roles/stepupra/tasks/main.yml
@@ -79,3 +79,4 @@
       - source: /opt/openconext/ra
         target: /var/www/html/config/openconext
         type: bind
+  register: racontainer

--- a/roles/stepupselfservice/handlers/main.yml
+++ b/roles/stepupselfservice/handlers/main.yml
@@ -12,3 +12,4 @@
     name: selfservice
     state: started
     restart: true
+  when: selfservicecontainer is success and selfservicecontainer is not change

--- a/roles/stepupselfservice/tasks/main.yml
+++ b/roles/stepupselfservice/tasks/main.yml
@@ -81,3 +81,4 @@
       - source: /opt/openconext/selfservice
         target: /var/www/html/config/openconext
         type: bind
+    register: selfservicecontainer

--- a/roles/stepuptiqr/handlers/main.yml
+++ b/roles/stepuptiqr/handlers/main.yml
@@ -12,4 +12,4 @@
     name: tiqr
     state: started
     restart: true
-
+  when: tiqrcontainer is success and tiqrcontainer is not change

--- a/roles/stepuptiqr/tasks/main.yml
+++ b/roles/stepuptiqr/tasks/main.yml
@@ -85,3 +85,4 @@
       - source: /opt/openconext/tiqr
         target: /var/www/html/config/openconext
         type: bind
+  register: tiqrcontainer

--- a/roles/stepupwebauthn/handlers/main.yml
+++ b/roles/stepupwebauthn/handlers/main.yml
@@ -12,3 +12,4 @@
     name: webauthn
     state: started
     restart: true
+  when: webauthncontainer is success and webauthncontainer is not change

--- a/roles/stepupwebauthn/tasks/main.yml
+++ b/roles/stepupwebauthn/tasks/main.yml
@@ -119,3 +119,4 @@
       - source: /opt/openconext/webauthn
         target: /var/www/html/config/openconext
         type: bind
+  register: webauthncontainer

--- a/roles/teams/handlers/main.yml
+++ b/roles/teams/handlers/main.yml
@@ -3,4 +3,4 @@
     name: teamsserver
     state: started
     restart: true
-
+  when: teamsserverontainer is success and teamsserverontainer is not change

--- a/roles/teams/tasks/main.yml
+++ b/roles/teams/tasks/main.yml
@@ -54,7 +54,7 @@
       timeout: 10s
       retries: 3
       start_period: 10s
-  notify: restart teamsserver
+  register: teamsserverontainer
 
 - name: Create the gui container
   community.docker.docker_container:


### PR DESCRIPTION
Restarting a new (freshly started) container might cause issues, e.g. with running migrations. Only restart the container if it's not new.