### PR TITLE
Fix/hotfix617 stats

### DIFF
--- a/roles/rsyslog/defaults/main.yml
+++ b/roles/rsyslog/defaults/main.yml
@@ -28,3 +28,6 @@ rsyslog_queue_dir: "/var/spool/rsyslog"
 # rsyslog_imjournal_ratelimitburst: 2000
 # rsyslog_imjournal_ratelimitinterval: 600
 # rsyslog_maxmessagesize: 8000
+
+# rsyslog_imjournal_statefile # default is imjournal.state which means imjournal.state relative to the rsyslog workdir
+# rsyslog_workdirectory # default /var/spool/rsyslog

--- a/roles/rsyslog/tasks/rsyslog_central.yml
+++ b/roles/rsyslog/tasks/rsyslog_central.yml
@@ -49,18 +49,21 @@
   template:
     src: sc_template.conf.j2
     dest: /etc/rsyslog.d/templates/{{ item.name }}.conf
+    backup: true
   with_items: "{{ rsyslog_environments }}"
 
 - name: Create ruleset configurations
   template:
     src: sc_ruleset.conf.j2
     dest: /etc/rsyslog.d/rulesets/{{ item.name }}.conf
+    backup: true
   with_items: "{{ rsyslog_environments }}"
 
 - name: Create sc listener configurations
   template:
     src: listener.conf.j2
     dest: /etc/rsyslog.d/listeners/{{ item.name }}.conf
+    backup: true
   with_items: "{{ rsyslog_environments }}"
 
 - name: Create logrotate file for apps and host logs

--- a/roles/rsyslog/tasks/rsyslog_central.yml
+++ b/roles/rsyslog/tasks/rsyslog_central.yml
@@ -51,6 +51,8 @@
     dest: /etc/rsyslog.d/templates/{{ item.name }}.conf
     backup: true
   with_items: "{{ rsyslog_environments }}"
+  notify:
+    - "restart rsyslog"
 
 - name: Create ruleset configurations
   template:
@@ -58,6 +60,8 @@
     dest: /etc/rsyslog.d/rulesets/{{ item.name }}.conf
     backup: true
   with_items: "{{ rsyslog_environments }}"
+  notify:
+    - "restart rsyslog"
 
 - name: Create sc listener configurations
   template:
@@ -65,6 +69,8 @@
     dest: /etc/rsyslog.d/listeners/{{ item.name }}.conf
     backup: true
   with_items: "{{ rsyslog_environments }}"
+  notify:
+    - "restart rsyslog"
 
 - name: Create logrotate file for apps and host logs
   template:

--- a/roles/rsyslog/templates/rsyslog_onlyforward.conf.j2
+++ b/roles/rsyslog/templates/rsyslog_onlyforward.conf.j2
@@ -11,8 +11,8 @@ module(load="imuxsock")
 module(load="imjournal"             # provides access to the systemd journal
        UsePid="system" # PID number is retrieved as the ID of the process the journal entry originates from
        StateFile="{{ rsyslog_imjournal_statefile | default('imjournal.state') }}"
-       ratelimit.interval="{{ rsyslog_imjournal_ratelimitinterval | default('600') }}"
-       ratelimit.burst="{{ rsyslog_imjournal_ratelimitburst | default('20000') }}")  # Reads journald logs
+       ratelimit.interval="{{ rsyslog_imjournal_ratelimitinterval | default('60') }}"
+       ratelimit.burst="{{ rsyslog_imjournal_ratelimitburst | default('10000') }}")  # Reads journald logs
 module(load="imklog")   # provides kernel logging support
 module(load="immark" interval="300" )  # provides --MARK-- message capability
 module(load="omrelp")

--- a/roles/rsyslog/templates/rsyslog_onlyforward.conf.j2
+++ b/roles/rsyslog/templates/rsyslog_onlyforward.conf.j2
@@ -12,7 +12,7 @@ module(load="imjournal"             # provides access to the systemd journal
        UsePid="system" # PID number is retrieved as the ID of the process the journal entry originates from
        StateFile="{{ rsyslog_imjournal_statefile | default('imjournal.state') }}"
        ratelimit.interval="{{ rsyslog_imjournal_ratelimitinterval | default('60') }}"
-       ratelimit.burst="{{ rsyslog_imjournal_ratelimitburst | default('10000') }}")  # Reads journald logs
+       ratelimit.burst="{{ rsyslog_imjournal_ratelimitburst | default('20000') }}")  # Reads journald logs
 module(load="imklog")   # provides kernel logging support
 module(load="immark" interval="300" )  # provides --MARK-- message capability
 module(load="omrelp")

--- a/roles/rsyslog/templates/rsyslog_onlyforward.conf.j2
+++ b/roles/rsyslog/templates/rsyslog_onlyforward.conf.j2
@@ -1,4 +1,6 @@
-# This rsyslog configuration takes logs from journald and forwards them to a remote log serverad="imuxsock") # provides support for local system logging
+# Where to place auxiliary files
+global(workDirectory="{{ rsyslog_workdirectory | default('/var/spool/rsyslog') }}")
+
 {% if 'docker' in group_names %}
 module(load="imptcp")
 input(type="imptcp" port="514")
@@ -8,7 +10,7 @@ module(load="imuxsock")
 {% endif %}
 module(load="imjournal"             # provides access to the systemd journal
        UsePid="system" # PID number is retrieved as the ID of the process the journal entry originates from
-       StateFile="imjournal.state"
+       StateFile="{{ rsyslog_imjournal_statefile | default('imjournal.state') }}"
        ratelimit.interval="{{ rsyslog_imjournal_ratelimitinterval | default('600') }}"
        ratelimit.burst="{{ rsyslog_imjournal_ratelimitburst | default('20000') }}")  # Reads journald logs
 module(load="imklog")   # provides kernel logging support

--- a/roles/rsyslog/templates/sc_ruleset.conf.j2
+++ b/roles/rsyslog/templates/sc_ruleset.conf.j2
@@ -17,6 +17,7 @@ if $programname == "engineblock" and $msg contains '{"channel":"authentication"'
 :programname, isequal, "manageserver" { action(type="omfile" DynaFile="manage-{{ item.name }}" {{ rsyslog_dir_file_modes }} ) stop }
 :programname, isequal, "managegui" { action(type="omfile" DynaFile="apache-manage-{{ item.name }}" {{ rsyslog_dir_file_modes }} ) stop }
 :programname, isequal, "PDPANALYTICS" { action(type="omfile" DynaFile="pdpanalytics-{{ item.name }}" {{ rsyslog_dir_file_modes }} ) stop }
+:programname, isequal, "pdp" { action(type="omfile" DynaFile="pdp-{{ item.name }}" {{ rsyslog_dir_file_modes }} ) stop }
 :programname, isequal, "pdpserver" { action(type="omfile" DynaFile="pdp-{{ item.name }}" {{ rsyslog_dir_file_modes }} ) stop }
 :programname, isequal, "pdpgui" { action(type="omfile" DynaFile="apache-pdp-{{ item.name }}" {{ rsyslog_dir_file_modes }} ) stop }
 if $programname == "profile" and $msg startswith " {" then { action(type="omfile" DynaFile="profile-{{ item.name }}" {{ rsyslog_dir_file_modes }} ) stop }

--- a/roles/rsyslog/templates/sc_ruleset.conf.j2
+++ b/roles/rsyslog/templates/sc_ruleset.conf.j2
@@ -1,7 +1,8 @@
 $RuleSet {{ item.name }}
 {% if item.name != "mgnt_sc" %}
 if $programname == "engineblock" and $msg startswith " engine" then { action(type="omfile" DynaFile="apache-eb-{{ item.name }}" {{ rsyslog_dir_file_modes }} ) stop }
-if $programname == "engineblock" and $msg startswith ' {"channel":"authentication"' then { action(type="omfile" DynaFile="ebauth-{{ item.name }}" {{ rsyslog_dir_file_modes }} ) stop  }
+if $programname == "engineblock" and $msg startswith "engine" then { action(type="omfile" DynaFile="apache-eb-{{ item.name }}" {{ rsyslog_dir_file_modes }} ) stop }
+if $programname == "engineblock" and $msg contains '{"channel":"authentication"' then { action(type="omfile" DynaFile="ebauth-{{ item.name }}" {{ rsyslog_dir_file_modes }} ) stop  }
 :programname, isequal, "engineblock" { action(type="omfile" DynaFile="eblog-{{ item.name }}" {{ rsyslog_dir_file_modes }} ) stop }
 :programname, isequal, "EBLOG" { action(type="omfile" DynaFile="eblog-{{ item.name }}" {{ rsyslog_dir_file_modes }} ) stop }
 :programname, isequal, "Apache-EB" { action(type="omfile" DynaFile="apache-eb-{{ item.name }}" {{ rsyslog_dir_file_modes }} ) stop }

--- a/roles/rsyslog/templates/sc_ruleset.conf.j2
+++ b/roles/rsyslog/templates/sc_ruleset.conf.j2
@@ -46,8 +46,8 @@ if $programname == "profile" and $msg startswith " {" then { action(type="omfile
 :programname, startswith, "inviteprovisioningmock" { action(type="omfile" DynaFile="inviteprovisioningmock-{{ item.name }}" {{ rsyslog_dir_file_modes }} ) stop }
 :programname, startswith, "loadbalancer" { action(type="omfile" DynaFile="loadbalancer-{{ item.name }}" {{ rsyslog_dir_file_modes }} ) stop }
 
-if $programname == "gateway" and $msg startswith ' {"message":"Second Factor Authenticated"' then { action(type="omfile" DynaFile="stepup-authentication-{{ item.name }}" {{ rsyslog_dir_file_modes }} ) stop }
-if $programname == "gateway" and $msg startswith ' {"message":"Intrinsic Loa Requested"' then { action(type="omfile" DynaFile="stepup-authentication-{{ item.name }}" {{ rsyslog_dir_file_modes }} ) stop }
+if $programname == "gateway" and $msg contains '{"message":"Second Factor Authenticated"' then { action(type="omfile" DynaFile="stepup-authentication-{{ item.name }}" {{ rsyslog_dir_file_modes }} ) stop }
+if $programname == "gateway" and $msg contains '{"message":"Intrinsic Loa Requested"' then { action(type="omfile" DynaFile="stepup-authentication-{{ item.name }}" {{ rsyslog_dir_file_modes }} ) stop }
 
 {% for stepupapp in stepupapps %}
 :programname, isequal, "stepup-{{ stepupapp }}" { action(type="omfile" DynaFile="stepup-{{ stepupapp }}-{{item.name }}" {{ rsyslog_dir_file_modes }} ) stop }

--- a/roles/rsyslog/templates/sc_template.conf.j2
+++ b/roles/rsyslog/templates/sc_template.conf.j2
@@ -36,7 +36,7 @@ $template myconext-{{ item.name }}, "{{ rsyslog_dir }}/apps/{{ item.name }}/edui
 $template myconextjson-{{ item.name }}, "{{ rsyslog_dir }}/apps/{{ item.name }}/eduid/myconextjson.log"
 $template apache-myconext-{{ item.name }}, "{{ rsyslog_dir }}/apps/{{ item.name }}/eduid/myconext-apache.log"
 $template apache-account-{{ item.name }}, "{{ rsyslog_dir }}/apps/{{ item.name }}/eduid/account-apache.log"
-$template servicedesk-{{ item.name }}, "{{ rsyslog_dir }}/apps/{{ item.name }}/servicedeskgui/servicedesk-apache.log
+$template apache-servicedesk-{{ item.name }}, "{{ rsyslog_dir }}/apps/{{ item.name }}/servicedeskgui/servicedesk-apache.log
 $template apache-eduid-{{ item.name }}, "{{ rsyslog_dir }}/apps/{{ item.name }}/eduid/eduid-apache.log"
 $template spdashboard-{{ item.name }}, "{{ rsyslog_dir }}/apps/{{ item.name }}/spdashboard/spdashboard.log"
 $template apache-spdashboard-{{ item.name }}, "{{ rsyslog_dir }}/apps/{{ item.name }}/spdashboard/apache.log"

--- a/roles/rsyslog/templates/sc_template.conf.j2
+++ b/roles/rsyslog/templates/sc_template.conf.j2
@@ -36,6 +36,7 @@ $template myconext-{{ item.name }}, "{{ rsyslog_dir }}/apps/{{ item.name }}/edui
 $template myconextjson-{{ item.name }}, "{{ rsyslog_dir }}/apps/{{ item.name }}/eduid/myconextjson.log"
 $template apache-myconext-{{ item.name }}, "{{ rsyslog_dir }}/apps/{{ item.name }}/eduid/myconext-apache.log"
 $template apache-account-{{ item.name }}, "{{ rsyslog_dir }}/apps/{{ item.name }}/eduid/account-apache.log"
+$template servicedesk-{{ item.name }}, "{{ rsyslog_dir }}/apps/{{ item.name }}/servicedeskgui/servicedesk-apache.log
 $template apache-eduid-{{ item.name }}, "{{ rsyslog_dir }}/apps/{{ item.name }}/eduid/eduid-apache.log"
 $template spdashboard-{{ item.name }}, "{{ rsyslog_dir }}/apps/{{ item.name }}/spdashboard/spdashboard.log"
 $template apache-spdashboard-{{ item.name }}, "{{ rsyslog_dir }}/apps/{{ item.name }}/spdashboard/apache.log"


### PR DESCRIPTION
- fix for filtering failed after deployment 617 imjournal based rsyslog on hosts
- fixed error non existing servicedesk apache template
- enable template backup for rsyslog conf
- define a workdirectory or imjournal.state ends up in /
- higher rate limit defaults
- related to PR 367 in environments