### PR TITLE
Fix: push_mw_* tags not working

### DIFF
--- a/roles/stepupmiddleware/tasks/main.yml
+++ b/roles/stepupmiddleware/tasks/main.yml
@@ -1,7 +1,13 @@
 - name: Include docker tasks when running docker
   import_tasks: docker.yml
-  when: "'docker' in group_names"
+  when: "'docker' in group_names
+    or 'push_mw_config' in ansible_run_tags
+    or 'push_mw_institution' in ansible_run_tags
+    or 'push_mw_whitelist' in ansible_run_tags"
 
 - name: Include vm tasks when running on a vm
   import_tasks: vm.yml
-  when: "'docker' not in group_names"
+  when: "'docker' not in group_names
+    or 'push_mw_config' in ansible_run_tags
+    or 'push_mw_institution' in ansible_run_tags
+    or 'push_mw_whitelist' in ansible_run_tags"

--- a/roles/stepupmiddleware/tasks/main.yml
+++ b/roles/stepupmiddleware/tasks/main.yml
@@ -1,13 +1,13 @@
 - name: Include docker tasks when running docker
   import_tasks: docker.yml
   when: "'docker' in group_names
-    or 'push_mw_config' in ansible_run_tags
+    and ('push_mw_config' in ansible_run_tags
     or 'push_mw_institution' in ansible_run_tags
-    or 'push_mw_whitelist' in ansible_run_tags"
+    or 'push_mw_whitelist' in ansible_run_tags)"
 
 - name: Include vm tasks when running on a vm
   import_tasks: vm.yml
   when: "'docker' not in group_names
-    or 'push_mw_config' in ansible_run_tags
+    and ('push_mw_config' in ansible_run_tags
     or 'push_mw_institution' in ansible_run_tags
-    or 'push_mw_whitelist' in ansible_run_tags"
+    or 'push_mw_whitelist' in ansible_run_tags)"


### PR DESCRIPTION
The push_mw_* tags used to push new configuration to the middleware stopped working. The problem is that "import_tasks" is not run when one the push_mw_* tags is set, so the docker/vm tasks are not included. Fixed by explicitly adding the tags to the import_tasks condition when so the tasks are imported.