### PR TITLE
Feature/mongo docker

### DIFF
--- a/provision.yml
+++ b/provision.yml
@@ -189,5 +189,11 @@
     - { role: lifecycle,      tags: ["lifecycle"] }  
     - { role: stepuptiqr, tags: ['stepuptiqr' , 'stepup'] }
 
+- hosts: docker_mariadb
+  become: true
+  roles:
+    - { role: mariadbdocker, tags: ['mariadbdocker']}
+    - { role: mongodbdocker, tags: ['mongodbdocker']}
+
 - import_playbook: "{{ environment_dir }}/playbook.yml"
 

--- a/roles/manage/defaults/main.yml
+++ b/roles/manage/defaults/main.yml
@@ -1,8 +1,8 @@
 ---
 manage_dir: /config/
-manage_snapshot_timestamp: ''
+manage_snapshot_timestamp: ""
 manage_jar: manage-current.jar
-manage_random_source: 'file:///dev/urandom'
+manage_random_source: "file:///dev/urandom"
 manage_cronjobmaster: false
 manage_disclaimer_background_color: "{{ environment_ribbon_colour }}"
 manage_disclaimer_content: "{{ environment_shortname }}"
@@ -30,3 +30,6 @@ manage_tabs_enabled:
   - single_tenant_template
   - provisioning
   - sram
+
+manage_docker_networks:
+  - name: loadbalancer

--- a/roles/manage/tasks/main.yml
+++ b/roles/manage/tasks/main.yml
@@ -72,6 +72,13 @@
   notify:
     - "restart manageserver"
 
+- name: Add the mongodb docker network to the list of networks when MongoDB runs in Docker
+  ansible.builtin.set_fact:
+    manage_docker_networks:
+      - name: loadbalancer
+      - name: openconext_mongodb
+  when: mongodb_in_docker | default(false) | bool
+
 - name: Create and start the server container
   community.docker.docker_container:
     name: manageserver
@@ -80,8 +87,7 @@
     pull: true
     restart_policy: "always"
     state: started
-    networks:
-      - name: "loadbalancer"
+    networks: "{{ manage_docker_networks }}"
     mounts:
       - source: /opt/openconext/manage/
         target: /config/

--- a/roles/mongodbdocker/defaults/main.yml
+++ b/roles/mongodbdocker/defaults/main.yml
@@ -1,0 +1,2 @@
+replica_set_name: "{{ instance_name }}"
+docker_mongodb_network_range: "172.21.22.0/24"

--- a/roles/mongodbdocker/tasks/main.yml
+++ b/roles/mongodbdocker/tasks/main.yml
@@ -1,0 +1,87 @@
+---
+- name: Install required packages
+  ansible.builtin.apt:
+    name: "python3-pymongo"
+    state: present
+
+- name: Create MongoDB volume
+  community.docker.docker_volume:
+    name: openconext_mongodb
+    state: present
+
+- name: Create MongoDB network
+  community.docker.docker_network:
+    name: openconext_mongodb
+    state: present
+    internal: false
+    ipam_config:
+      - subnet: "{{ docker_mongodb_network_range }}"
+
+- name: Create the MongoDB container
+  community.docker.docker_container:
+    name: openconext_mongodb
+    image: bitnami/mongodb:7.0
+    state: started
+    pull: true
+    restart_policy: "always"
+    ports: "127.0.0.1:27017:27017"
+    networks:
+      - name: "openconext_mongodb"
+    mounts:
+      - type: volume
+        source: openconext_mongodb
+        target: /var/lib/mysql
+      - type: bind
+        source: /home/backup/mongo/
+        target: /home/backup
+    env:
+      MONGODB_ROOT_USER: admin
+      MONGODB_ROOT_PASSWORD: "{{ mongo_admin_password }}"
+      MONGODB_REPLICA_SET_NAME: "{{ replica_set_name }}"
+      MONGODB_REPLICA_SET_MODE: primary
+      MONGODB_REPLICA_SET_KEY: "{{ mongodb_replicateset_key }}"
+      MONGODB_ADVERTISED_HOSTNAME: openconext_mongodb
+    volumes:
+      - openconext_mongodb:/bitnami/mongodb
+    hostname: openconext_mongodb
+
+- name: Create mongo database users
+  community.mongodb.mongodb_user:
+    login_database: admin
+    database: "{{ item.db_name }}"
+    login_user: admin
+    login_password: "{{ mongo_admin_password }}"
+    login_host: 127.0.0.1
+    name: "{{ item.name }}"
+    password: "{{ item.password }}"
+    roles: readWrite
+    replica_set: "{{ replica_set_name }}"
+    strict_compatibility: false
+  no_log: false
+  run_once: true
+  with_items: "{{ mongo.users }}"
+  changed_when: false
+  tags: mongo_users
+
+- name: Create the backupdir
+  ansible.builtin.file:
+    path: /home/backup/mongo
+    owner: 1001
+    group: 1001
+    mode: "0700"
+
+- name: Install the backup script
+  ansible.builtin.template:
+    src: "backup_mongo.pl.j2"
+    dest: "/usr/local/sbin/backup_mongo.pl"
+    mode: "0700"
+    owner: root
+    group: root
+
+- name: Create cron symlink for backup script
+  ansible.builtin.file:
+    src: "/usr/local/sbin/backup_mongo.pl"
+    dest: "/etc/cron.daily/mongodb_backup"
+    state: link
+    mode: "0700"
+    owner: root

--- a/roles/mongodbdocker/templates/backup_mongo.pl.j2
+++ b/roles/mongodbdocker/templates/backup_mongo.pl.j2
@@ -1,0 +1,37 @@
+#!/usr/bin/perl
+# Variables
+
+$backupdir = "/home/backup";
+$username = "admin";
+$password = "{{ mongo_admin_password }}";
+
+umask 0077;
+
+# Determine current day
+$day = `/bin/date +'%a'`;
+chomp($day);
+
+# Remove old backups if exists
+if ( -e "$backupdir/mongo-dump-$day/") {
+`rm -rf $backupdir/mongo-dump-$day/`;
+}
+
+# Dump databases
+`docker exec openconext_mongodb mongodump --username $username --password $password --authenticationDatabase admin --out $backupdir/mongo-dump-$day`;
+
+# Gzip dumps
+opendir(BDIR, "$backupdir/mongo-dump-$day/");
+my @files = readdir(BDIR);
+closedir(BDIR);
+chdir("$backupdir/mongo-dump-$day/");
+foreach $dir (@files) {
+if ($dir !~ /^\.+$/) {
+if ($dir !~ /\.\./g) {
+if ( -d "$backupdir/mongo-dump-$day/$dir") {
+`tar -cvzf $backupdir/mongo-dump-$day/$dir.tar.gz $dir/`;
+`rm -rf $backupdir/mongo-dump-$day/$dir/`;
+}
+}
+}
+}
+umask 0022; 

--- a/roles/myconext/defaults/main.yml
+++ b/roles/myconext/defaults/main.yml
@@ -1,2 +1,4 @@
 ---
 myconext_cronjobmaster: true
+myconext_docker_networks:
+  - name: loadbalancer

--- a/roles/myconext/tasks/main.yml
+++ b/roles/myconext/tasks/main.yml
@@ -56,7 +56,7 @@
   notify:
     - "restart myconextserver"
 
-- name: copy / create private key
+- name: Copy / create private key
   ansible.builtin.copy:
     content: "{{ myconext_private_key }}"
     dest: "/opt/openconext/myconext/myconext_saml.key"
@@ -66,7 +66,7 @@
   notify:
     - "restart myconextserver"
 
-- name: copy / create certificate
+- name: Copy / create certificate
   ansible.builtin.copy:
     src: "{{ inventory_dir }}/files/certs/myconext/myconext_saml.crt"
     dest: "/opt/openconext/myconext/myconext_saml.crt"
@@ -92,6 +92,13 @@
     group: "root"
     mode: "0755"
 
+- name: Add the mongodb docker network to the list of networks when MongoDB runs in Docker
+  ansible.builtin.set_fact:
+    myconext_docker_networks:
+      - name: loadbalancer
+      - name: openconext_mongodb
+  when: mongodb_in_docker | default(false) | bool
+
 - name: Create and start the server container
   community.docker.docker_container:
     name: myconextserver
@@ -102,8 +109,7 @@
     env:
       USE_SYSTEM_CA_CERTS: "1"
       TZ: "{{ timezone }}"
-    networks:
-      - name: "loadbalancer"
+    networks: "{{ myconext_docker_networks }}"
     mounts:
       - source: /opt/openconext/myconext/
         target: /config/

--- a/roles/myconext/templates/application.yml.j2
+++ b/roles/myconext/templates/application.yml.j2
@@ -215,7 +215,7 @@ verify:
 spring:
   data:
     mongodb:
-      uri: mongodb://{{ myconext.mongo_user }}:{{ myconext.mongo_password }}@{% for host in groups['mongo_servers'] %}{{ hostvars[host]['inventory_hostname'] }}:{{ myconext.mongo_port }}{% if not loop.last %},{% endif %}{% endfor %}/{{ myconext.mongo_database }}?ssl=true
+      uri: mongodb://{{ myconext.mongo_user }}:{{ myconext.mongo_password }}@{% for host in groups['mongo_servers'] %}{{ hostvars[host]['inventory_hostname'] }}:{{ myconext.mongo_port }}{% if not loop.last %},{% endif %}{% endfor %}/{{ myconext.mongo_database }}?ssl={{ mongodb_ssl | default('true') }}
 
   mail:
     host: {{ smtp_server }}

--- a/roles/oidcng/defaults/main.yml
+++ b/roles/oidcng/defaults/main.yml
@@ -1,8 +1,8 @@
 ---
 oidcng_dir: /opt/openconext/oidcng
 oidcng_config_dir: /config
-oidcng_version: ''
-oidcng_snapshot_timestamp: ''
+oidcng_version: ""
+oidcng_snapshot_timestamp: ""
 oidcng_cronjobmaster: true
 oidcng_saml_sp_entityid: https://connect.{{ base_domain }}
 oidcng_idp_metadata_url: https://engine.{{ base_domain }}/authentication/idp/metadata
@@ -19,4 +19,5 @@ oidcng_manage_provision_samlsp_metadata_url: "https://connect.{{ base_domain }}/
 oidcng_manage_provision_samlsp_sp_cert: "{{ lookup('file', '{{ inventory_dir }}/files/certs/oidc/oidcsaml.crt') | depem }}"
 oidcng_manage_provision_samlsp_sign: "True"
 oidcng_manage_provision_samlsp_trusted_proxy: "True"
-
+oidcng_docker_networks:
+  - name: loadbalancer

--- a/roles/oidcng/tasks/main.yml
+++ b/roles/oidcng/tasks/main.yml
@@ -88,6 +88,13 @@
     group: "root"
     mode: "0755"
 
+- name: Add the mongodb docker network to the list of networks when MongoDB runs in Docker
+  ansible.builtin.set_fact:
+    oidcng_docker_networks:
+      - name: loadbalancer
+      - name: openconext_mongodb
+  when: mongodb_in_docker | default(false) | bool
+
 - name: Create and start the server container
   community.docker.docker_container:
     name: oidcngserver
@@ -96,8 +103,7 @@
     pull: true
     restart_policy: "always"
     state: started
-    networks:
-      - name: "loadbalancer"
+    networks: "{{ oidcng_docker_networks }}"
     mounts:
       - source: "{{ oidcng_dir }}"
         target: /config/
@@ -137,9 +143,6 @@
       traefik.http.middlewares.oidcngmw.replacepathregex.regex: "^/.well-known/openid-configuration"
       traefik.http.middlewares.oidcngmw.replacepathregex.replacement: "/oidc/.well-known/openid-configuration"
   register: oidcngservercontainer
-
-
-
 #- name: Include the role manage_provision_entities to provision oidncg to Manage
 #  ansible.builtin.include_role:
 #    name: manage_provision_entities

--- a/roles/oidcng/templates/application.yml.j2
+++ b/roles/oidcng/templates/application.yml.j2
@@ -76,7 +76,7 @@ idp:
 spring:
   data:
     mongodb:
-      uri: "mongodb://{{ oidcng.mongo_user }}:{{ oidcng.mongo_password }}@{% for host in groups['mongo_servers'] %}{{ hostvars[host]['inventory_hostname'] }}:{{ oidcng.mongo_port }}{% if not loop.last %},{% endif %}{%endfor %}/{{ oidcng.mongo_database }}?ssl=true"
+      uri: "mongodb://{{ oidcng.mongo_user }}:{{ oidcng.mongo_password }}@{% for host in groups['mongo_servers'] %}{{ hostvars[host]['inventory_hostname'] }}:{{ oidcng.mongo_port }}{% if not loop.last %},{% endif %}{%endfor %}/{{ oidcng.mongo_database }}?ssl={{ mongodb_ssl | default('true') }}"
 
   thymeleaf:
     cache: true


### PR DESCRIPTION
This adds a role mongodbdocker so you can install MongoDB on a docker host. 
A seperate docker network is created for the mongo traffic. The apps that use mongo have been adapted so that they can access mongo on a docker host, and that the containers are added to the mongo db docker network using a feature toggle. 