### PR TITLE
Use local machine for Middleware config, make memory limit configurable

### DIFF
--- a/roles/stepupmiddleware/defaults/main.yml
+++ b/roles/stepupmiddleware/defaults/main.yml
@@ -1,2 +1,3 @@
 middelware_docker_networks:
   - name: loadbalancer
+middleware_mem_limit: "256M"

--- a/roles/stepupmiddleware/tasks/docker.yml
+++ b/roles/stepupmiddleware/tasks/docker.yml
@@ -59,7 +59,7 @@
       APACHE_GUID: "#{{ middleware_guid.gid }}"
       APP_ENV: prod
       HTTPD_CSP: ""
-      PHP_MEMORY_LIMIT: 512M
+      PHP_MEMORY_LIMIT: "{{ middleware_mem_limit }}"
     mounts:
       - source: /opt/openconext/middleware/parameters.yaml
         target: /var/www/html/config/parameters.yaml

--- a/roles/stepupmiddleware/templates/middleware-push-config.sh.j2
+++ b/roles/stepupmiddleware/templates/middleware-push-config.sh.j2
@@ -21,6 +21,7 @@ fi
 echo "Pushing new config to: https://{{ middleware_vhost_name }}/management/configuration"
 
 http_response=`curl --write-out %{http_code} --output ${TMP_FILE} -XPOST -s \
+    --resolve {{ middleware_vhost_name }}:443:{{ ansible_default_ipv4.address }} -k \
     -u management:{{ management_password }} \
     -H "Accept: application/json" \
     -H "Content-type: application/json" \

--- a/roles/stepupmiddleware/templates/middleware-push-institution.sh.j2
+++ b/roles/stepupmiddleware/templates/middleware-push-institution.sh.j2
@@ -21,6 +21,7 @@ fi
 echo "Pushing new institution configuration to: https://{{ middleware_vhost_name }}/management/institution-configuration"
 
 http_response=`curl --write-out %{http_code} --output ${TMP_FILE} -XPOST -s \
+    --resolve {{ middleware_vhost_name }}:443:{{ ansible_default_ipv4.address }} -k \
     -u management:{{ management_password }} \
     -H "Accept: application/json" \
     -H "Content-type: application/json" \

--- a/roles/stepupmiddleware/templates/middleware-push-whitelist.sh.j2
+++ b/roles/stepupmiddleware/templates/middleware-push-whitelist.sh.j2
@@ -21,6 +21,7 @@ fi
 echo "Pushing new institution whitelist to: https://{{ middleware_vhost_name }}/management/whitelist/replace"
 
 http_response=`curl --write-out %{http_code} --output ${TMP_FILE} -XPOST -s \
+    --resolve {{ middleware_vhost_name }}:443:{{ ansible_default_ipv4.address }} -k \
     -u management:{{ management_password }} \
     -H "Accept: application/json" \
     -H "Content-type: application/json" \


### PR DESCRIPTION
This makes the config-push scripts use the 'local' frontend of middleware, instead of a random (loadbalanced) one.
This way, we only need to increase the memory limit on a single host.