### PR TITLE
Add small MariaDB docker role, for running on a single node

### DIFF
--- a/roles/attribute-aggregation/defaults/main.yml
+++ b/roles/attribute-aggregation/defaults/main.yml
@@ -9,3 +9,5 @@ aa_manage_provision_oidcrp_description_en: "OAuth client to access VOOT for grou
 aa_manage_provision_oidcrp_grants: "client_credentials"
 aa_manage_provision_oidcrp_allowed_resource_servers: '{"name": "{{ voot.oidcng_checkToken_clientId }}"}'
 aa_spring_flyway_enabled: true
+aa_docker_networks:
+  - name: loadbalancer

--- a/roles/attribute-aggregation/tasks/main.yml
+++ b/roles/attribute-aggregation/tasks/main.yml
@@ -21,6 +21,13 @@
     - apachelink.conf
   notify: restart attribute-aggregationserver
 
+- name: Add the MariaDB docker network to the list of networks when MariaDB runs in Docker
+  ansible.builtin.set_fact:
+    aa_docker_networks:
+      - name: loadbalancer
+      - name: openconext_mariadb
+  when: mariadb_in_docker | default(false) | bool
+
 - name: Create and start the server container
   community.docker.docker_container:
     name: aaserver
@@ -28,8 +35,7 @@
     pull: true
     restart_policy: "always"
     state: started
-    networks:
-      - name: "loadbalancer"
+    networks: "{{ aa_docker_networks }}"
     mounts:
       - source: /opt/openconext/attribute-aggregation/serverapplication.yml
         target: /application.yml

--- a/roles/engineblock/defaults/main.yml
+++ b/roles/engineblock/defaults/main.yml
@@ -107,3 +107,5 @@ engine_site_notice_show: false
 engineblock_log_attributes: []
 
 engine_php_memory: 256M
+engine_docker_networks:
+  - name: loadbalancer

--- a/roles/engineblock/tasks/main.yml
+++ b/roles/engineblock/tasks/main.yml
@@ -176,14 +176,20 @@
     name: engineblock_sessions
     state: present
 
+- name: Add the MariaDB docker network to the list of networks when MariaDB runs in Docker
+  ansible.builtin.set_fact:
+    engine_docker_networks:
+      - name: loadbalancer
+      - name: openconext_mariadb
+  when: mariadb_in_docker | default(false) | bool
+
 - name: Create the container
   community.docker.docker_container:
     name: "engineblock"
     image: ghcr.io/openconext/openconext-engineblock/openconext-engineblock:{{ engine_version }}
     pull: true
     restart_policy: "always"
-    networks:
-      - name: "loadbalancer"
+    networks: "{{ engine_docker_networks}}"
     labels:
       traefik.http.routers.engine.rule: "Host(`engine.{{ base_domain }}`)"
       traefik.http.routers.engine.service: "engineblock"

--- a/roles/invite/defaults/main.yml
+++ b/roles/invite/defaults/main.yml
@@ -15,3 +15,5 @@ invite_manage_provision_oauth_rs_scopes: "openid"
 invite_mock_install: false
 # Override is in the dockerX.env host_var files
 invite_cronjobmaster: true
+invite_docker_networks:
+  - name: loadbalancer

--- a/roles/invite/tasks/main.yml
+++ b/roles/invite/tasks/main.yml
@@ -48,6 +48,13 @@
   when: invite_mock_install
   notify: restart inviteprovisioningmock
 
+- name: Add the MariaDB docker network to the list of networks when MariaDB runs in Docker
+  ansible.builtin.set_fact:
+    invite_docker_networks:
+      - name: loadbalancer
+      - name: openconext_mariadb
+  when: mariadb_in_docker | default(false) | bool
+
 - name: Create and start the server container
   community.docker.docker_container:
     name: inviteserver
@@ -57,8 +64,7 @@
     pull: true
     restart_policy: "always"
     state: started
-    networks:
-      - name: "loadbalancer"
+    networks: "{{ invite_docker_networks }}"
     mounts:
       - source: /opt/openconext/invite/serverapplication.yml
         target: /application.yml
@@ -79,7 +85,6 @@
       retries: 3
       start_period: 10s
   register: inviteservercontainer
-
 
 - name: Create the client container
   community.docker.docker_container:
@@ -133,6 +138,7 @@
     env:
       HTTPD_CSP: "{{ httpd_csp.strict_with_static_img }}"
 
+
 - name: Create and start the mock provisioning container
   community.docker.docker_container:
     name: inviteprovisioningmock
@@ -148,8 +154,7 @@
       - source: /etc/localtime
         target: /etc/localtime
         type: bind
-    networks:
-      - name: "loadbalancer"
+    networks: "{{ invite_docker_networks }}"
     labels:
       traefik.http.routers.invitemock.rule: "Host(`mock.{{ base_domain }}`)"
       traefik.http.routers.invitemock.tls: "true"

--- a/roles/lifecycle/defaults/main.yml
+++ b/roles/lifecycle/defaults/main.yml
@@ -11,3 +11,5 @@ lifecycle_api_enabled: true
 lifecycle_api_password: secret
 lifecycle_api_username: lifecycle
 current_release_config_dir_name: /opt/openconext/{{ appname }}
+lifecycle_docker_networks:
+  - name: loadbalancer

--- a/roles/lifecycle/tasks/main.yml
+++ b/roles/lifecycle/tasks/main.yml
@@ -33,6 +33,13 @@
   notify:
     - restart {{ appname }}
 
+- name: Add the MariaDB docker network to the list of networks when MariaDB runs in Docker
+  ansible.builtin.set_fact:
+    lifecycle_docker_networks:
+      - name: loadbalancer
+      - name: openconext_mariadb
+  when: mariadb_in_docker | default(false) | bool
+
 - name: Create the container
   community.docker.docker_container:
     name: "{{ appname }}"
@@ -41,8 +48,7 @@
       host.docker.internal: host-gateway
     pull: true
     restart_policy: "always"
-    networks:
-      - name: "loadbalancer"
+    networks: "{{ lifecycle_docker_networks }}"
     labels:
       traefik.http.routers.lifecycle.rule: "Host(`lifecycle.{{ base_domain }}`)"
       traefik.http.routers.lifecycle.tls: "true"

--- a/roles/manage/defaults/main.yml
+++ b/roles/manage/defaults/main.yml
@@ -30,3 +30,5 @@ manage_tabs_enabled:
   - single_tenant_template
   - provisioning
   - sram
+manage_docker_networks:
+  - name: loadbalancer

--- a/roles/manage/tasks/main.yml
+++ b/roles/manage/tasks/main.yml
@@ -72,6 +72,13 @@
   notify:
     - "restart manageserver"
 
+- name: Add the MariaDB docker network to the list of networks when MariaDB runs in Docker
+  ansible.builtin.set_fact:
+    manage_docker_networks:
+      - name: loadbalancer
+      - name: openconext_mariadb
+  when: mariadb_in_docker | default(false) | bool
+
 - name: Create and start the server container
   community.docker.docker_container:
     name: manageserver
@@ -80,8 +87,7 @@
     pull: true
     restart_policy: "always"
     state: started
-    networks:
-      - name: "loadbalancer"
+    networks: "{{ manage_docker_networks}}"
     mounts:
       - source: /opt/openconext/manage/
         target: /config/

--- a/roles/mariadbdocker/defaults/main.yml
+++ b/roles/mariadbdocker/defaults/main.yml
@@ -1,0 +1,3 @@
+docker_mariadb_network_range: "172.21.21.0/24"
+mysql_backup_user: backup_user
+backup_node: True

--- a/roles/mariadbdocker/files/settings.cnf
+++ b/roles/mariadbdocker/files/settings.cnf
@@ -1,0 +1,2 @@
+[mariadb]
+sql_mode=NO_ENGINE_SUBSTITUTION

--- a/roles/mariadbdocker/tasks/main.yml
+++ b/roles/mariadbdocker/tasks/main.yml
@@ -1,0 +1,96 @@
+---
+- name: Create MariaDB volume
+  community.docker.docker_volume:
+    name: openconext_mariadb
+    state: present
+
+- name: Create MariaDB network
+  community.docker.docker_network:
+    name: openconext_mariadb
+    state: present
+    internal: false
+    ipam_config:
+      - subnet: "{{ docker_mariadb_network_range }}"
+
+- name: Create the MariaDB container
+  community.docker.docker_container:
+    name: openconext_mariadb
+    image: mariadb:10.6
+    state: started
+    pull: true
+    restart_policy: "always"
+    ports: "127.0.0.1:3306:3306"
+    networks:
+      - name: "openconext_mariadb"
+    mounts:
+      - type: volume
+        source: openconext_mariadb
+        target: /var/lib/mysql
+    env:
+      MARIADB_ROOT_PASSWORD: "{{ mariadb_root_password }}"
+
+- name: Create database
+  community.mysql.mysql_db:
+    name: "{{ item }}"
+    state: present
+    login_user: root
+    login_host: localhost
+    login_password: "{{ mariadb_root_password }}"
+  with_items:
+    - "{{ databases.names }}"
+
+- name: Create database user
+  community.mysql.mysql_user:
+    name: "{{ item[0].name }}"
+    host: "{{ item[1] }}"
+    password: "{{ item[0].password }}"
+    priv: "{{ item[0].db_name }}.*:{{ item[0].privilege }}"
+    state: present
+    append_privs: true
+    login_user: root
+    login_host: localhost
+    login_password: "{{ mariadb_root_password }}"
+  #  no_log: true
+  with_nested:
+    - "{{ databases.users }}"
+    - "{{ database_clients }}"
+
+- name: Add mariadb backup user
+  community.mysql.mysql_user:
+    name: "{{ mysql_backup_user }}"
+    password: "{{ mysql_backup_password }}"
+    login_user: root
+    login_password: "{{ mariadb_root_password }}"
+    login_host: localhost
+    priv: "*.*:SELECT,RELOAD,PROCESS,LOCK TABLES,BINLOG MONITOR,CONNECTION ADMIN,SHOW VIEW"
+    state: present
+  #  no_log: true
+
+- name: Create the backup directory
+  ansible.builtin.file:
+    path: /home/backup
+    state: directory
+    owner: root
+    group: root
+    mode: "0700"
+  when:
+    - backup_node | bool
+
+- name: Put mariadb_backup script
+  ansible.builtin.template:
+    src: "mariadb_backup.sh.j2"
+    dest: "/usr/local/sbin/mariadb_backup.sh"
+    mode: "0700"
+    owner: root
+  when:
+    - backup_node | bool
+
+- name: Create cron symlink for backup script
+  file:
+    src: /usr/local/sbin/mariadb_backup.sh
+    dest: /etc/cron.daily/db_backup
+    state: link
+    mode: 0700
+    owner: root
+  when:
+    - backup_node | bool

--- a/roles/mariadbdocker/tasks/main.yml
+++ b/roles/mariadbdocker/tasks/main.yml
@@ -3,6 +3,21 @@
   community.docker.docker_volume:
     name: openconext_mariadb
     state: present
+- name: Create MariaDB config dir
+  ansible.builtin.file:
+    path: /opt/openconext/mariadb/
+    owner: root
+    group: root
+    mode: "0755"
+    state: directory
+
+- name: Copy mariadb config file
+  ansible.builtin.copy:
+    src: settings.cnf
+    dest: /opt/openconext/mariadb/settings.cnf
+    owner: root
+    group: root
+    mode: "0644"
 
 - name: Create MariaDB network
   community.docker.docker_network:
@@ -26,6 +41,9 @@
       - type: volume
         source: openconext_mariadb
         target: /var/lib/mysql
+      - type: bind
+        source: /opt/openconext/mariadb/settings.cnf
+        target: /etc/mysql/conf.d/settings.cnf
     env:
       MARIADB_ROOT_PASSWORD: "{{ mariadb_root_password }}"
 

--- a/roles/mariadbdocker/templates/mariadb_backup.sh.j2
+++ b/roles/mariadbdocker/templates/mariadb_backup.sh.j2
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+umask 0077
+
+declare -x PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin
+
+MYSQL_USER="{{ mysql_backup_user }}"
+MYSQL_PASS="{{ mysql_backup_password }}"
+FOLDER="/home/backup"
+
+DAY=$(/bin/date +'%a')
+
+echo "-- Remove old backups --"
+find /home/backup/ -type f -ctime +2 -delete
+
+echo "-- START new backups --"
+
+echo "SET autocommit=0;SET unique_checks=0;SET foreign_key_checks=0;" > tmp_sqlhead.sql
+echo "SET autocommit=1;SET unique_checks=1;SET foreign_key_checks=1;" > tmp_sqlend.sql
+
+if [ -z "$1" ]
+  then
+    echo "-- Dumping all DB ..."
+    for I in $(docker exec openconext_mariadb mariadb -u $MYSQL_USER --password=$MYSQL_PASS -e 'show databases' -s --skip-column-names);
+    do
+      if [ "$I" = information_schema ] || [ "$I" =  mysql ] || [ "$I" =  sys ] || [ "$I" =  performance_schema ]  # exclude this DB
+      then
+         echo "-- Skip $I ..."
+       continue
+      fi
+      echo "-- Dumping $I ..."
+      # Pipe compress and concat the head/end with the stoutput of mysqlump ( '-' cat argument)
+      docker exec openconext_mariadb mysqldump -u $MYSQL_USER --password=$MYSQL_PASS $I | cat tmp_sqlhead.sql - tmp_sqlend.sql | gzip -fc > "$FOLDER/$DAY-$I.sql.gz"
+    done
+
+else
+      I=$1;
+      echo "-- Dumping $I ..."
+      # Pipe compress and concat the head/end with the stoutput of mysqlump ( '-' cat argument)
+      docker exec openconext_mariadb mysqldump -u $MYSQL_USER --password=$MYSQL_PASS $I | cat tmp_sqlhead.sql - tmp_sqlend.sql | gzip -fc > "$FOLDER/$DAY-$I.sql.gz"
+fi
+
+# remove tmp files
+rm tmp_sqlhead.sql
+rm tmp_sqlend.sql
+
+echo "-- FINISH —"
+
+umask 0022

--- a/roles/pdp/defaults/main.yml
+++ b/roles/pdp/defaults/main.yml
@@ -21,3 +21,5 @@ pdp_manage_provision_samlsp_trusted_proxy: false
 pdp_manage_provision_samlsp_sign: false
 pdp_spring_flyway_enabled: true
 pdp_manage_push_testmode: true
+pdp_docker_networks:
+  -name: loadbalancer

--- a/roles/pdp/tasks/main.yml
+++ b/roles/pdp/tasks/main.yml
@@ -20,6 +20,13 @@
     - xacml.conext.properties
   notify: restart pdpserver
 
+- name: Add the MariaDB docker network to the list of networks when MariaDB runs in Docker
+  ansible.builtin.set_fact:
+    pdp_docker_networks:
+      - name: loadbalancer
+      - name: openconext_mariadb
+  when: mariadb_in_docker | default(false) | bool
+
 - name: Create and start the server container
   community.docker.docker_container:
     name: pdpserver
@@ -29,8 +36,7 @@
     pull: true
     restart_policy: "always"
     state: started
-    networks:
-      - name: "loadbalancer"
+    networks: "{{ pdp_docker_networks }}"
     mounts:
       - source: /opt/openconext/pdp/serverapplication.properties
         target: /application.properties
@@ -59,7 +65,7 @@
       retries: 3
       start_period: 10s
   register: pdpservercontainer
-    
+ 
 - name: Create the gui container
   community.docker.docker_container:
     name: pdpgui

--- a/roles/spdashboard/defaults/main.yml
+++ b/roles/spdashboard/defaults/main.yml
@@ -37,3 +37,5 @@ spdashboard_oidcng_playground_uri_test: https://oidc-playground.dev.support.surf
 spdashboard_oidcng_playground_uri_prod: https://oidc-playground.dev.support.surfconext.nl/redirect
 spdashboard_show_global_notice: False
 spdashboard_global_notice_date: "01-01-2020"
+spdashboard_docker_networks: 
+  - name: loadbalancer

--- a/roles/spdashboard/tasks/main.yml
+++ b/roles/spdashboard/tasks/main.yml
@@ -15,9 +15,12 @@
     group: root
     mode: 0644
 
-- name: Create the spdashboard container network
-  docker_network:
-    name: "spdashboard"
+- name: Add the MariaDB docker network to the list of networks when MariaDB runs in Docker
+  ansible.builtin.set_fact:
+    spdashboard_docker_networks:
+      - name: loadbalancer
+      - name: openconext_mariadb
+  when: mariadb_in_docker | default(false) | bool
 
 - name: Create the container
   docker_container:
@@ -26,8 +29,7 @@
     env_file: "/opt/openconext/spdashboard/env"
     pull: true
     restart_policy: "always"
-    networks:
-      - name: "loadbalancer"
+    networks: "{{ spdashboard_docker_networks }}"
     labels:
       traefik.http.routers.spdashboard.rule: "Host(`{{ spdashboard_domain }}`)"
       traefik.http.routers.spdashboard.tls: "true"

--- a/roles/stepupgateway/defaults/main.yml
+++ b/roles/stepupgateway/defaults/main.yml
@@ -1,0 +1,2 @@
+gateway_docker_networks:
+  - name: loadbalancer

--- a/roles/stepupgateway/tasks/main.yml
+++ b/roles/stepupgateway/tasks/main.yml
@@ -109,14 +109,20 @@
     owner: "{{ appname }}"
     mode: "0600"
 
+- name: Add the MariaDB docker network to the list of networks when MariaDB runs in Docker
+  ansible.builtin.set_fact:
+    gateway_docker_networks:
+      - name: loadbalancer
+      - name: openconext_mariadb
+  when: mariadb_in_docker | default(false) | bool
+
 - name: Create the container
   community.docker.docker_container:
     name: "{{ appname }}"
     image: ghcr.io/openconext/stepup-gateway/stepup-gateway:{{ gateway_version }}
     pull: true
     restart_policy: "always"
-    networks:
-      - name: "loadbalancer"
+    networks: "{{ gateway_docker_networks }}"
     labels:
       traefik.http.routers.gateway.rule: "Host(`{{ gateway_vhost_name }}`)"
       traefik.http.routers.gateway.tls: "true"

--- a/roles/stepupmiddleware/defaults/main.yml
+++ b/roles/stepupmiddleware/defaults/main.yml
@@ -1,0 +1,2 @@
+middelware_docker_networks:
+  - name: loadbalancer

--- a/roles/stepupmiddleware/tasks/docker.yml
+++ b/roles/stepupmiddleware/tasks/docker.yml
@@ -36,14 +36,20 @@
   notify:
     - restart {{ appname }}
 
+- name: Add the MariaDB docker network to the list of networks when MariaDB runs in Docker
+  ansible.builtin.set_fact:
+    middelware_docker_networks:
+      - name: loadbalancer
+      - name: openconext_mariadb
+  when: mariadb_in_docker | default(false) | bool
+
 - name: Create the container
   community.docker.docker_container:
     name: "{{ appname }}"
     image: ghcr.io/openconext/stepup-middleware/stepup-middleware:{{ middleware_version }}
     pull: true
     restart_policy: "always"
-    networks:
-      - name: "loadbalancer"
+    networks: "{{ middelware_docker_networks }}"
     labels:
       traefik.http.routers.middleware.rule: "Host(`{{ middleware_vhost_name }}`)"
       traefik.http.routers.middleware.tls: "true"

--- a/roles/stepuptiqr/defaults/main.yml
+++ b/roles/stepuptiqr/defaults/main.yml
@@ -1,0 +1,2 @@
+tiqr_docker_networks:
+  - name: loadbalancer

--- a/roles/stepuptiqr/tasks/main.yml
+++ b/roles/stepuptiqr/tasks/main.yml
@@ -45,11 +45,11 @@
   when: tiqr_apns_pemfile is defined
 
 - name: Write tiqr Firebase service json
-  copy:
+  ansible.builtin.copy:
     src: "{{ inventory_dir }}/secrets/stepup/tiqr-demo.json"
     dest: "{{ current_release_config_file_dir_name }}/tiqr-demo.json"
     owner: "{{ appname }}"
-    mode: 0400
+    mode: "0400"
   when: tiqr_firebase_credentialsfile is defined
 
 - name: Place parameters.yml
@@ -62,14 +62,20 @@
   notify:
     - restart tiqr
 
+- name: Add the MariaDB docker network to the list of networks when MariaDB runs in Docker
+  ansible.builtin.set_fact:
+    tiqr_docker_networks:
+      - name: loadbalancer
+      - name: openconext_mariadb
+  when: mariadb_in_docker | default(false) | bool
+
 - name: Create the container
   community.docker.docker_container:
     name: "{{ appname }}"
     image: ghcr.io/openconext/stepup-tiqr/stepup-tiqr:{{ tiqr_version }}
     pull: true
     restart_policy: "always"
-    networks:
-      - name: "loadbalancer"
+    networks: "{{ tiqr_docker_networks }}"
     labels:
       traefik.http.routers.tiqr.rule: "Host(`tiqr.{{ base_domain }}`)"
       traefik.http.routers.tiqr.tls: "true"

--- a/roles/stepupwebauthn/defaults/main.yml
+++ b/roles/stepupwebauthn/defaults/main.yml
@@ -1,0 +1,2 @@
+webauthn_docker_networks:
+  - name: loadbalancer

--- a/roles/stepupwebauthn/tasks/main.yml
+++ b/roles/stepupwebauthn/tasks/main.yml
@@ -97,14 +97,20 @@
   with_items:
     - "01-webauthn-db_init.sh"
 
+- name: Add the MariaDB docker network to the list of networks when MariaDB runs in Docker
+  ansible.builtin.set_fact:
+    webauthn_docker_networks:
+      - name: loadbalancer
+      - name: openconext_mariadb
+  when: mariadb_in_docker | default(false) | bool
+
 - name: Create the container
   community.docker.docker_container:
     name: "{{ appname }}"
     image: ghcr.io/openconext/stepup-webauthn/stepup-webauthn:{{ webauthn_version }}
     pull: true
     restart_policy: "always"
-    networks:
-      - name: "loadbalancer"
+    networks: "{{ webauthn_docker_networks }}"
     labels:
       traefik.http.routers.webauthn.rule: "Host(`webauthn.{{ base_domain }}`)"
       traefik.http.routers.webauthn.tls: "true"

--- a/roles/teams/defaults/main.yml
+++ b/roles/teams/defaults/main.yml
@@ -8,7 +8,7 @@ teams_tos_en: https://example.org
 teams_tos_nl: https://example.org
 teams_tos_pt: https://example.org
 teams_main_link: https://www.openconext.org
-teams_organization: "{{ instance_name}}"
+teams_organization: "{{ instance_name }}"
 teams_api_lifecycle_username: teams_api_lifecycle_user
 teams_oauth2_token_url: "https://connect.{{ base_domain }}/oidc/token"
 teams_authz_client_id: "teams.{{ base_domain }}"
@@ -27,3 +27,5 @@ teams_manage_provision_samlsp_sp_cert: ""
 teams_manage_provision_samlsp_trusted_proxy: false
 teams_manage_provision_samlsp_sign: false
 teams_spring_flyway_enabled: true
+teams_docker_networks: 
+  - name: "loadbalancer"

--- a/roles/teams/tasks/main.yml
+++ b/roles/teams/tasks/main.yml
@@ -19,6 +19,13 @@
     - logback.xml
   notify: restart teamsserver
 
+- name: Add the MariaDB docker network to the list of networks when MariaDB runs in Docker
+  ansible.builtin.set_fact:
+    teams_docker_networks:
+      - name: loadbalancer
+      - name: openconext_mariadb
+  when: mariadb_in_docker | default(false) | bool
+
 - name: Create and start the server container
   community.docker.docker_container:
     name: teamsserver
@@ -28,8 +35,7 @@
     pull: true
     restart_policy: "always"
     state: started
-    networks:
-      - name: "loadbalancer"
+    networks: "{{ teams_docker_networks }}"
     mounts:
       - source: /opt/openconext/teams/serverapplication.yml
         target: /application.yml


### PR DESCRIPTION
The role mariadbdocker is added, which provisions a MariaDB docker container on the Docker host. It allows for hosting all MariaDB databases. 
A docker network is created, and all roles that require MariaDB access have access to this network 