### PR TITLE
rsyslog: Only one forwarding config, allowing to forward to two servers

### DIFF
--- a/roles/rsyslog/tasks/main.yml
+++ b/roles/rsyslog/tasks/main.yml
@@ -23,8 +23,8 @@
     dest: "/etc/pki/rsyslog/rsyslogclient.key"
     mode: 0400
     owner: root
-  when: 
-    - rsyslog_remote_server_relp is defined
+  when:
+    - "'sysloghost' not in group_names"
   no_log: true
   notify:
     - "restart rsyslog"
@@ -36,46 +36,35 @@
     mode: 0744
     owner: root
     group: adm
-  when: 
-    - rsyslog_remote_server_relp is defined
+  when:
+    - "'sysloghost' not in group_names"
   notify:
     - "restart rsyslog"
 
-- name: put rsyslog CA file (new location) 
-  copy: 
+- name: put rsyslog CA file (new location)
+  copy:
     src: "{{ inventory_dir }}/files/certs/rsyslog/rsyslogclientca.crt"
     dest: "/etc/pki/rsyslog/rsyslogclientca.crt"
     mode: 0744
     owner: root
     group: adm
-  when: 
-    - rsyslog_remote_server_relp is defined
-
-- name: put Redhat ryslog config file
-  template:
-    src: "rsyslog.conf.j2"
-    dest: "/etc/rsyslog.conf"
-  notify:
-    - "restart rsyslog"
   when:
-    - ansible_os_family == 'RedHat' 
     - "'sysloghost' not in group_names"
 
-- name: put Debian ryslog config file
+- name: put ryslog config file for logforwarding
   template:
     src: "rsyslog_onlyforward.conf.j2"
     dest: "/etc/rsyslog.conf"
   notify:
     - "restart rsyslog"
   when:
-    - ansible_os_family == 'Debian'
     - "'sysloghost' not in group_names"
 
 - name: include tasks for central syslog server
   include_tasks: rsyslog_central.yml
   when:  "'sysloghost' in group_names"
 
-- name: Include tasks for authentication log processing 
+- name: Include tasks for authentication log processing
   include_tasks: process_auth_logs.yml
   when: "'auth_processor' in group_names"
 

--- a/roles/rsyslog/templates/rsyslog_onlyforward.conf.j2
+++ b/roles/rsyslog/templates/rsyslog_onlyforward.conf.j2
@@ -7,23 +7,26 @@ $PreserveFQDN on
 
 *.emerg                         :omusrmsg:* 
 
-{% if rsyslog_remote_server_relp is defined and 'sysloghost' not in group_names %}
-# Forward all logs to the central logging server using relp
+{% if  'sysloghost' not in group_names %}
+{% for relp_host in relp_remote %}
+# Logs are forwarded to {{ relp_host.name }}
 module(load="omrelp")
 action(type="omrelp" 
-target="{{ rsyslog_remote_server_relp }}" 
-port="{{ rsyslog_remote_relp_port }}" 
+target="{{ relp_host.host }}" 
+port="{{ relp_host.port }}" 
 tls="on" 
 tls.caCert="/etc/pki/rsyslog/rsyslogclientca.crt" 
 tls.MyCert="/etc/pki/rsyslog/rsyslogclient.crt"
 tls.MyPrivKey="/etc/pki/rsyslog/rsyslogclient.key"
 tls.authmode="name" 
-tls.permittedpeer=["{{ rsyslog_remote_server_relp }}"]
+tls.permittedpeer=["{{ relp_host.peer }}"]
 queue.type="LinkedList" 
-queue.filename="rsyslog_relp_q"
+queue.filename="{{ relp_host.name }}"
+queue.spoolDirectory="/var/spool/rsyslog"
 queue.maxdiskspace="1G"
 queue.saveonshutdown="on" 
 action.resumeRetryCount="-1"
 action.resumeInterval="5"
 action.writeAllMarkMessages="on")
+{% endfor %}
 {% endif %}


### PR DESCRIPTION
- Add the option to deploy to more than 1 syslog host
- Make 1 logforwarding configuration file, for both Debian and Redhat 