### PR TITLE
Hotfix rsyslog breaks after reboot

### DIFF
--- a/provision.yml
+++ b/provision.yml
@@ -8,12 +8,17 @@
       tags:
        - always
 
-- hosts: base
+- hosts: rsyslog
   gather_facts: yes
   become: true
   roles:
     - role: rsyslog
       tags: ['core', 'base', 'rsyslog']
+
+- hosts: base
+  gather_facts: yes
+  become: true
+  roles:
     - role: iptables
       when:
         - iptables_enable | bool

--- a/roles/rsyslog/tasks/main.yml
+++ b/roles/rsyslog/tasks/main.yml
@@ -74,6 +74,7 @@
     - name: Show stat
       ansible.builtin.debug:
         msg: "{{ devlog_statresult }}"
+      when: devlog_statresult.stat.exists and not devlog_statresult.stat.islnk
 
     - name: Remove /dev/log file
       ansible.builtin.file:
@@ -87,6 +88,7 @@
         owner: root
         group: root
         state: link
+      ignore_errors: '{{ ansible_check_mode }}'
       notify:
         - "restart rsyslog"
         - "Restart journald"

--- a/roles/rsyslog/tasks/main.yml
+++ b/roles/rsyslog/tasks/main.yml
@@ -14,7 +14,6 @@
     enabled: true
 
 - name: Forwarding journalctl to rsyslog forward syslog to central logserver
-  # forwarding journalctl to rsyslog https://access.redhat.com/articles/4058681
   when: "'sysloghost' not in group_names"
   block:
 

--- a/roles/rsyslog/tasks/main.yml
+++ b/roles/rsyslog/tasks/main.yml
@@ -27,22 +27,10 @@
       notify:
         - "Restart journald"
 
-    # Ensure socket creation and linking
-    - name: Create the rsyslog service dropin directory if it does not exist
+    - name: Remove logging dropin
       ansible.builtin.file:
-        path: "{{ rsyslog_service_dropindir }}"
-        state: directory
-        owner: root
-        group: root
-        mode: "0755"
-
-    - name: Put logging dropin
-      ansible.builtin.template:
-        dest: "{{ rsyslog_service_dropindir }}/logging.conf"
-        src: logging.conf.j2
-        owner: root
-        group: root
-        mode: "0644"
+        path: "{{ rsyslog_service_dropindir }}/logging.conf"
+        state: absent
       notify: "Reload systemd"
 
     # Since we specify queue.spoolDirectory, lets make sure it exists

--- a/roles/rsyslog/tasks/main.yml
+++ b/roles/rsyslog/tasks/main.yml
@@ -78,7 +78,7 @@
     - name: Remove /dev/log file
       ansible.builtin.file:
         path: /dev/log
-      when: devlog_statresult.exists and not devlog_statresult.islnk
+      when: devlog_statresult.stat.exists and not devlog_statresult.stat.islnk
 
     - name: Create a symbolic link to /run/systemd/journal/dev-log
       ansible.builtin.file:

--- a/roles/rsyslog/tasks/main.yml
+++ b/roles/rsyslog/tasks/main.yml
@@ -76,6 +76,9 @@
       notify:
         - "restart rsyslog"
         - "Restart journald"
+      when:
+        - ansible_os_family != "RedHat"
+        - ansible_os_version != "7"
 
     # rsyslog certificates for relp
     - name: Create the pki directory if it does not exist

--- a/roles/rsyslog/tasks/main.yml
+++ b/roles/rsyslog/tasks/main.yml
@@ -69,11 +69,16 @@
     - name: Remove /dev/log if it exists and is not a symlink
       ansible.builtin.stat:
         path: /dev/log
-      register: statresult
+      register: devlog_statresult
 
     - name: Show stat
       ansible.builtin.debug:
-        msg: "{{ statresult }}"
+        msg: "{{ devlog_statresult }}"
+
+    - name: Remove /dev/log file
+      ansible.builtin.file:
+        path: /dev/log
+      when: devlog_statresult.exists and not devlog_statresult.islnk
 
     - name: Create a symbolic link to /run/systemd/journal/dev-log
       ansible.builtin.file:

--- a/roles/rsyslog/tasks/main.yml
+++ b/roles/rsyslog/tasks/main.yml
@@ -30,7 +30,7 @@
       ansible.builtin.file:
         path: "{{ rsyslog_service_dropindir }}/logging.conf"
         state: absent
-      notify: "Restart journald"
+      notify: "Reload systemd"
 
     # Since we specify queue.spoolDirectory, lets make sure it exists
     - name: Create queue dir

--- a/roles/rsyslog/tasks/main.yml
+++ b/roles/rsyslog/tasks/main.yml
@@ -73,6 +73,9 @@
         owner: root
         group: root
         state: link
+      notify:
+        - "restart rsyslog"
+        - "Restart journald"
 
     # rsyslog certificates for relp
     - name: Create the pki directory if it does not exist

--- a/roles/rsyslog/tasks/main.yml
+++ b/roles/rsyslog/tasks/main.yml
@@ -68,8 +68,8 @@
 
     - name: Create a symbolic link to /run/systemd/journal/dev-log
       ansible.builtin.file:
-        src: /dev/log
-        dest: /run/systemd/journal/dev-log
+        src: /run/systemd/journal/dev-log
+        dest: /dev/log
         owner: root
         group: root
         state: link

--- a/roles/rsyslog/tasks/main.yml
+++ b/roles/rsyslog/tasks/main.yml
@@ -30,7 +30,7 @@
       ansible.builtin.file:
         path: "{{ rsyslog_service_dropindir }}/logging.conf"
         state: absent
-      notify: "Reload systemd"
+      notify: "Restart journald"
 
     # Since we specify queue.spoolDirectory, lets make sure it exists
     - name: Create queue dir

--- a/roles/rsyslog/tasks/main.yml
+++ b/roles/rsyslog/tasks/main.yml
@@ -79,6 +79,7 @@
     - name: Remove /dev/log file
       ansible.builtin.file:
         path: /dev/log
+        state: absent
       when: devlog_statresult.stat.exists and not devlog_statresult.stat.islnk
 
     - name: Create a symbolic link to /run/systemd/journal/dev-log

--- a/roles/rsyslog/tasks/main.yml
+++ b/roles/rsyslog/tasks/main.yml
@@ -54,6 +54,26 @@
         group: root
         mode: "0700"
 
+    # Lets make a link from /dev/log to /run/systemd/journal/dev-log
+    # For some reason, sometimes the link exists, sometimes /dev/log is a socket, sometimes /dev/log is missing
+    # Rsyslog creates and deletes the /dev/log socket depending on imuxsock settings, journald wants to create the symlink
+    # and sometimes they get in each others way
+    # option syssock.name =  /run/systemd/journal/dev-log results in a missing /dev/log and although logging seems
+    # to keep working, the logger command complains
+    # Creating the link if it is not there seems to be the best option
+    # More info:
+    # https://askubuntu.com/questions/861227/dev-log-is-missing-how-do-i-fix
+    # https://github.com/rsyslog/rsyslog-doc/issues/397
+    # https://unix.stackexchange.com/questions/317064/how-do-i-restore-dev-log-in-systemdrsyslog-host
+
+    - name: Create a symbolic link to /run/systemd/journal/dev-log
+      ansible.builtin.file:
+        src: /dev/log
+        dest: /run/systemd/journal/dev-log
+        owner: root
+        group: root
+        state: link
+
     # rsyslog certificates for relp
     - name: Create the pki directory if it does not exist
       ansible.builtin.file:

--- a/roles/rsyslog/tasks/main.yml
+++ b/roles/rsyslog/tasks/main.yml
@@ -54,46 +54,6 @@
         group: root
         mode: "0700"
 
-    # Lets make a link from /dev/log to /run/systemd/journal/dev-log
-    # For some reason, sometimes the link exists, sometimes /dev/log is a socket, sometimes /dev/log is missing
-    # Rsyslog creates and deletes the /dev/log socket depending on imuxsock settings, journald wants to create the symlink
-    # and sometimes they get in each others way
-    # option syssock.name =  /run/systemd/journal/dev-log results in a missing /dev/log and although logging seems
-    # to keep working, the logger command complains
-    # Creating the link if it is not there seems to be the best option
-    # More info:
-    # https://askubuntu.com/questions/861227/dev-log-is-missing-how-do-i-fix
-    # https://github.com/rsyslog/rsyslog-doc/issues/397
-    # https://unix.stackexchange.com/questions/317064/how-do-i-restore-dev-log-in-systemdrsyslog-host
-
-    - name: Remove /dev/log if it exists and is not a symlink
-      ansible.builtin.stat:
-        path: /dev/log
-      register: devlog_statresult
-
-    - name: Show stat
-      ansible.builtin.debug:
-        msg: "{{ devlog_statresult }}"
-      when: devlog_statresult.stat.exists and not devlog_statresult.stat.islnk
-
-    - name: Remove /dev/log file
-      ansible.builtin.file:
-        path: /dev/log
-        state: absent
-      when: devlog_statresult.stat.exists and not devlog_statresult.stat.islnk
-
-    - name: Create a symbolic link to /run/systemd/journal/dev-log
-      ansible.builtin.file:
-        src: /run/systemd/journal/dev-log
-        dest: /dev/log
-        owner: root
-        group: root
-        state: link
-      ignore_errors: '{{ ansible_check_mode }}'
-      notify:
-        - "restart rsyslog"
-        - "Restart journald"
-
     # rsyslog certificates for relp
     - name: Create the pki directory if it does not exist
       ansible.builtin.file:

--- a/roles/rsyslog/tasks/main.yml
+++ b/roles/rsyslog/tasks/main.yml
@@ -66,13 +66,13 @@
     # https://github.com/rsyslog/rsyslog-doc/issues/397
     # https://unix.stackexchange.com/questions/317064/how-do-i-restore-dev-log-in-systemdrsyslog-host
 
-    - name: Remove /de/vlog if it exists and is not a symlink
+    - name: Remove /dev/log if it exists and is not a symlink
       ansible.builtin.file:
         path: /dev/log
         state: absent
       when: >
-        ansible_facts['files']['/path/to/target/link'] is defined and
-        ansible_facts['files']['/path/to/target/link'].islnk is not defined
+        ansible_facts['files']['/dev/log'] is defined and
+        ansible_facts['files']['/dev/log'].islnk is not defined
 
     - name: Create a symbolic link to /run/systemd/journal/dev-log
       ansible.builtin.file:

--- a/roles/rsyslog/tasks/main.yml
+++ b/roles/rsyslog/tasks/main.yml
@@ -76,9 +76,6 @@
       notify:
         - "restart rsyslog"
         - "Restart journald"
-      when:
-        - ansible_os_family != "RedHat"
-        - ansible_os_version != "7"
 
     # rsyslog certificates for relp
     - name: Create the pki directory if it does not exist

--- a/roles/rsyslog/tasks/main.yml
+++ b/roles/rsyslog/tasks/main.yml
@@ -66,6 +66,14 @@
     # https://github.com/rsyslog/rsyslog-doc/issues/397
     # https://unix.stackexchange.com/questions/317064/how-do-i-restore-dev-log-in-systemdrsyslog-host
 
+    - name: Remove /de/vlog if it exists and is not a symlink
+      ansible.builtin.file:
+        path: /dev/log
+        state: absent
+      when: >
+        ansible_facts['files']['/path/to/target/link'] is defined and
+        ansible_facts['files']['/path/to/target/link'].islnk is not defined
+
     - name: Create a symbolic link to /run/systemd/journal/dev-log
       ansible.builtin.file:
         src: /run/systemd/journal/dev-log

--- a/roles/rsyslog/tasks/main.yml
+++ b/roles/rsyslog/tasks/main.yml
@@ -67,12 +67,13 @@
     # https://unix.stackexchange.com/questions/317064/how-do-i-restore-dev-log-in-systemdrsyslog-host
 
     - name: Remove /dev/log if it exists and is not a symlink
-      ansible.builtin.file:
+      ansible.builtin.stat:
         path: /dev/log
-        state: absent
-      when: >
-        ansible_facts['files']['/dev/log'] is defined and
-        ansible_facts['files']['/dev/log'].islnk is not defined
+      register: statresult
+
+    - name: Show stat
+      ansible.builtin.debug:
+        msg: "{{ statresult }}"
 
     - name: Create a symbolic link to /run/systemd/journal/dev-log
       ansible.builtin.file:

--- a/roles/rsyslog/templates/logging.conf.j2
+++ b/roles/rsyslog/templates/logging.conf.j2
@@ -1,6 +1,0 @@
-# https://access.redhat.com/articles/4058681
-[Unit]
-;Requires=syslog.socket
-
-[Install]
-Alias=syslog.service

--- a/roles/rsyslog/templates/logging.conf.j2
+++ b/roles/rsyslog/templates/logging.conf.j2
@@ -1,6 +1,6 @@
 # https://access.redhat.com/articles/4058681
 [Unit]
-Requires=syslog.socket
+;Requires=syslog.socket
 
 [Install]
 Alias=syslog.service

--- a/roles/rsyslog/templates/rsyslog_onlyforward.conf.j2
+++ b/roles/rsyslog/templates/rsyslog_onlyforward.conf.j2
@@ -30,4 +30,3 @@ action.resumeInterval="5"
 action.writeAllMarkMessages="on")
 {% endfor %}
 {% endif %}
-

--- a/roles/rsyslog/templates/rsyslog_onlyforward.conf.j2
+++ b/roles/rsyslog/templates/rsyslog_onlyforward.conf.j2
@@ -2,6 +2,7 @@
 module(load="imuxsock" SysSock.Use="on")
 module(load="imklog")   # provides kernel logging support
 module(load="immark" interval="600" )  # provides --MARK-- message capability
+module(load="omrelp")
 
 $PreserveFQDN on
 
@@ -10,7 +11,6 @@ $PreserveFQDN on
 {% if  'sysloghost' not in group_names %}
 {% for relp_host in relp_remote %}
 # Logs are forwarded to {{ relp_host.name }}
-module(load="omrelp")
 action(type="omrelp"
 target="{{ relp_host.host }}"
 port="{{ relp_host.port }}"

--- a/roles/rsyslog/templates/rsyslog_onlyforward.conf.j2
+++ b/roles/rsyslog/templates/rsyslog_onlyforward.conf.j2
@@ -1,7 +1,7 @@
 # This rsyslog configuration takes logs from journald and forwards them to a remote log serverad="imuxsock") # provides support for local system logging
 module(load="imuxsock" SysSock.Use="on")
 module(load="imklog")   # provides kernel logging support
-module(load="immark" interval="600" )  # provides --MARK-- message capability
+module(load="immark" interval="300" )  # provides --MARK-- message capability
 module(load="omrelp")
 
 $PreserveFQDN on


### PR DESCRIPTION
- remove syslog.socket dependency, breaks rsyslog after reboot
- temporarily use an rsyslog group because we want to exclude some servers
- mark messages every five minutes for faster debugging