### PR TITLE
Allow more memory for PHP in stepup-middleware

### DIFF
--- a/roles/stepupmiddleware/tasks/docker.yml
+++ b/roles/stepupmiddleware/tasks/docker.yml
@@ -59,6 +59,7 @@
       APACHE_GUID: "#{{ middleware_guid.gid }}"
       APP_ENV: prod
       HTTPD_CSP: ""
+      PHP_MEMORY_LIMIT: 512M
     mounts:
       - source: /opt/openconext/middleware/parameters.yaml
         target: /var/www/html/config/parameters.yaml


### PR DESCRIPTION
Stepup-Middleware runs out of memory when receiving new config via the API. This raises the limit.