### PR TITLE
Update deprecated CI containers to ubuntu-24.04

### DIFF
--- a/.github/workflows/molecule-loadbalancer.yml
+++ b/.github/workflows/molecule-loadbalancer.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/molecule-mongo.yml
+++ b/.github/workflows/molecule-mongo.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Ok, molecule tests are running ahgain, now let's get them back working.