### PR TITLE
use absolute haproxy weights

### DIFF
--- a/roles/haproxy_mgnt/tasks/main.yml
+++ b/roles/haproxy_mgnt/tasks/main.yml
@@ -51,7 +51,7 @@
     host: "{{ item.label }}"
     fail_on_not_found: true
     socket: /var/lib/haproxy/haproxy.stats
-    weight: "{{ item.weight }}%"
+    weight: "{{ item.weight }}"
     backend: "{{ app_name }}_be"
   with_items: "{{ server_labels_with_weights }}"
   register: "haproxy_weights"


### PR DESCRIPTION
Dit zorgt ervoor dat we altijd 100-based weights gebruiken voor rood/blauw, in plaats van een random gewicht op basis van de oorspronkelijke waarde in de config file.