### PR TITLE
Remove remote-users from template

### DIFF
--- a/roles/invite/templates/serverapplication.yml.j2
+++ b/roles/invite/templates/serverapplication.yml.j2
@@ -149,59 +149,7 @@ feature:
 # We don't encode in-memory passwords, but they are reused so do NOT prefix them with {noop}
 external-api-configuration:
   remote-users:
-    - username: {{ invite.vootuser }}
-      password: "{{ invite.vootsecret }}"
-      scopes:
-        - voot
-    - username: {{ invite.teamsuser}}
-      password: "{{ invite.teamssecret }}"
-      scopes:
-        - teams
-    - username: {{ aa.invite_username }}
-      password: "{{ invite_attribute_aggregation_secret }}"
-      scopes:
-        - attribute_aggregation
-        - crm
-    - username: {{ invite.lifecycle_user }}
-      password: "{{ invite.lifecycle_secret }}"
-      scopes:
-        - lifecycle
-    - username: internal
-      password: "{{ invite.internal_secret }}"
-      scopes:
-        - actuator
-    - username: {{ invite.profile_user }}
-      password: "{{ invite.profile_secret }}"
-      scopes:
-        - profile
-    - username: {{ invite.pdp_user }}
-      password: "{{ invite.pdp_secret }}"
-      scopes:
-        - crm
-    - username: {{ invite.idp_dashboard_user }}
-      password: "{{ invite.idp_dashboard_secret }}"
-      scopes:
-        - crm
-    - username: "{{ invite.tools_user }}"
-      password: "{{ invite.tools_secret }}"
-      scopes:
-        - "crm"
-    - username: {{ invite.sp_dashboard_user }}
-      password: "{{ invite.sp_dashboard_secret }}"
-      organizationGUIDFallback: {{ invite.surf_idp_organization_guid }}
-      scopes:
-        - sp_dashboard
-      applications:
-        - manageId: {{ invite.sp_dashboard_manage_id }}
-          manageType: SAML20_SP
-    - username: "{{ invite.access_dashboard_user }}"
-      password: "{{ invite.access_dashboard_secret }}"
-      organizationGUIDFallback: {{ invite.surf_idp_organization_guid }}
-      scopes:
-        - access
-      applications:
-        - manageId: {{ invite.access_manage_id }}
-          manageType: OIDC10_RP
+    {{ invite.api_users | to_nice_yaml(indent=2) | indent(4, first=false) }}
 
 voot:
   group_urn_domain: "{{ invite.group_urn_domain }}"


### PR DESCRIPTION
This PR tries to migrate the invite remote-users config to their respective environments group_vars