### PR TITLE
mysql needs read access to the server pem

### DIFF
--- a/roles/galera/tasks/arbiter_node.yml
+++ b/roles/galera/tasks/arbiter_node.yml
@@ -49,6 +49,7 @@
     src: "{{ inventory_dir }}/files/certs/galera/{{ item.crt_name }}"
     dest: "{{ galera_tls_cert_path }}/{{ item.crt_name }}"
     owner: root
+    mode: '0644'
   with_items:
     - "{{ galera_tls }}"
   no_log: true


### PR DESCRIPTION
- On prd permissions are already 644, change ansible to match
- for server.pem this is necessary to start garbd service